### PR TITLE
!feat: default to project settings for risk domain thresholds

### DIFF
--- a/docs/gitlab_ci.md
+++ b/docs/gitlab_ci.md
@@ -4,7 +4,7 @@
 
 Once configured for a repository, the GitLab CI integration will provide analysis of project dependencies from a
 lockfile during a Merge Request (MR) and output the results as a note (comment) on the MR.
-The CI job will return an error (i.e., fail the build) if any dependencies fail to meet the specified project risk
+The CI job will return an error (i.e., fail the build) if any dependencies fail to meet the project risk
 thresholds for any of the five Phylum risk domains:
 
 * Vulnerability (aka `vul`)

--- a/src/phylum/ci/common.py
+++ b/src/phylum/ci/common.py
@@ -17,6 +17,38 @@ class PackageDescriptor:
 Packages = List[PackageDescriptor]
 
 
+@dataclass()
+class ProjectThresholdInfo:
+    """Class for keeping track of project risk threshold information.
+
+    `threshold`: The risk domain threshold value in use.
+    `req_src`: The source of the threshold requirement. Possible values are:
+      * `phylum-ci option`: The threshold in use came from using a command line option
+      * `project setting`: The threshold in use comes from the Phylum project settings
+      * `N/A (fail safe)`: No source was found/determined; used with a default secure value for `threshold`
+    """
+
+    threshold: float
+    req_src: str
+
+
+@dataclass(order=True, frozen=True)
+class RiskDomain:
+    """Class for keeping track of a specific risk domain.
+
+    Each risk domain can be referenced in various ways. See "Phylum Risk Domains" documentation for more detail:
+    https://docs.phylum.io/docs/phylum-package-score#risk-domains
+
+    * `output_name`: The descriptive name; useful for output expected to be read by humans
+    * `project_name`: Key name returned from a Phylum analysis as known by the overall project threshold mapping
+    * `package_name`: Key name returned from a Phylum analysis as known by an individual package riskVectors mapping
+    """
+
+    output_name: str
+    project_name: str
+    package_name: str
+
+
 class ReturnCode(IntEnum):
     """Integer enumeration to track return codes."""
 

--- a/src/phylum/ci/constants.py
+++ b/src/phylum/ci/constants.py
@@ -2,6 +2,8 @@
 import string
 import textwrap
 
+from phylum.ci.common import RiskDomain
+
 # The common Phylum header that must exist as the first text in the first line of all analysis output
 PHYLUM_HEADER = "## Phylum OSS Supply Chain Risk Analysis"
 
