### PR TITLE
fix: Ensure notes are not duplicated in GitLab MRs

### DIFF
--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -18,8 +18,8 @@ from packaging.version import Version
 from phylum.ci.common import PackageDescriptor, Packages, ReturnCode
 from phylum.ci.constants import (
     FAILED_COMMENT,
-    FAILED_INCOMPLETE_COMMENT_TEMPLATE,
     INCOMPLETE_COMMENT_TEMPLATE,
+    INCOMPLETE_WITH_FAILURE_COMMENT_TEMPLATE,
     SUCCESS_COMMENT,
 )
 from phylum.constants import SUPPORTED_LOCKFILES, TOKEN_ENVVAR_NAME
@@ -167,7 +167,11 @@ class CIBase(ABC):
 
     @abstractmethod
     def post_output(self) -> None:
-        """Post the output of the analysis in the means appropriate for the CI environment."""
+        """Post the output of the analysis in the means appropriate for the CI environment.
+
+        Output in the form of comments on a pull/merge request should be unique and not added multiple times as
+        the review changes but the lock file doesn't.
+        """
         raise NotImplementedError()
 
     # TODO: Use the `@functools.cached_property` decorator, introduced in Python 3.8, to avoid computing more than once.
@@ -331,7 +335,7 @@ class CIBase(ABC):
             if self.gbl_failed:
                 print(" [!] There were failures in one or more completed packages")
                 returncode = ReturnCode.FAILURE_INCOMPLETE
-                output = FAILED_INCOMPLETE_COMMENT_TEMPLATE.substitute(count=incomplete_pkg_count)
+                output = INCOMPLETE_WITH_FAILURE_COMMENT_TEMPLATE.substitute(count=incomplete_pkg_count)
                 for line in risk_data:
                     output += line
             else:
@@ -379,7 +383,7 @@ class CIBase(ABC):
         failed_flag = False
         risk_vectors = package_result.get("riskVectors", {})
         issue_flags = []
-        fail_string = f"### Package: `{package_result.get('name')}@{package_result.get('version')}` failed.\n"
+        fail_string = f"\n### Package: `{package_result.get('name')}@{package_result.get('version')}` failed.\n"
         fail_string += "|Risk Domain|Identified Score|Requirement|\n"
         fail_string += "|-----------|----------------|-----------|\n"
 

--- a/src/phylum/ci/constants.py
+++ b/src/phylum/ci/constants.py
@@ -2,40 +2,16 @@
 import string
 import textwrap
 
-# Headers for distinct comment types
-FAILED_COMMENT = textwrap.dedent(
-    """
-    ## Phylum OSS Supply Chain Risk Analysis - FAILED
+# The common Phylum header that must exist as the first text in the first line of all analysis output
+PHYLUM_HEADER = "## Phylum OSS Supply Chain Risk Analysis"
 
-    <details>
-    <summary>Background</summary>
-    <br />
-    This repository analyzes the risk of new dependencies. An administrator of
-    this repository has set score requirements for Phylum's five risk domains.
-    <br /><br />
-    If you see this comment, one or more dependencies added to the
-    package manager lockfile have failed Phylum's risk analysis.
-    </details>
+# NOTE: All multi-line strings are indented by two levels on purpose, to ensure they line up correctly when used with
+#       each other in templates and are all fully left justified after applying `textwrap.dedent` for normalization.
 
-    """
-)
-SUCCESS_COMMENT = textwrap.dedent(
-    """
-    ## Phylum OSS Supply Chain Risk Analysis - SUCCESS
+SUCCESS_DETAILS = "The Phylum risk analysis is complete and did not identify any issues."
 
-    The Phylum risk analysis is complete and did not identify any issues.
-    """
-).strip()
-FAILED_INCOMPLETE_COMMENT_TEMPLATE = string.Template(
-    textwrap.dedent(
-        """
-        ## Phylum OSS Supply Chain Risk Analysis - INCOMPLETE WITH FAILURES
-
-        The analysis contains $count package(s) Phylum has not yet processed,
-        preventing a complete risk analysis. Phylum is processing these
-        packages currently and should complete soon.
-        Please wait for up to 30 minutes, then re-run the analysis.
-
+# Expandable HTML providing information on why there was a failure
+FAILURE_DETAILS = """
         <details>
         <summary>Background</summary>
         <br />
@@ -45,19 +21,51 @@ FAILED_INCOMPLETE_COMMENT_TEMPLATE = string.Template(
         If you see this comment, one or more dependencies added to the
         package manager lockfile have failed Phylum's risk analysis.
         </details>
+        """.strip()
 
-        """
-    )
-)
-INCOMPLETE_COMMENT_TEMPLATE = string.Template(
-    textwrap.dedent(
-        """
-        ## Phylum OSS Supply Chain Risk Analysis - INCOMPLETE
-
+# String template providing information about an incomplete analysis.
+# Substitution variable(s) should be accounted for when using string variables containing this text.
+INCOMPLETE_DETAILS = """
         The analysis contains $count package(s) Phylum has not yet processed,
         preventing a complete risk analysis. Phylum is processing these
         packages currently and should complete soon.
         Please wait for up to 30 minutes, then re-run the analysis.
         """
-    ).strip()
+
+# Headers for distinct comment types:
+FAILED_COMMENT = textwrap.dedent(
+    f"""
+        {PHYLUM_HEADER} - FAILED
+
+        {FAILURE_DETAILS}
+        """
+)
+
+SUCCESS_COMMENT = textwrap.dedent(
+    f"""
+        {PHYLUM_HEADER} - SUCCESS
+
+        {SUCCESS_DETAILS}
+        """
+)
+
+# Substitution variable(s) should be accounted for when using this template
+INCOMPLETE_WITH_FAILURE_COMMENT_TEMPLATE = string.Template(
+    textwrap.dedent(
+        f"""
+        {PHYLUM_HEADER} - INCOMPLETE WITH FAILURE
+        {INCOMPLETE_DETAILS}
+        {FAILURE_DETAILS}
+        """
+    )
+)
+
+# Substitution variable(s) should be accounted for when using this template
+INCOMPLETE_COMMENT_TEMPLATE = string.Template(
+    textwrap.dedent(
+        f"""
+        {PHYLUM_HEADER} - INCOMPLETE
+        {INCOMPLETE_DETAILS}
+        """
+    )
 )


### PR DESCRIPTION
This change makes use of the GitLab Merge Request API for Notes (comments) to check the existing notes and, when the most recent Phylum note contents match the contents of the note that is proposed to be written, skip posting that duplicate note. It also broke the comment templates up into components so that they can be re-used and referenced more easily.

Since there still is no automated testing available for the GitLab integration, testing was performed manually. It was not working with the CLI v3.4.0 release...and then also not with the CLI v3.3.0 release, but CLI v3.5.0 *did* work.

Closes #39 

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [ ] ~Have you created sufficient tests?~
  - There still aren't any tests for the GitLab integration
- [ ] ~Have you updated all affected documentation?~
  - There was nothing to update
