### PR TITLE
feat: host `phylum-ci` Docker image on GitHub Container Registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -94,11 +94,16 @@ jobs:
       - name: Login to Docker Hub
         run: docker login --username ${{ secrets.DOCKER_HUB_USERNAME }} --password ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        run: docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
+
       - name: Tag and push unique docker image
         run: |
           export CLI_REL_VER=$(docker run --rm phylum-ci phylum --version | sed 's/phylum //')
           docker tag phylum-ci phylumio/phylum-ci:${{ env.REL_VER_WITHOUT_v }}-CLI$CLI_REL_VER
+          docker tag phylum-ci ghcr.io/phylum-dev/phylum-ci:${{ env.REL_VER_WITHOUT_v }}-CLI$CLI_REL_VER
           docker push phylumio/phylum-ci:${{ env.REL_VER_WITHOUT_v }}-CLI$CLI_REL_VER
+          docker push ghcr.io/phylum-dev/phylum-ci:${{ env.REL_VER_WITHOUT_v }}-CLI$CLI_REL_VER
 
       - name: Tag and push latest docker image
         # Only tag and push `latest` when it's not a CLI pre-release
@@ -107,8 +112,14 @@ jobs:
         if: ${{ !contains(github.event.client_payload.CLI_version, 'rc') }}
         run: |
           docker tag phylum-ci phylumio/phylum-ci:latest
+          docker tag phylum-ci ghcr.io/phylum-dev/phylum-ci:latest
           docker push phylumio/phylum-ci:latest
+          docker push ghcr.io/phylum-dev/phylum-ci:latest
 
       - name: Logout of Docker Hub
         if: always()
         run: docker logout
+
+      - name: Logout of GitHub Container Registry
+        if: always()
+        run: docker logout ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,11 +165,16 @@ jobs:
       - name: Login to Docker Hub
         run: docker login --username ${{ secrets.DOCKER_HUB_USERNAME }} --password ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        run: docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
+
       - name: Tag and push unique docker image
         run: |
           export CLI_REL_VER=$(docker run --rm phylum-ci phylum --version | sed 's/phylum //')
           docker tag phylum-ci phylumio/phylum-ci:${{ env.PHYLUM_REL_VER }}-CLI$CLI_REL_VER
+          docker tag phylum-ci ghcr.io/phylum-dev/phylum-ci:${{ env.PHYLUM_REL_VER }}-CLI$CLI_REL_VER
           docker push phylumio/phylum-ci:${{ env.PHYLUM_REL_VER }}-CLI$CLI_REL_VER
+          docker push ghcr.io/phylum-dev/phylum-ci:${{ env.PHYLUM_REL_VER }}-CLI$CLI_REL_VER
 
       - name: Tag and push latest docker image
         # Only tag and push `latest` when it's not a phylum-ci pre-release
@@ -178,11 +183,17 @@ jobs:
         if: ${{ !inputs.prerelease }}
         run: |
           docker tag phylum-ci phylumio/phylum-ci:latest
+          docker tag phylum-ci ghcr.io/phylum-dev/phylum-ci:latest
           docker push phylumio/phylum-ci:latest
+          docker push ghcr.io/phylum-dev/phylum-ci:latest
 
       - name: Logout of Docker Hub
         if: always()
         run: docker logout
+
+      - name: Logout of GitHub Container Registry
+        if: always()
+        run: docker logout ghcr.io
 
   docs:
     name: Update the readme documentation

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,7 @@ FROM python:3.10-alpine
 ARG CLI_VER
 
 LABEL maintainer="Phylum, Inc. <engineering@phylum.io>"
+LABEL org.opencontainers.image.source="https://github.com/phylum-dev/phylum-ci"
 
 # Copy only Python packages to limit the image size
 COPY --from=builder /root/.local /root/.local

--- a/docs/sync/gitlab_ci.md
+++ b/docs/sync/gitlab_ci.md
@@ -103,9 +103,10 @@ documentation for more detail.
 
 ### Docker image selection
 
-Choose the Docker image tag to match your comfort level with image dependencies. `latest` is a "rolling" tag that will
-point to the image created for the latest released `phylum-ci` Python package. A particular version tag (e.g., `0.4.0`)
-is created for each release of the `phylum-ci` Python package and _should_ not change once published.
+Choose the Docker image tag to match your comfort level with image dependencies. `latest` is a "rolling" tag that
+will point to the image created for the latest released `phylum-ci` Python package. A particular version tag
+(e.g., `0.11.0-CLIv3.7.3`) is created for each release of the `phylum-ci` Python package and _should_ not change
+once published.
 
 However, to be certain that the image does not change...or be warned when it does because it won't be available anymore
 ...use the SHA256 digest of the tag. The digest can be found by looking at the `phylumio/phylum-ci`
@@ -113,8 +114,8 @@ However, to be certain that the image does not change...or be warned when it doe
 
 ```sh
 # NOTE: The command-line JSON processor `jq` is used here for the sake of a one line example. It is not required.
-❯ docker manifest inspect --verbose phylumio/phylum-ci:0.4.0 | jq .Descriptor.digest
-"sha256:8d29ac57dfe4d0fca5c3b8c8b37b1188d13faa5e5c61e53aace7026804eac2c5"
+❯ docker manifest inspect --verbose phylumio/phylum-ci:0.11.0-CLIv3.7.3 | jq .Descriptor.digest
+"sha256:4e01c6f6a8eed994b385d5908d463f28b57bb31f902a10561bad5e4d7aa81459"
 ```
 
 For instance, at the time of this writing, all of these tag references pointed to the same image:
@@ -129,10 +130,10 @@ For instance, at the time of this writing, all of these tag references pointed t
   image: phylumio/phylum-ci:latest
 
   # use a specific release version of the `phylum-ci` package
-  image: phylumio/phylum-ci:0.4.0
+  image: phylumio/phylum-ci:0.11.0-CLIv3.7.3
 
   # use a specific image with it's SHA256 digest
-  image: phylumio/phylum-ci@sha256:8d29ac57dfe4d0fca5c3b8c8b37b1188d13faa5e5c61e53aace7026804eac2c5
+  image: phylumio/phylum-ci@sha256:4e01c6f6a8eed994b385d5908d463f28b57bb31f902a10561bad5e4d7aa81459
 ```
 
 Only the last tag reference, by SHA256 digest, is guaranteed to not have the underlying image it points to change.


### PR DESCRIPTION
This change will tag and push the `phylum-ci` Docker image to *both* Docker Hub and the GitHub Container Registry (ghcr.io). Hosting the image on ghcr.io will allow the GitHub Action integration to pull the image without any rate limits...and likely much faster as well.

Closes #92

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
  - These changes were tested manually by running the same commands locally, resulting in the package at <https://github.com/phylum-dev/phylum-ci/pkgs/container/phylum-ci>
- [x] Have you updated all affected documentation?
- [ ] The [phylum-ci package](https://github.com/phylum-dev/phylum-ci/pkgs/container/phylum-ci) still needs to be made public
  - A GitHub Org Admin will need to help with this step (CC: @louislang)
