### PR TITLE
fix: use `phylum-bot` account instead of a personal account

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,19 @@ jobs:
         with:
           # `python-semantic-release` needs full history to properly determine the next release version
           fetch-depth: 0
-          # `python-semantic-release` needs this personal access token in order to push to a protected branch
+          # `python-semantic-release` needs this personal access token (PAT) in order to push to a protected branch.
+          # This PAT is for the `phylum-bot` account and only has the `public_repo` scope to limit privileges.
           token: ${{ secrets.GH_RELEASE_PAT }}
+
+      # This GPG key is for the `phylum-bot` account and used in order to ensure commits and tags are signed/verified
+      - name: Import GPG key for bot account
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.PHYLUM_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PHYLUM_BOT_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
 
       - name: Install poetry
         run: pipx install poetry
@@ -123,8 +134,6 @@ jobs:
           REPOSITORY_USERNAME: __token__
           REPOSITORY_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
           if [ "${{ github.event.inputs.prerelease }}" = "true" ]; then
             poetry run semantic-release publish -v DEBUG --prerelease
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is partially based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The entries in this changelog are primarily automatically generated through the use of
 [conventional commits](https://www.conventionalcommits.org) and the
@@ -11,16 +11,17 @@ However, some entries may be manually edited, where it helps for clarity and und
 <!--next-version-placeholder-->
 
 ## v0.2.0-rc.0 (2022-05-03)
+### Added
+* Modern release workflow
 
-
-## 0.1.1 - 2022-04-25
+## v0.1.1 (2022-04-25)
 ### Added
 * `phylum-init` script entry point and initial functionality
 * Test workflows for local and CI based testing
 * Preview and Release workflows for Staging and Production environments
 * Phylum analyze workflow for PRs
 
-## 0.0.1 - 2022-03-28
+## v0.0.1 (2022-03-28)
 ### Added
 * Basic Python project structure
   * Make use of `poetry` for environment, dependency, and package build/publish workflows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,4 +88,4 @@ remove_dist = false
 # Setting build_command to false here b/c `poetry build -vvv` will be used prior to a PSR publish command
 build_command = false
 commit_subject = "chore: bump to v{version}"
-commit_author = "github-actions <github-actions@github.com>"
+commit_author = "phylum-bot <69485888+phylum-bot@users.noreply.github.com>"


### PR DESCRIPTION
The previous GitHub Personal Access Token (PAT) used in the `Release` workflow was created with a short lifetime and from a personal account (@maxrake). This was not sustainable and was replaced by a company controlled bot/service account (@phylum-bot). This account was configured for code signing and vigilant mode. The `Production` deployment environment and `Release` workflow were updated to include the secrets necessary to make use of the code signing to ensure verified commits and tags.

closes #33

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [ ] Have you ensured that you have met the expected acceptance criteria?
  - We won't really know if it works until _after_ the PR is merged and a release is attempted
  - The commit/PR title is using the `fix` type to trigger a new patch version
- [x] ~Have you created sufficient tests?~
- [ ] Have you updated all affected documentation?
  - The only documentation left to update is possibly to create an internal Notion page talking about how to refresh the PAT once a quarter. It has not been done yet b/c there is a chance that the GitHub system will send an email automatically when the token expires...or is about to expire. That theory is being tested with a personal PAT that is set to expire on 05 MAY 2022.
