### PR TITLE
feat: coordinate phylum-ci Docker image releases with new CLI releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,98 @@
+# This is a workflow for building and pushing Docker images.
+#
+# It is configured to be triggered by repository dispatch events which come from outside of this repository.
+# It requires write access to the repository by providing a personal access token (PAT) with `repo` scope.
+#
+# The `event_type` parameter is expected to be `build-push-docker-images`.
+# The `client_payload` parameter is expected to contain the following data:
+#   * `CLI_version`: a string containing the Phylum CLI version to include in the image
+#
+# Here is an example repository dispatch event, triggered with `curl` from the command line:
+#
+# curl \
+#   -X POST \
+#   --fail-with-body \
+#   -H "Accept: application/vnd.github.v3+json" \
+#   -H "Authorization: token <PAT>" \
+#   -d '{"event_type":"build-push-docker-images","client_payload":{"CLI_version":"v3.5.0"}}' \
+#   https://api.github.com/repos/phylum-dev/phylum-ci/dispatches
+#
+# References:
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch
+# https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event
+---
+name: Build and push images
+
+concurrency: Production
+
+on:
+  repository_dispatch:
+    types: [build-push-docker-images]
+
+jobs:
+  docker:
+    name: Build and push Docker images
+    environment:
+      name: Production
+      url: https://hub.docker.com/r/phylumio/phylum-ci/tags
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - name: Get latest phylum-ci release version
+        # The API is called directly here instead of using git commands because the repo is not checked out yet
+        run: >
+          echo "phylum_rel_ver=$(curl --silent
+          https://api.github.com/repos/phylum-dev/phylum-ci/releases/latest
+          | jq --raw-output .tag_name)"
+          >> $GITHUB_ENV
+
+      - name: Checkout the repo
+        uses: actions/checkout@v3
+        with:
+          # This will ensure the checkout matches the tag for the latest release
+          ref: ${{ env.phylum_rel_ver }}
+
+      - name: Get phylum wheel from latest release
+        run: gh release download ${{ env.phylum_rel_ver }} --pattern '*.whl'
+
+      - name: Build docker image with latest phylum wheel
+        run: >
+          docker build
+          --tag phylum-ci
+          --build-arg PKG_SRC=phylum-*.whl
+          --build-arg PKG_NAME=phylum-*.whl
+          --build-arg CLI_VER=${{ github.event.client_payload.CLI_version }}
+          --build-arg BUILDKIT_INLINE_CACHE=1
+          .
+
+      - name: Test docker image with latest phylum wheel
+        run: |
+          docker run --rm phylum-ci git --version
+          docker run --rm phylum-ci phylum-ci --version
+          docker run --rm phylum-ci phylum-ci --help
+          docker run --rm phylum-ci phylum-init --help
+          docker run --rm phylum-ci phylum --help
+
+      - name: Login to Docker Hub
+        run: docker login --username ${{ secrets.DOCKER_HUB_USERNAME }} --password ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Tag and push unique docker image
+        run: |
+          export CLI_REL_VER=$(docker run --rm phylum-ci phylum --version | sed 's/phylum //')
+          docker tag phylum-ci phylumio/phylum-ci:${{ env.phylum_rel_ver }}-CLI$CLI_REL_VER
+          docker push phylumio/phylum-ci:${{ env.phylum_rel_ver }}-CLI$CLI_REL_VER
+
+      - name: Tag and push latest docker image
+        # Only tag and push `latest` when it's not a CLI pre-release
+        if: ! contains(github.event.client_payload.CLI_version, 'rc')
+        run: |
+          docker tag phylum-ci phylumio/phylum-ci:latest
+          docker push phylumio/phylum-ci:latest
+
+      - name: Logout of Docker Hub
+        if: always()
+        run: docker logout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,11 +44,20 @@ jobs:
     steps:
       - name: Get latest phylum-ci release version
         # The API is called directly here instead of using git commands because the repo is not checked out yet
-        run: >
-          echo "phylum_rel_ver=$(curl --silent
-          https://api.github.com/repos/phylum-dev/phylum-ci/releases/latest
-          | jq --raw-output .tag_name)"
-          >> $GITHUB_ENV
+        run: |
+          export phylum_release_version=$( \
+            curl \
+              --silent \
+              -H "Accept: application/vnd.github.v3+json" \
+              https://api.github.com/repos/phylum-dev/phylum-ci/releases/latest \
+            | \
+            jq \
+              --raw-output \
+              --exit-status \
+              .tag_name \
+          )
+          echo $phylum_release_version
+          echo "phylum_rel_ver=$phylum_release_version" >> $GITHUB_ENV
 
       - name: Checkout the repo
         uses: actions/checkout@v3
