### PR TITLE
fix: `Issue Summary` data missing for vulnerability domain

### DIFF
--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -415,10 +415,18 @@ class CIBase(ABC):
 
         for threshold_option, risk_domain in PROJECT_THRESHOLD_OPTIONS.items():
             pti = self._get_project_threshold_info(project_thresholds, threshold_option)
-            vul = risk_vectors.get(risk_domain.package_name, 1.0)
+            # The `RiskDomain` dataclass and this logic can be simplified once the API standardizes the use of names
+            # so that risk domains are referenced with the same name everywhere (e.g., vulnerability/vulnerabilities
+            # and malicious_code/malicious)
+            potential_names = [risk_domain.package_name, risk_domain.project_name]
+            for potential_name in potential_names:
+                vul = risk_vectors.get(potential_name)
+                if vul is not None:
+                    break
+            vul = vul if vul is not None else 1.0
             if vul < pti.threshold:
                 failed_flag = True
-                issue_flags.append(risk_domain.package_name)
+                issue_flags.extend(potential_names)
                 fail_string += f"|{risk_domain.output_name}|{vul*100:.0f}|{pti.threshold*100:.0f}|{pti.req_src}|\n"
 
         fail_string += "\n"


### PR DESCRIPTION
Naming things is hard. Keeping names for risk domains consistent across the various places they are referenced is even harder, it appears. There are still some differences in the API response data for the vulnerability/vulnerabilities risk domain. There is also still a difference for `malicious` and `malicious_code`. These differences are accounted for in the `RiskDomain` dataclass, but they were not accounted for in the different locations these names show up in the json response from the CLI:

* project level threshold name
* individual package `riskVectors` name
* domain name for an issue in an individual package
 
This PR attempts to account for each of the potential names in each of the places they could be referenced.

Closes #98

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [] ~Have you created sufficient tests?~
  - Still no tests; tested locally/manually
- [x] Have you updated all affected documentation?

## Screenshots

Results, from the changes in this PR, showing the issue summary for a vulnerability:

<img width="926" alt="image" src="https://user-images.githubusercontent.com/18729796/184410860-385de907-64c1-4290-a557-48f0969b4edd.png">

