### PR TITLE
docs: add a security policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,11 @@ If you are proposing a feature, please use the feature request template which sh
 * Provide additional context
 * Add acceptance criteria
 
+## Security Disclosures
+
+Found a security issue in this repository? See the [security policy](docs/security.md)
+for details on coordinated disclosure.
+
 ## Local Development
 
 Ready to contribute with code submissions and pull requests (PRs)?

--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ MIT - with complete text available in the [LICENSE](LICENSE) file.
 Suggestions and help are welcome. Feel free to open an issue or otherwise contribute.
 More information is available on the [contributing documentation](CONTRIBUTING.md) page.
 
+## Security Disclosures
+
+Found a security issue in this repository? See the [security policy](docs/security.md)
+for details on coordinated disclosure.
+
 ## Change log
 
 All notable changes to this project are documented in the [CHANGELOG](CHANGELOG.md).

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+Phylum was founded by a team of security researchers at heart, and we take the security of our tooling seriously.
+
+## Reporting a Vulnerability
+
+We love coordinated disclosure!
+Please email [security@phylum.io](mailto:security@phylum.io) to start a conversation!
+We'll coordinate a secure communication mechanism first, then evaluate the reported issue(s)
+and keep you apprised each step of the way.
+
+## Supported Versions
+
+The project currently makes use of a [zero-based versioning scheme](https://0ver.org/) and will continue to do so until
+it is deemed stable. Until then, only the latest release of the project is supported with security updates. That is, if
+changes are made to adhere to security, a new release containing those changes will be made from the latest commits to
+the default branch. No long-living release branches will be created. This policy may change once there are non-zero
+major version releases.


### PR DESCRIPTION
The security policy comes from the [CLI repo](https://github.com/phylum-dev/cli/blob/main/docs/security.md)...with an addition about supported versions.

Some relevant links/references:
* [`phylum-ci` repo security overview](https://github.com/phylum-dev/phylum-ci/security)
  * This will close out one of the last two items there
* [GitHub documentation on how to add a security policy](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository#about-security-policies)
