### PR TITLE
ci: update Phylum Analyze PR action to v2

### DIFF
--- a/.github/workflows/phylum_analyze_pr.yml
+++ b/.github/workflows/phylum_analyze_pr.yml
@@ -2,24 +2,20 @@
 # in this repository with Phylum during pull requests.
 ---
 name: Phylum_analyze
-
-on:
-  pull_request:
-
+on: pull_request
 jobs:
   Analyze_PR_with_Phylum:
     name: Analyze PR with phylum
+    permissions:            # Ensure least privilege of actions
+      contents: read        # For actions/checkout
+      pull-requests: write  # For phylum-dev/phylum-analyze-pr-action
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v3
-
-      - name: Analyze poetry.lock file
-        uses: phylum-dev/phylum-analyze-pr-action@v1
         with:
-          vul_threshold: 0.99
-          mal_threshold: 0.99
-          eng_threshold: 0.99
-          lic_threshold: 0.99
-          aut_threshold: 0.99
+          fetch-depth: 0
+      - name: Analyze poetry.lock file
+        uses: phylum-dev/phylum-analyze-pr-action@v2
+        with:
           phylum_token: ${{ secrets.PHYLUM_TOKEN }}


### PR DESCRIPTION
The individual thresholds were removed since they are set at the project level. Additionally, the `license` threshold was reduced to 20 in the project settings since group accounts do not allow for issue suppression at the moment and there are a handful of false positive issues related to the license risk domain, the lowest of which is reporting as a 20.

Closes #69

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [ ] ~Have you created sufficient tests?~
  - This PR will serve as the "test"...since the action is a required status check for PRs
- [ ] ~Have you updated all affected documentation?~
  - Nothing to update
