### PR TITLE
fix: incorrect vulnerability risk domain package key name

### DIFF
--- a/src/phylum/ci/constants.py
+++ b/src/phylum/ci/constants.py
@@ -79,7 +79,7 @@ INCOMPLETE_COMMENT_TEMPLATE = string.Template(
 #   * key name returned from a Phylum analysis as known by the overall project threshold mapping
 #   * key name returned from a Phylum analysis as known by an individual package riskVectors mapping
 PROJECT_THRESHOLD_OPTIONS = {
-    "vul_threshold": RiskDomain("Software Vulnerability", "vulnerability", "vulnerability"),
+    "vul_threshold": RiskDomain("Software Vulnerability", "vulnerability", "vulnerabilities"),
     "mal_threshold": RiskDomain("Malicious Code", "malicious", "malicious_code"),
     "eng_threshold": RiskDomain("Engineering", "engineering", "engineering"),
     "lic_threshold": RiskDomain("License", "license", "license"),


### PR DESCRIPTION
The key name returned from a Phylum analysis, as known by an individual
package `riskVectors` mapping, changed from `vulnerability` to
`vulnerabilities` in the latest release of the Phylum API.

This PR accounts for that change, allowing packages with vulnerabilities to once
again show in the CI integration results.

Closes #93

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
  - Tested locally, with @louislang, @kylewillmon, @furi0us333, and @peterjmorgan watching in a screen share to confirm the issue and it's resolution
- [ ] ~Have you updated all affected documentation?~
  - No docs to update