@@ -60,14 +69,14 @@ jobs:
         run: gh release download ${{ env.phylum_rel_ver }} --pattern '*.whl'
 
       - name: Build docker image with latest phylum wheel
-        run: >
-          docker build
-          --tag phylum-ci
-          --build-arg PKG_SRC=phylum-*.whl
-          --build-arg PKG_NAME=phylum-*.whl
-          --build-arg CLI_VER=${{ github.event.client_payload.CLI_version }}
-          --build-arg BUILDKIT_INLINE_CACHE=1
-          .
+        run: |
+          docker build \
+            --tag phylum-ci \
+            --build-arg PKG_SRC=phylum-*.whl \
+            --build-arg PKG_NAME=phylum-*.whl \
+            --build-arg CLI_VER=${{ github.event.client_payload.CLI_version }} \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            .
 
       - name: Test docker image with latest phylum wheel
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,8 +98,8 @@ jobs:
             poetry version $(poetry run semantic-release print-version --next)
           fi
 
-      - name: Set phylum_release_version value
-        run: echo "phylum_release_version=$(poetry version --short)" >> $GITHUB_ENV
+      - name: Set phylum_rel_ver value
+        run: echo "phylum_rel_ver=$(poetry version --short)" >> $GITHUB_ENV
 
       # NOTE: Run the tests for the current active Python version, as a sanity check.
       - name: Run tox via poetry
@@ -121,13 +121,13 @@ jobs:
         run: >
           pipx run
           --index-url https://test.pypi.org/simple/
-          --spec "phylum==${{ env.phylum_release_version }}"
+          --spec "phylum==${{ env.phylum_rel_ver }}"
           --pip-args="--extra-index-url=https://pypi.org/simple/"
           phylum-init -h
 
           pipx run
           --index-url https://test.pypi.org/simple/
-          --spec "phylum==${{ env.phylum_release_version }}"
+          --spec "phylum==${{ env.phylum_rel_ver }}"
           --pip-args="--extra-index-url=https://pypi.org/simple/"
           phylum-ci -h
 
@@ -147,28 +147,36 @@ jobs:
           else
             poetry run semantic-release publish -v DEBUG
           fi
-          echo "::set-output name=url::https://pypi.org/project/phylum/${{ env.phylum_release_version }}/"
+          echo "::set-output name=url::https://pypi.org/project/phylum/${{ env.phylum_rel_ver }}/"
 
       - name: Build docker image
         run: |
           export PKG_SRC=dist/phylum-*.whl
           export PKG_NAME=phylum-*.whl
           docker build --tag phylum-ci --build-arg PKG_SRC --build-arg PKG_NAME --build-arg BUILDKIT_INLINE_CACHE=1 .
-          docker tag phylum-ci phylumio/phylum-ci:latest
-          docker tag phylum-ci phylumio/phylum-ci:${{ env.phylum_release_version }}
 
       - name: Test docker image with pre-built distributions
         run: |
-          docker run --rm phylumio/phylum-ci:latest git --version
-          docker run --rm phylumio/phylum-ci:latest phylum-ci --version
-          docker run --rm phylumio/phylum-ci:latest phylum-ci --help
-          docker run --rm phylumio/phylum-ci:latest phylum-init --help
-          docker run --rm phylumio/phylum-ci:latest phylum --help
+          docker run --rm phylum-ci git --version
+          docker run --rm phylum-ci phylum-ci --version
+          docker run --rm phylum-ci phylum-ci --help
+          docker run --rm phylum-ci phylum-init --help
+          docker run --rm phylum-ci phylum --help
 
-      - name: Push docker image
+      - name: Login to Docker Hub
+        run: docker login --username ${{ secrets.DOCKER_HUB_USERNAME }} --password ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Tag and push unique docker image
         run: |
-          docker login --username ${{ secrets.DOCKER_HUB_USERNAME }} --password ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          docker push phylumio/phylum-ci:${{ env.phylum_release_version }}
+          echo "cli_rel_ver=$(docker run --rm phylum-ci phylum --version | sed 's/phylum //')" >> $GITHUB_ENV
+          docker tag phylum-ci phylumio/phylum-ci:${{ env.phylum_rel_ver }}-CLI${{ env.cli_rel_ver }}
+          docker push phylumio/phylum-ci:${{ env.phylum_rel_ver }}-CLI${{ env.cli_rel_ver }}
+
+      - name: Tag and push latest docker image
+        # Only tag and push `latest` when it's not a phylum-ci pre-release
+        if: ! github.event.inputs.prerelease
+        run: |
+          docker tag phylum-ci phylumio/phylum-ci:latest
           docker push phylumio/phylum-ci:latest
 
       - name: Logout of Docker Hub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,18 +118,17 @@ jobs:
       # "reviewers" for that environment would be notified of the release and could check that the package verification
       # step(s) worked as intended before approving the release to proceed.
       - name: Verify the package
