### PR TITLE
feat!: use a single character for "single dash" options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,18 @@ However, some entries may be manually edited, where it helps for clarity and und
 ## v0.6.0 (2022-05-27)
 ### Feature
 * Provide an option to force analysis ([#55](https://github.com/phylum-dev/phylum-ci/pull/55)) ([`4d6fc3b`](https://github.com/phylum-dev/phylum-ci/commit/4d6fc3b842cec004d655d1c1a63553a0c54e1d54))
+* Default to project settings for risk domain thresholds ([#52](https://github.com/phylum-dev/phylum-ci/pull/52)) ([`9f10442`](https://github.com/phylum-dev/phylum-ci/commit/9f10442ba41300093c65a5e5e1ff2fdb71c0772e))
+* Default to analyzing new dependencies only ([#53](https://github.com/phylum-dev/phylum-ci/pull/53)) ([`e0894fc`](https://github.com/phylum-dev/phylum-ci/commit/e0894fcf9f52d3014798f8676a5ff2360e725a8a))
 
 ### Fix
 * Ensure the "CI Platform Name" portion of a label is correct ([#55](https://github.com/phylum-dev/phylum-ci/pull/55)) ([`1867fb6`](https://github.com/phylum-dev/phylum-ci/commit/1867fb6e543183aa894cec4e06828069d62dee01))
 * Enable Phylum UI links for groups ([#54](https://github.com/phylum-dev/phylum-ci/issues/54)) ([`8775a63`](https://github.com/phylum-dev/phylum-ci/commit/8775a6392456fe64f97efae7f8d514ebf66f6949))
 
 ### Breaking Changes
-* Default to project settings for risk domain thresholds ([#52](https://github.com/phylum-dev/phylum-ci/pull/52)) ([`9f10442`](https://github.com/phylum-dev/phylum-ci/commit/9f10442ba41300093c65a5e5e1ff2fdb71c0772e))
-  * Individual risk domain threshold values can be set with command line options, which now accept values between 0 and 100, inclusive
+* Individual risk domain threshold values can be set with command line options, which now accept values between 0 and 100, inclusive
   * Previously, the accepted values were between 0 and 99, inclusive
-* Default to analyzing new dependencies only ([#53](https://github.com/phylum-dev/phylum-ci/pull/53)) ([`e0894fc`](https://github.com/phylum-dev/phylum-ci/commit/e0894fcf9f52d3014798f8676a5ff2360e725a8a))
-  * The option to analyze `--new-deps-only` was removed and replaced with one that has the opposite meaning: `--all-deps`
+* The option to analyze `--new-deps-only` was removed and replaced with one that has the opposite meaning: `--all-deps`
+* The short option to `--force-install` was changed from `-f` to `-fi`
 
 ## v0.5.2 (2022-05-24)
 ### Fix

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,5 +186,9 @@ To iterate during development of the `phylum-ci` integrations, it can be helpful
 even when it has not changed. It can also be useful to ensure all dependencies are considered. To do so, use the flags:
 
 ```sh
+# long form options
 poetry run phylum-ci --force-analysis --all-deps
+
+# short form options
+poetry run phylum-ci -fa
 ```

--- a/docs/gitlab_ci.md
+++ b/docs/gitlab_ci.md
@@ -15,6 +15,10 @@ to meet the project risk thresholds for any of the five Phylum risk domains:
 
 See [Phylum Risk Domains documentation](https://docs.phylum.io/docs/phylum-package-score#risk-domains) for more detail.
 
+**NOTE**: It is not enough to have the total project threshold set. Individual risk domain threshold values must be set,
+either in the UI or with `phylum-ci` options, in order to enable analysis results for CI. Otherwise, the risk domain is
+considered disabled and the threshold value used will be zero (0).
+
 There will be no note if no dependencies were added or modified for a given MR.
 If one or more dependencies are still processing (no results available), then the note will make that clear and the CI
 job will only fail if dependencies that have _completed analysis results_ do not meet the specified project risk
@@ -204,8 +208,8 @@ output as specified in the [Usage section of the top-level README.md](../README.
     # Thresholds for the five risk domains may be set at the Phylum project level.
     # They can be set differently for CI environments to "fail the build."
     # NOTE: The shortened form is used here for brevity, but the long form might be more
-    #       descriptive for future readers. For instance `--vul-threshold` instead of `-vt`.
-    - phylum-ci -vt 60 -mt 60 -et 70 -lt 90 -at 80
+    #       descriptive for future readers. For instance `--vul-threshold` instead of `-u`.
+    - phylum-ci -u 60 -m 60 -e 70 -c 90 -o 80
 
     # Ensure the latest Phylum CLI is installed.
     - phylum-ci --force-install
@@ -214,7 +218,7 @@ output as specified in the [Usage section of the top-level README.md](../README.
     - phylum-ci --phylum-release 3.3.0 --force-install
 
     # Mix and match for your specific use case.
-    - phylum-ci -vt 60 -mt 60 -et 70 -lt 90 -at 80 --lockfile requirements-prod.txt --all-deps
+    - phylum-ci -u 60 -m 60 -e 70 -c 90 -o 80 --lockfile requirements-prod.txt --all-deps
 ```
 
 ## Alternatives

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -101,12 +101,13 @@ def get_args(args: Optional[Sequence[str]] = None) -> Tuple[argparse.Namespace, 
             specify an explicit lockfile path.""",
     )
     analysis_group.add_argument(
+        "-a",
         "--all-deps",
         action="store_true",
         help="Specify this flag to consider all dependencies in analysis results instead of just the newly added ones.",
     )
     analysis_group.add_argument(
-        "-fa",
+        "-f",
         "--force-analysis",
         action="store_true",
         help="Specify this flag to force analysis, even when the lockfile has not changed.",
@@ -132,34 +133,34 @@ def get_args(args: Optional[Sequence[str]] = None) -> Tuple[argparse.Namespace, 
             detail: https://docs.phylum.io/docs/phylum-package-score#risk-domains""",
     )
     threshold_group.add_argument(
-        "-vt",
+        "-u",
         "--vul-threshold",
         type=threshold_check,
-        help="Vulnerability risk score threshold value.",
+        help="v(u)lnerability risk score threshold value.",
     )
     threshold_group.add_argument(
-        "-mt",
+        "-m",
         "--mal-threshold",
         type=threshold_check,
-        help="Malicious Code risk score threshold value.",
+        help="(m)alicious Code risk score threshold value.",
     )
     threshold_group.add_argument(
-        "-et",
+        "-e",
         "--eng-threshold",
         type=threshold_check,
-        help="Engineering risk score threshold value.",
+        help="(e)ngineering risk score threshold value.",
     )
     threshold_group.add_argument(
-        "-lt",
+        "-c",
         "--lic-threshold",
         type=threshold_check,
-        help="License risk score threshold value.",
+        help="li(c)ense risk score threshold value.",
     )
     threshold_group.add_argument(
-        "-at",
+        "-o",
         "--aut-threshold",
         type=threshold_check,
-        help="Author risk score threshold value.",
+        help="auth(o)r risk score threshold value.",
     )
 
     cli_group = parser.add_argument_group(
@@ -185,7 +186,7 @@ def get_args(args: Optional[Sequence[str]] = None) -> Tuple[argparse.Namespace, 
         help="The target platform type where the CLI will be installed.",
     )
     cli_group.add_argument(
-        "-fi",
+        "-i",
         "--force-install",
         action="store_true",
         help="""Specify this flag to ensure the specified Phylum CLI release version is the one that is installed.


### PR DESCRIPTION
Add single character option for all flags and current "single dash"
arguments. Update documentation to match.

BREAKING CHANGE: The short options for the following arguments changed:
* `--force-analysis` was changed from `-fa` to `-f`
* `--force-install` was changed from `-fi` to `-i`
* `--vul-threshold` was changed from `-vt` to `-u`
* `--mal-threshold` was changed from `-mt` to `-m`
* `--eng-threshold` was changed from `-et` to `-e`
* `--lic-threshold` was changed from `-lt` to `-c`
* `--aut-threshold` was changed from `-at` to `-o`

Closes #56

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [ ] ~Have you created sufficient tests?~
- [x] Have you updated all affected documentation?
