### PR TITLE
perf: optimize Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,3 @@
 .mypy_cache
 .venv
 .tox
-dist

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,10 @@
 .DS_Store
+**/__pycache__
+**/*.py[cod]
 .gitignore
 .git
 .github
 .mypy_cache
 .venv
 .tox
+dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,8 @@ jobs:
     defaults:
       run:
         shell: bash
+    env:
+      DOCKER_BUILDKIT: 1
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v3
@@ -151,7 +153,7 @@ jobs:
         run: |
           export PKG_SRC=dist/phylum-*.whl
           export PKG_NAME=phylum-*.whl
-          docker build --tag phylum-ci --build-arg PKG_SRC --build-arg PKG_NAME .
+          docker build --tag phylum-ci --build-arg PKG_SRC --build-arg PKG_NAME --build-arg BUILDKIT_INLINE_CACHE=1 .
           docker tag phylum-ci phylumio/phylum-ci:latest
           docker tag phylum-ci phylumio/phylum-ci:${{ env.phylum_release_version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,8 @@ jobs:
     defaults:
       run:
         shell: bash
+    env:
+      DOCKER_BUILDKIT: 1
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,10 +165,13 @@ interact with `pytest` by passing additional positional arguments:
 ```sh
 # run a specific test module across all test environments
 poetry run tox tests/unit/test_package_metadata.py
+
 # run a specific test module across a specific test environment
 poetry run tox -e py39 tests/unit/test_package_metadata.py
+
 # run a specific test function within a test module, in a specific test environment
 poetry run tox -e py310 tests/unit/test_package_metadata.py::test_python_version
+
 # passing additional options to pytest requires using the double dash escape
 poetry run tox -e py310 -- --help
 ```
@@ -178,6 +181,7 @@ To run a script entry point with the local checkout of the code (in develop mode
 ```sh
 # If not done previously, ensure the project is installed by poetry (only required once)
 poetry install
+
 # Use the `poetry run` command to ensure the installed project is used
 poetry run phylum-init -h
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,6 @@ ENV PATH=/root/.local/bin:$PATH \
 RUN set -eux; \
     apk add --update --no-cache git; \
     phylum-init; \
-    find / -type f -name '*.pyc' -delete; \
-    # Ensure no keys used during image creation are leaked through
-    unset PHYLUM_API_KEY
+    find / -type f -name '*.pyc' -delete
 
 CMD ["phylum-ci"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
+# syntax=docker/dockerfile:1
+# The syntax statement above is to make use of buildkit's build mounts for caching
+
+##########################################################################################
+# This Dockerfile makes use of BuildKit mode, which needs to be enabled client side first:
+#
+# $ export DOCKER_BUILDKIT=1
+#
 # This Dockerfile can be used to build the project's package within the image it creates.
 # To do so, simply build the image WITHOUT any build args specified (e.g., `--build-arg`):
 #
@@ -14,9 +22,19 @@
 # $ export PKG_SRC=dist/phylum-*.whl
 # $ export PKG_NAME=phylum-*.whl
 # $ docker build --tag phylum-ci --build-arg PKG_SRC --build-arg PKG_NAME .
+#
+# To make use of BuildKit's inline layer caching feature, add the `BUILDKIT_INLINE_CACHE`
+# build argument to any instance of building an image. Then, that image can be used
+# locally or remotely (if it was pushed to a repository) to warm the build cache by using
+# the `--cache-from` argument:
+#
+# $ docker build --tag phylumio/phylum-ci:cache --build-arg BUILDKIT_INLINE_CACHE=1 .
+# $ docker push phylumio/phylum-ci:cache && docker image rm phylumio/phylum-ci:cache
+# $ docker build --tag phylumio/phylum-ci:faster --cache-from phylumio/phylum-ci:cache .
+##########################################################################################
 
 # Explicitly specify a platform that is supported by `phylum-init`
-FROM --platform=linux/amd64 python:3.10-slim AS builder
+FROM --platform=linux/amd64 python:3.10-alpine AS builder
 
 # PKG_SRC is the path to a built distribution/wheel and PKG_NAME is the name of the built
 # distribution/wheel. Both can optionally be specified in glob form. When not defined,
@@ -25,27 +43,51 @@ ARG PKG_SRC
 ARG PKG_NAME
 
 WORKDIR /app
+
+ENV PIP_NO_COMPILE=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Install build tools to compile dependencies that don't have prebuilt wheels
+RUN apk add --update --no-cache build-base git poetry libffi-dev
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+
+# Copy the bare minimum needed for specifying dependencies.
+# This will enable better layer caching and faster builds when iterating locally.
+# `--without-hashes` is used to ensure the `pip` cache mount is used for packages that
+# would otherwise only match the sdist and therefore have to be built for every run.
+# References:
+#   * https://pythonspeed.com/articles/pipenv-docker/
+#   * https://hub.docker.com/r/docker/dockerfile
+COPY pyproject.toml poetry.lock ./
+RUN poetry export --without-hashes --format requirements.txt --output requirements.txt
+
+# Cache the pip installed dependencies
+# NOTE: This `--mount` feature requires BUILDKIT to be used
+RUN --mount=type=cache,id=pip,target=/root/.cache/pip \
+    set -eux; \
+    pip cache info; \
+    pip cache list; \
+    pip install --user -r requirements.txt
 COPY "${PKG_SRC:-.}" .
-RUN apt update \
-    && apt upgrade -y \
-    # Install build tools to compile dependencies that don't have prebuilt wheels
-    && apt install -y git build-essential \
-    && pip install --no-cache-dir --upgrade pip setuptools wheel \
-    && pip install --user --no-cache-dir ${PKG_NAME:-.}
+RUN pip install --user --no-cache-dir ${PKG_NAME:-.}
+RUN find /root/.local -type f -name '*.pyc' -delete
 
 # Explicitly specify a platform that is supported by `phylum-init`
-FROM --platform=linux/amd64 python:3.10-slim
+FROM --platform=linux/amd64 python:3.10-alpine
 
 LABEL maintainer="Phylum, Inc. <engineering@phylum.io>"
-# copy only Python packages to limit the image size
+
+# Copy only Python packages to limit the image size
 COPY --from=builder /root/.local /root/.local
-ENV PATH=/root/.local/bin:$PATH
-RUN apt update \
-    && apt upgrade -y \
-    && apt install -y git \
-    && apt clean \
-    && apt purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-    && rm -rf /var/lib/apt/lists /var/cache/apt/archives \
-    && phylum-init
+
+ENV PATH=/root/.local/bin:$PATH \
+    PYTHONDONTWRITEBYTECODE=1
+
+RUN set -eux; \
+    apk add --update --no-cache git; \
+    phylum-init; \
+    find / -type f -name '*.pyc' -delete; \
+    # Ensure no keys used during image creation are leaked through
+    unset PHYLUM_API_KEY
 
 CMD ["phylum-ci"]

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -85,6 +85,7 @@ def get_args(args: Optional[Sequence[str]] = None) -> Tuple[argparse.Namespace, 
     )
 
     parser.add_argument(
+        "-V",
         "--version",
         action="version",
         version=f"{SCRIPT_NAME} {__version__}",

--- a/src/phylum/init/cli.py
+++ b/src/phylum/init/cli.py
@@ -279,6 +279,7 @@ def get_args(args=None):
             `phylum auth register` command after install.""",
     )
     parser.add_argument(
+        "-V",
         "--version",
         action="version",
         version=f"{SCRIPT_NAME} {__version__}",


### PR DESCRIPTION
Some of the changes made to complete this issue and resulting improvements:

* The image base layer was switched from one based on Debian to one based on Alpine
* The compressed image size was reduced from 84MB to 35MB
* The expanded image size was reduced from 245MB to 96MB
* The image acquisition process in GitLab was reduced from ~16s to ~9s and the total run time was reduced from ~26s to ~19s
* The Dockerfile now makes use of BuildKit for caching purposes
  * It can be used to create images used for layer caching
  * It is also making use of a cache type build mount in order to re-use already built wheels
    * This cuts the build time for cross compiled builds by ~75% (after the wheels are in the cache)

Additional changes made in this PR, unrelated to issue #48:

* Reformat code examples to add whitespace lines
* Expose version arguments with a short form `-V`
  * The lowercase form `-v` is reserved for future use, to represent the short form of `--verbose`

Closes #48

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [ ] ~Have you created sufficient tests?~
  - Still only manually tested
- [x] Have you updated all affected documentation?

## Screenshots

---

GitLab run before the changes:

<img width="2285" alt="image" src="https://user-images.githubusercontent.com/18729796/172653281-154fb119-11d8-4069-a55b-551d098c8ebe.png">

---

GitLab run after the changes:

<img width="2285" alt="image" src="https://user-images.githubusercontent.com/18729796/172653523-33fc2421-ea09-4461-b1e4-12e87c4f73e6.png">