-        run: >
-          pipx run
-          --index-url https://test.pypi.org/simple/
-          --spec "phylum==${{ env.phylum_rel_ver }}"
-          --pip-args="--extra-index-url=https://pypi.org/simple/"
-          phylum-init -h
-
-          pipx run
-          --index-url https://test.pypi.org/simple/
-          --spec "phylum==${{ env.phylum_rel_ver }}"
-          --pip-args="--extra-index-url=https://pypi.org/simple/"
-          phylum-ci -h
+        run: |
+          pipx run \
+            --index-url https://test.pypi.org/simple/ \
+            --spec "phylum==${{ env.phylum_rel_ver }}" \
+            --pip-args="--extra-index-url=https://pypi.org/simple/" \
+            phylum-init -h
+          pipx run \
+            --index-url https://test.pypi.org/simple/ \
+            --spec "phylum==${{ env.phylum_rel_ver }}" \
+            --pip-args="--extra-index-url=https://pypi.org/simple/" \
+            phylum-ci -h
 
       # This step is needed b/c otherwise the Python Semantic Release `publish` cmd would bump the version a 2nd time.
       - name: Revert to original version
@@ -168,9 +167,9 @@ jobs:
 
       - name: Tag and push unique docker image
         run: |
-          echo "cli_rel_ver=$(docker run --rm phylum-ci phylum --version | sed 's/phylum //')" >> $GITHUB_ENV
-          docker tag phylum-ci phylumio/phylum-ci:${{ env.phylum_rel_ver }}-CLI${{ env.cli_rel_ver }}
-          docker push phylumio/phylum-ci:${{ env.phylum_rel_ver }}-CLI${{ env.cli_rel_ver }}
+          export CLI_REL_VER=$(docker run --rm phylum-ci phylum --version | sed 's/phylum //')
+          docker tag phylum-ci phylumio/phylum-ci:${{ env.phylum_rel_ver }}-CLI$CLI_REL_VER
+          docker push phylumio/phylum-ci:${{ env.phylum_rel_ver }}-CLI$CLI_REL_VER
 
       - name: Tag and push latest docker image
         # Only tag and push `latest` when it's not a phylum-ci pre-release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,17 +123,13 @@ jobs:
         run: poetry build -vvv
 
       - name: Build docker image with pre-built distributions
-        run: >
-          export PKG_SRC=dist/phylum-*.whl
-
-          export PKG_NAME=phylum-*.whl
-
-          docker build
-          --tag phylum-ci:from-dist
-          --cache-from phylumio/phylum-ci:latest
-          --build-arg PKG_SRC
-          --build-arg PKG_NAME
-          .
+        run: |
+          docker build \
+            --tag phylum-ci:from-dist \
+            --cache-from phylumio/phylum-ci:latest \
+            --build-arg PKG_SRC=dist/phylum-*.whl \
+            --build-arg PKG_NAME=phylum-*.whl \
+            .
 
       - name: Test docker image built from dist
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
           poetry install --verbose --no-root
 
       - name: Build docker image from source
-        run: docker build --tag phylum-ci:from-src .
+        run: docker build --tag phylum-ci:from-src --cache-from phylumio/phylum-ci:latest .
 
       - name: Test docker image built from source
         run: |
@@ -123,10 +123,17 @@ jobs:
         run: poetry build -vvv
 
       - name: Build docker image with pre-built distributions
-        run: |
+        run: >
           export PKG_SRC=dist/phylum-*.whl
+
           export PKG_NAME=phylum-*.whl
-          docker build --tag phylum-ci:from-dist --build-arg PKG_SRC --build-arg PKG_NAME .
+
+          docker build
+          --tag phylum-ci:from-dist
+          --cache-from phylumio/phylum-ci:latest
+          --build-arg PKG_SRC
+          --build-arg PKG_NAME
+          .
 
       - name: Test docker image built from dist
         run: |


### PR DESCRIPTION
* Create a new GitHub workflow for building and pushing Docker images
  * Configure it to be triggered by repository dispatch events
* Ensure the `latest` image tag is not created/pushed for pre-releases
* Expose another build arg to the Dockerfile: `CLI_VER`
  * Used to optionally specify the Phylum CLI version to install
* Update the Test workflow to make use of BuildKit-enabled layer caching
  * The Release and Docker workflows were purposely not updated to match
  * Release docker builds should build from scratch to get latest deps
* Refactor throughout

Closes #50

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [ ] Have you created sufficient tests?
  - It won't be possible to truly test this change until the corresponding work in `phylum-dev/cli` is merged to `main`
  - https://github.com/phylum-dev/cli/pull/466
- [x] Have you updated all affected documentation?
