### PR TITLE
ci: automatically add issues to main project board

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,16 @@
+name: Add issues to main project board
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/phylum-dev/projects/24
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,14 @@ However, some entries may be manually edited, where it helps for clarity and und
 * Use a single character for "single dash" options ([`6a4b032`](https://github.com/phylum-dev/phylum-ci/commit/6a4b032262222173e69463fbcc232555f499c97e))
 
 ### Breaking
-* The short options for the following arguments changed: * `--force-analysis` was changed from `-fa` to `-f` * `--force-install` was changed from `-fi` to `-i` * `--vul-threshold` was changed from `-vt` to `-u` * `--mal-threshold` was changed from `-mt` to `-m` * `--eng-threshold` was changed from `-et` to `-e` * `--lic-threshold` was changed from `-lt` to `-c` * `--aut-threshold` was changed from `-at` to `-o`  ([`6a4b032`](https://github.com/phylum-dev/phylum-ci/commit/6a4b032262222173e69463fbcc232555f499c97e))
+* The short options for the following arguments changed ([`6a4b032`](https://github.com/phylum-dev/phylum-ci/commit/6a4b032262222173e69463fbcc232555f499c97e)):
+  * `--force-analysis` was changed from `-fa` to `-f`
+  * `--force-install` was changed from `-fi` to `-i`
+  * `--vul-threshold` was changed from `-vt` to `-u`
+  * `--mal-threshold` was changed from `-mt` to `-m`
+  * `--eng-threshold` was changed from `-et` to `-e`
+  * `--lic-threshold` was changed from `-lt` to `-c`
+  * `--aut-threshold` was changed from `-at` to `-o`
 
 ## v0.6.0 (2022-05-27)
 ### Feature


### PR DESCRIPTION
# Overview
Automatically add issues created in this project to the main project planning board.

# Checklist
- ~[ ] Does this PR have an associated issue?~
- ~[ ] Have you ensured that you have met the expected acceptance criteria?~
- ~[ ] Have you created sufficient tests?~

Be sure to review additional expectations on the [developments standards page](https://www.notion.so/phylum/Development-Standards-and-Expectations-07f01c12f56b4bc099840d6074c92615#15d11ce9c55540cb90d604a4a178ee86).

# Issue
~What issue(s) does this PR close. Use the `closes #<issueNum>` here.~