### PR TITLE
fix: docker image tags are inconsistent

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,8 @@
 #
 # The `event_type` parameter is expected to be `build-push-docker-images`.
 # The `client_payload` parameter is expected to contain the following data:
-#   * `CLI_version`: a string containing the Phylum CLI version to include in the image
+#   * `CLI_version`: a string containing the Phylum CLI version to include
+#                    in the image, in a format acceptable to `phylum-init`
 #
 # Here is an example repository dispatch event, triggered with `curl` from the command line:
 #
@@ -45,7 +46,7 @@ jobs:
       - name: Get latest phylum-ci release version
         # The API is called directly here instead of using git commands because the repo is not checked out yet
         run: |
-          export phylum_release_version=$( \
+          REL_VER_WITH_v=$( \
             curl \
               --silent \
               -H "Accept: application/vnd.github.v3+json" \
@@ -56,19 +57,21 @@ jobs:
               --exit-status \
               .tag_name \
           )
-          echo $phylum_release_version
-          echo "phylum_rel_ver=$phylum_release_version" >> $GITHUB_ENV
+          REL_VER_WITHOUT_v=$(echo $REL_VER_WITH_v | sed 's/v//')
+          echo $REL_VER_WITH_v $REL_VER_WITHOUT_v
+          echo "REL_VER_WITH_v=$REL_VER_WITH_v" >> $GITHUB_ENV
+          echo "REL_VER_WITHOUT_v=$REL_VER_WITHOUT_v" >> $GITHUB_ENV
 
       - name: Checkout the repo
         uses: actions/checkout@v3
         with:
           # This will ensure the checkout matches the tag for the latest release
-          ref: ${{ env.phylum_rel_ver }}
+          ref: ${{ env.REL_VER_WITH_v }}
 
       - name: Get phylum wheel from latest release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release download ${{ env.phylum_rel_ver }} --pattern '*.whl'
+        run: gh release download ${{ env.REL_VER_WITH_v }} --pattern '*.whl'
 
       - name: Build docker image with latest phylum wheel
         run: |
@@ -94,12 +97,14 @@ jobs:
       - name: Tag and push unique docker image
         run: |
           export CLI_REL_VER=$(docker run --rm phylum-ci phylum --version | sed 's/phylum //')
-          docker tag phylum-ci phylumio/phylum-ci:${{ env.phylum_rel_ver }}-CLI$CLI_REL_VER
-          docker push phylumio/phylum-ci:${{ env.phylum_rel_ver }}-CLI$CLI_REL_VER
+          docker tag phylum-ci phylumio/phylum-ci:${{ env.REL_VER_WITHOUT_v }}-CLI$CLI_REL_VER
+          docker push phylumio/phylum-ci:${{ env.REL_VER_WITHOUT_v }}-CLI$CLI_REL_VER
 
       - name: Tag and push latest docker image
         # Only tag and push `latest` when it's not a CLI pre-release
-        if: contains(github.event.client_payload.CLI_version, 'rc') != true
+        # NOTE: This is an instance where the expression syntax (`${{ }}`) is required for the `if` conditional,
+        #       contrary to the GitHub workflow syntax documentation. Do not remove the expression syntax.
+        if: ${{ !contains(github.event.client_payload.CLI_version, 'rc') }}
         run: |
           docker tag phylum-ci phylumio/phylum-ci:latest
           docker push phylumio/phylum-ci:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,8 +87,8 @@ jobs:
           poetry env use python${{ matrix.python-version }}
           poetry install --verbose --no-root
 
-      - name: Set phylum_original_version value
-        run: echo "phylum_original_version=$(poetry version --short)" >> $GITHUB_ENV
+      - name: Set PHYLUM_ORIGINAL_VER value
+        run: echo "PHYLUM_ORIGINAL_VER=$(poetry version --short)" >> $GITHUB_ENV
 
       - name: Set to next version for build
         run: |
@@ -98,8 +98,8 @@ jobs:
             poetry version $(poetry run semantic-release print-version --next)
           fi
 
-      - name: Set phylum_rel_ver value
-        run: echo "phylum_rel_ver=$(poetry version --short)" >> $GITHUB_ENV
+      - name: Set PHYLUM_REL_VER value
+        run: echo "PHYLUM_REL_VER=$(poetry version --short)" >> $GITHUB_ENV
 
       # NOTE: Run the tests for the current active Python version, as a sanity check.
       - name: Run tox via poetry
@@ -121,18 +121,18 @@ jobs:
         run: |
           pipx run \
             --index-url https://test.pypi.org/simple/ \
-            --spec "phylum==${{ env.phylum_rel_ver }}" \
+            --spec "phylum==${{ env.PHYLUM_REL_VER }}" \
             --pip-args="--extra-index-url=https://pypi.org/simple/" \
             phylum-init -h
           pipx run \
             --index-url https://test.pypi.org/simple/ \
-            --spec "phylum==${{ env.phylum_rel_ver }}" \
+            --spec "phylum==${{ env.PHYLUM_REL_VER }}" \
             --pip-args="--extra-index-url=https://pypi.org/simple/" \
             phylum-ci -h
 
       # This step is needed b/c otherwise the Python Semantic Release `publish` cmd would bump the version a 2nd time.
       - name: Revert to original version
-        run: poetry version ${{ env.phylum_original_version }}
+        run: poetry version ${{ env.PHYLUM_ORIGINAL_VER }}
 
       - name: Use Python Semantic Release to publish release
         id: psr_release
@@ -146,7 +146,7 @@ jobs:
           else
             poetry run semantic-release publish -v DEBUG
           fi
-          echo "::set-output name=url::https://pypi.org/project/phylum/${{ env.phylum_rel_ver }}/"
+          echo "::set-output name=url::https://pypi.org/project/phylum/${{ env.PHYLUM_REL_VER }}/"
 
       - name: Build docker image
         run: |
@@ -168,12 +168,12 @@ jobs:
       - name: Tag and push unique docker image
         run: |
           export CLI_REL_VER=$(docker run --rm phylum-ci phylum --version | sed 's/phylum //')
-          docker tag phylum-ci phylumio/phylum-ci:${{ env.phylum_rel_ver }}-CLI$CLI_REL_VER
-          docker push phylumio/phylum-ci:${{ env.phylum_rel_ver }}-CLI$CLI_REL_VER
+          docker tag phylum-ci phylumio/phylum-ci:${{ env.PHYLUM_REL_VER }}-CLI$CLI_REL_VER
+          docker push phylumio/phylum-ci:${{ env.PHYLUM_REL_VER }}-CLI$CLI_REL_VER
 
       - name: Tag and push latest docker image
         # Only tag and push `latest` when it's not a phylum-ci pre-release
-        if: inputs.prerelease == false
+        if: ${{ !inputs.prerelease }}
         run: |
           docker tag phylum-ci phylumio/phylum-ci:latest
           docker push phylumio/phylum-ci:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,8 @@ jobs:
 
       - name: Tag and push latest docker image
         # Only tag and push `latest` when it's not a phylum-ci pre-release
+        # NOTE: This is an instance where the expression syntax (`${{ }}`) is required for the `if` conditional,
+        #       contrary to the GitHub workflow syntax documentation. Do not remove the expression syntax.
         if: ${{ !inputs.prerelease }}
         run: |
           docker tag phylum-ci phylumio/phylum-ci:latest

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/phylum-dev/phylum-ci/Test/main?label=Test&logo=GitHub)](https://github.com/phylum-dev/phylum-ci/actions/workflows/test.yml)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](./CODE_OF_CONDUCT.md)
 
-Python package for handling CI and other integrations
+Utilities for handling Phylum integrations
 
 ## Installation and usage
 
@@ -20,7 +20,7 @@ The `phylum` Python package is pip installable for the environment of your choic
 pip install phylum
 ```
 
-It can also also be installed in an isolated environment with the excellent [`pipx` tool](https://pypa.github.io/pipx/):
+It can also be installed in an isolated environment with the excellent [`pipx` tool](https://pypa.github.io/pipx/):
 
 ```sh
 # Globally install the app(s) on your system in an isolated virtual environment for the package
@@ -68,9 +68,21 @@ docker run -it --rm -e PHYLUM_API_KEY --mount type=bind,src=$(pwd),dst=/phylum -
 ```
 
 The Docker image contains `git` and the installed `phylum` Python package.
-It also contains an installed version of the Phylum CLI. The version of the Phylum CLI is the `latest` at the time of
-the Docker image creation. An advantage of using the Docker image is that the complete environment is packaged and made
-available with components that are known to work together.
+It also contains an installed version of the Phylum CLI.
+An advantage of using the Docker image is that the complete environment is packaged and made available with components
+that are known to work together.
+
+When using the `latest` tagged image, the version of the Phylum CLI is the `latest` available.
+There are additional image tag options available to specify a specific release of the `phylum-ci` project and a specific
+version of the Phylum CLI, in the form of `<phylum-ci version>-CLIv<Phylum CLI version>`. Here are image tag examples:
+
+```sh
+# Get the most current release of *both* `phylum-ci` and the Phylum CLI
+docker pull phylumio/phylum-ci:latest
+
+# Get the image with `phylum-ci` version 0.8.0 and Phylum CLI version 3.5.0
+docker pull phylumio/phylum-ci:0.8.0-CLIv3.5.0
+```
 
 #### `phylum-init` Script Entry Point
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/phylum-dev/phylum-ci/Test/main?label=Test&logo=GitHub)](https://github.com/phylum-dev/phylum-ci/actions/workflows/test.yml)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](./CODE_OF_CONDUCT.md)
 
-Utilities for handling Phylum integrations
+Utilities for integrating Phylum into CI pipelines (and beyond)
 
 ## Installation and usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "phylum"
 version = "0.8.0"
-description = "Utilities for handling Phylum integrations"
+description = "Utilities for integrating Phylum into CI pipelines (and beyond)"
 license = "MIT"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 homepage = "https://phylum.io/"


### PR DESCRIPTION
The Docker workflow makes use of steps that expect the `phylum-ci`
release version to include the leading `v`, like checking out the repo
and getting the Python wheel from the latest release. This is due to how
the GitHub releases are referenced by the tag name, which includes the
leading `v`. However, the Docker image tags created by both the Release
and Docker workflows expect the version to be provided without the `v`,
based on standard tag formats in use today.

This change ensures the tags are created in the same format, regardless
of how or where the images are built. The format is:

`<phylum-ci version>-CLIv<Phylum CLI version>`

where both version component fields are expected to be semantic version
identifiers *without* a leading `v`.

Some additional formatting and documentation updates were made.

Closes #66

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?
