### PR TITLE
fix: using gh cli requires specifying a token

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,6 +66,8 @@ jobs:
           ref: ${{ env.phylum_rel_ver }}
 
       - name: Get phylum wheel from latest release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release download ${{ env.phylum_rel_ver }} --pattern '*.whl'
 
       - name: Build docker image with latest phylum wheel


### PR DESCRIPTION
The documentation makes it clear:
https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows

The basic `GITHUB_TOKEN` used for the workflow should be good enough
to download the artifacts.

Closes #50

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?
