### PR TITLE
fix: sync package issue key name changes from CLI v3.4.0 release

### DIFF
--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -417,8 +417,8 @@ class CIBase(ABC):
         fail_string += "|-----------|----------|-----|\n"
 
         issue_list = build_issues_list(package_result, issue_flags)
-        for risk_domain, risk_level, title in issue_list:
-            fail_string += f"|{risk_domain}|{risk_level}|{title}|\n"
+        for domain, severity, title in issue_list:
+            fail_string += f"|{domain}|{severity}|{title}|\n"
 
         if failed_flag:
             self.gbl_failed = True
@@ -436,9 +436,9 @@ def build_issues_list(package_result: dict, issue_flags: List[str]) -> List[Tupl
     pkg_issues = package_result.get("issues", [])
     for flag in issue_flags:
         for pkg_issue in pkg_issues:
-            if flag == pkg_issue.get("risk_domain"):
-                risk_domain = pkg_issue.get("risk_domain")
-                risk_level = pkg_issue.get("risk_level")
+            if flag == pkg_issue.get("domain"):
+                domain = pkg_issue.get("domain")
+                severity = pkg_issue.get("severity")
                 title = pkg_issue.get("title")
-                issues.append((risk_domain, risk_level, title))
+                issues.append((domain, severity, title))
     return issues


### PR DESCRIPTION
The mapping for package results in the verbose json response for an analyze command changed the key names for the CLI v3.4.0 release. `risk_domain` became `domain` and `risk_level` became `severity`.

Closes #40 

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- ~[ ] Have you created sufficient tests?~
- [x] Have you updated all affected documentation?