@@ -69,3 +71,17 @@ INCOMPLETE_COMMENT_TEMPLATE = string.Template(
         """
     )
 )
+
+# These are the project threshold options.
+# Keys are the risk domain threshold options, as provided/known by argparse.
+# Values are a RiskDomain dataclass object containing:
+#   * the descriptive name
+#   * key name returned from a Phylum analysis as known by the overall project threshold mapping
+#   * key name returned from a Phylum analysis as known by an individual package riskVectors mapping
+PROJECT_THRESHOLD_OPTIONS = {
+    "vul_threshold": RiskDomain("Software Vulnerability", "vulnerability", "vulnerability"),
+    "mal_threshold": RiskDomain("Malicious Code", "malicious", "malicious_code"),
+    "eng_threshold": RiskDomain("Engineering", "engineering", "engineering"),
+    "lic_threshold": RiskDomain("License", "license", "license"),
+    "aut_threshold": RiskDomain("Author", "author", "author"),
+}

--- a/src/phylum/common.py
+++ b/src/phylum/common.py
@@ -1,6 +1,0 @@
-"""Provide common data structures for the package."""
-import argparse
-
-
-class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
-    """Custom argparse formatter to get both default arguments and help text line wrapping."""

--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -58,4 +58,4 @@ SUPPORTED_LOCKFILES = {
 
 # Timeout value, in seconds, to tell the Python Requests package to stop waiting for a response.
 # Reference: https://2.python-requests.org/en/master/user/quickstart/#timeouts
-REQ_TIMEOUT: float = 5.0
+REQ_TIMEOUT: float = 10.0

--- a/src/phylum/init/cli.py
+++ b/src/phylum/init/cli.py
@@ -15,7 +15,6 @@ import requests
 from packaging.utils import canonicalize_version
 from packaging.version import InvalidVersion, Version
 from phylum import __version__
-from phylum.common import CustomFormatter
 from phylum.constants import (
     REQ_TIMEOUT,
     SUPPORTED_ARCHES,
@@ -250,7 +249,7 @@ def get_args(args=None):
     parser = argparse.ArgumentParser(
         prog=SCRIPT_NAME,
         description="Fetch and install the Phylum CLI",
-        formatter_class=CustomFormatter,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
     parser.add_argument(


### PR DESCRIPTION
Changes in this PR allow thresholds for the five risk domains to be set individually in several ways. They can be set at the Phylum project level from either the Phylum CLI or the web UI. They can also be set by `phylum-ci` options (e.g., `--vul-threshold`, `--mal-threshold`, etc.). The default is to use the project level setting unless overridden by a value specified by a `phylum-ci` option. A default secure value (100) will be used when neither of these sources are used to set the value.

Additional changes made:
* The command line arguments were split into logical groups to make their usage scenarios more obvious and provide better help output
* A "Requirement Source" column was added to the "failed" Package detail table output in order to better identify whether the risk domain threshold requirement came from the project settings, a command line option, or neither 
* Ensure the "identified score" and "requirement" values are displayed as whole integers between 0 and 100, inclusive
* The default `requests` timeout value was increased to 10.0 seconds
* Refactoring and formatting throughout

BREAKING CHANGE: Individual risk domain threshold values can be set with command line options, which now accept values between 0 and 100, inclusive. Previously, the accepted values were between 0 and 99, inclusive.

Closes #46

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [ ] ~Have you created sufficient tests?~
  - still no automated tests, but local testing and testing with a private GitLab repo was performed
- [x] Have you updated all affected documentation?
  - The documentation was minimally changed b/c the real effect of this PR is to make the risk domain threshold values track those set up at the Phylum project level, unless overridden by corresponding `phylum-ci` command line arguments (e.g., `--vul-threshold`)
  - CC: @furi0us333 and @peterjmorgan for confirmation on meeting the original intent...or if more explicit documentation is still desired

## Example Output

Each of these examples was taken against a lockfile named `requirementst-dev.txt`, containing:

```
requests==2.6.1   # is not a new dep (exists in `main`)
pillow==5.3.0     # is not a new dep (exists in `main`)
pyyaml==5.3.1     # has a known vulnerability
docutils==0.18.1  # has a known license risk
```

This first output is with a script command of: `phylum-ci --lockfile requirements-dev.txt --new-deps-only -lt 65`
and a disabled "Vulnerability Risk" threshold in the project settings:

---

<img width="966" alt="image" src="https://user-images.githubusercontent.com/18729796/170419265-89b4f6ea-5f23-4d3e-86b5-7cc526dc72d8.png">

This second output is with a script command of: `phylum-ci --lockfile requirements-dev.txt --new-deps-only -vt 60`
and a disabled "License Risk" threshold in the project settings:

---

<img width="968" alt="image" src="https://user-images.githubusercontent.com/18729796/170419338-6c237a1b-7f97-4b85-81d9-240a0a1f4f47.png">

This third output is with a script command of: `phylum-ci --lockfile requirements-dev.txt --new-deps-only -vt 60`, an enabled "License Risk" threshold in the project settings of 75, and an enabled "Vulnerability Risk" threshold in the project settings of 50:

---

<img width="964" alt="image" src="https://user-images.githubusercontent.com/18729796/170419034-f392cf33-fc2c-4b71-a3a1-e44d2e609ef7.png">
