### PR TITLE
fix: logical prefixed `not` fails GitHub workflow syntax

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Tag and push latest docker image
         # Only tag and push `latest` when it's not a CLI pre-release
-        if: ! contains(github.event.client_payload.CLI_version, 'rc')
+        if: contains(github.event.client_payload.CLI_version, 'rc') != true
         run: |
           docker tag phylum-ci phylumio/phylum-ci:latest
           docker push phylumio/phylum-ci:latest

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -81,5 +81,5 @@ jobs:
           retention-days: 7
 
       - name: Publish to TestPyPI
-        if: github.event.inputs.TestPyPI == 'true'
+        if: inputs.TestPyPI
         run: poetry publish --repository testpypi --username __token__ --password ${{ secrets.TESTPYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
 
       - name: Tag and push latest docker image
         # Only tag and push `latest` when it's not a phylum-ci pre-release
-        if: ! github.event.inputs.prerelease
+        if: github.event.inputs.prerelease == false
         run: |
           docker tag phylum-ci phylumio/phylum-ci:latest
           docker push phylumio/phylum-ci:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Set to next version for build
         run: |
-          if [ "${{ github.event.inputs.prerelease }}" = "true" ]; then
+          if [ "${{ inputs.prerelease }}" = "true" ]; then
             poetry version $(poetry run semantic-release print-version --next --prerelease)
           else
             poetry version $(poetry run semantic-release print-version --next)
@@ -141,7 +141,7 @@ jobs:
           REPOSITORY_USERNAME: __token__
           REPOSITORY_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          if [ "${{ github.event.inputs.prerelease }}" = "true" ]; then
+          if [ "${{ inputs.prerelease }}" = "true" ]; then
             poetry run semantic-release publish -v DEBUG --prerelease
           else
             poetry run semantic-release publish -v DEBUG
@@ -173,7 +173,7 @@ jobs:
 
       - name: Tag and push latest docker image
         # Only tag and push `latest` when it's not a phylum-ci pre-release
-        if: github.event.inputs.prerelease == false
+        if: inputs.prerelease == false
         run: |
           docker tag phylum-ci phylumio/phylum-ci:latest
           docker push phylumio/phylum-ci:latest


### PR DESCRIPTION
It turns out the following syntax is invalid for a GitHub Actions workflow:

```yaml
# both of these forms fail the syntax check
if: ! contains(github.ref, 'rc')
if: !contains(github.ref, 'rc')
```

This was discovered after merging the new Docker workflow and [attempting to trigger it](https://github.com/phylum-dev/phylum-ci/actions/runs/2497648487/workflow)

After searching the docs and coming up empty, a [GitHub Community Forum post](https://github.community/t/expression-syntax-for-not-startswith/17040) for this issue (but for `startswith` instead of `contains`) showed the way to go:

```yaml
# it works if you enclose everything in double quotes
if: "!contains(github.ref, 'rc')"

# this also works and reads more cleanly to my eye
if: contains(github.ref, 'rc') != true
```

Closes #50

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?
