### PR TITLE
docs: add script options docs with auto updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
     rev: 3298ddab3c13dd77d6ce1fc0baf97691430d84b0  # frozen: v4.3.0
     hooks:
       - id: trailing-whitespace
+        exclude_types: [svg]
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ It will accept a Phylum token from an environment variable or specified as an op
 that no token is provided. This can be because there is already a token set that should continue to be used or because
 no token exists and one will need to be manually created or set, after the CLI is installed.
 
+The options for `phylum-init`, automatically updated to be current for the latest release:
+
+![phylum-init options](https://raw.githubusercontent.com/phylum-dev/phylum-ci/main/docs/img/phylum-init_options.svg)
+
 #### `phylum-ci` Script Entry Point
 
 The `phylum-ci` script is for analyzing lockfile changes.
@@ -126,6 +130,10 @@ The current CI platforms/environments supported are:
   * Can be useful to analyze lockfiles locally, prior to or after submitting a pull/merge request (PR/MR) to a CI system
     * Establishing a successful submission prior to submitting a PR/MR to a CI system
     * Troubleshooting after submitting a PR/MR to a CI system and getting unexpected results
+
+The options for `phylum-ci`, automatically updated to be current for the latest release:
+
+![phylum-ci options](https://raw.githubusercontent.com/phylum-dev/phylum-ci/main/docs/img/phylum-ci_options.svg)
 
 [gitlab_docs]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/sync/gitlab_ci.md
 [github_docs]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/sync/github_actions.md

--- a/docs/img/phylum-ci_options.svg
+++ b/docs/img/phylum-ci_options.svg
@@ -1,0 +1,374 @@
+<svg class="rich-terminal" viewBox="0 0 994 2002.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-1555771947-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-1555771947-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-1555771947-r1 { fill: #c5c8c6 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-1555771947-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="1951.0" />
+    </clipPath>
+    <clipPath id="terminal-1555771947-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-22">
+    <rect x="0" y="538.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-23">
+    <rect x="0" y="562.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-24">
+    <rect x="0" y="587.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-25">
+    <rect x="0" y="611.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-26">
+    <rect x="0" y="635.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-27">
+    <rect x="0" y="660.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-28">
+    <rect x="0" y="684.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-29">
+    <rect x="0" y="709.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-30">
+    <rect x="0" y="733.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-31">
+    <rect x="0" y="757.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-32">
+    <rect x="0" y="782.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-33">
+    <rect x="0" y="806.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-34">
+    <rect x="0" y="831.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-35">
+    <rect x="0" y="855.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-36">
+    <rect x="0" y="879.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-37">
+    <rect x="0" y="904.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-38">
+    <rect x="0" y="928.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-39">
+    <rect x="0" y="953.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-40">
+    <rect x="0" y="977.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-41">
+    <rect x="0" y="1001.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-42">
+    <rect x="0" y="1026.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-43">
+    <rect x="0" y="1050.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-44">
+    <rect x="0" y="1075.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-45">
+    <rect x="0" y="1099.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-46">
+    <rect x="0" y="1123.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-47">
+    <rect x="0" y="1148.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-48">
+    <rect x="0" y="1172.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-49">
+    <rect x="0" y="1197.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-50">
+    <rect x="0" y="1221.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-51">
+    <rect x="0" y="1245.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-52">
+    <rect x="0" y="1270.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-53">
+    <rect x="0" y="1294.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-54">
+    <rect x="0" y="1319.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-55">
+    <rect x="0" y="1343.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-56">
+    <rect x="0" y="1367.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-57">
+    <rect x="0" y="1392.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-58">
+    <rect x="0" y="1416.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-59">
+    <rect x="0" y="1441.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-60">
+    <rect x="0" y="1465.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-61">
+    <rect x="0" y="1489.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-62">
+    <rect x="0" y="1514.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-63">
+    <rect x="0" y="1538.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-64">
+    <rect x="0" y="1563.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-65">
+    <rect x="0" y="1587.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-66">
+    <rect x="0" y="1611.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-67">
+    <rect x="0" y="1636.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-68">
+    <rect x="0" y="1660.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-69">
+    <rect x="0" y="1685.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-70">
+    <rect x="0" y="1709.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-71">
+    <rect x="0" y="1733.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-72">
+    <rect x="0" y="1758.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-73">
+    <rect x="0" y="1782.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-74">
+    <rect x="0" y="1807.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-75">
+    <rect x="0" y="1831.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-76">
+    <rect x="0" y="1855.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-77">
+    <rect x="0" y="1880.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1555771947-line-78">
+    <rect x="0" y="1904.7" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="2000" rx="8"/><text class="terminal-1555771947-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">phylum-ci&#160;options</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1555771947-clip-terminal)">
+    
+    <g class="terminal-1555771947-matrix">
+    <text class="terminal-1555771947-r1" x="0" y="20" textLength="219.6" clip-path="url(#terminal-1555771947-line-0)">$&#160;phylum-ci&#160;--help</text><text class="terminal-1555771947-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-1555771947-line-0)">
+</text><text class="terminal-1555771947-r1" x="0" y="44.4" textLength="744.2" clip-path="url(#terminal-1555771947-line-1)">usage:&#160;phylum-ci&#160;[-h]&#160;[-V]&#160;[-l&#160;LOCKFILE]&#160;[-a]&#160;[-f]&#160;[-k&#160;TOKEN]</text><text class="terminal-1555771947-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-1555771947-line-1)">
+</text><text class="terminal-1555771947-r1" x="0" y="68.8" textLength="890.6" clip-path="url(#terminal-1555771947-line-2)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;[-u&#160;VUL_THRESHOLD]&#160;[-m&#160;MAL_THRESHOLD]&#160;[-e&#160;ENG_THRESHOLD]</text><text class="terminal-1555771947-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-1555771947-line-2)">
+</text><text class="terminal-1555771947-r1" x="0" y="93.2" textLength="817.4" clip-path="url(#terminal-1555771947-line-3)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;[-c&#160;LIC_THRESHOLD]&#160;[-o&#160;AUT_THRESHOLD]&#160;[-r&#160;VERSION]</text><text class="terminal-1555771947-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-1555771947-line-3)">
+</text><text class="terminal-1555771947-r1" x="0" y="117.6" textLength="402.6" clip-path="url(#terminal-1555771947-line-4)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;[-t&#160;TARGET]&#160;[-i]</text><text class="terminal-1555771947-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-1555771947-line-4)">
+</text><text class="terminal-1555771947-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-1555771947-line-5)">
+</text><text class="terminal-1555771947-r1" x="0" y="166.4" textLength="658.8" clip-path="url(#terminal-1555771947-line-6)">Use&#160;Phylum&#160;to&#160;analyze&#160;dependencies&#160;in&#160;a&#160;CI&#160;environment</text><text class="terminal-1555771947-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-1555771947-line-6)">
+</text><text class="terminal-1555771947-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-1555771947-line-7)">
+</text><text class="terminal-1555771947-r1" x="0" y="215.2" textLength="97.6" clip-path="url(#terminal-1555771947-line-8)">options:</text><text class="terminal-1555771947-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-1555771947-line-8)">
+</text><text class="terminal-1555771947-r1" x="0" y="239.6" textLength="671" clip-path="url(#terminal-1555771947-line-9)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-1555771947-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-1555771947-line-9)">
+</text><text class="terminal-1555771947-r1" x="0" y="264" textLength="756.4" clip-path="url(#terminal-1555771947-line-10)">&#160;&#160;-V,&#160;--version&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;program&#x27;s&#160;version&#160;number&#160;and&#160;exit</text><text class="terminal-1555771947-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-1555771947-line-10)">
+</text><text class="terminal-1555771947-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-1555771947-line-11)">
+</text><text class="terminal-1555771947-r1" x="0" y="312.8" textLength="317.2" clip-path="url(#terminal-1555771947-line-12)">Lockfile&#160;Analysis&#160;Options:</text><text class="terminal-1555771947-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-1555771947-line-12)">
+</text><text class="terminal-1555771947-r1" x="0" y="337.2" textLength="414.8" clip-path="url(#terminal-1555771947-line-13)">&#160;&#160;-l&#160;LOCKFILE,&#160;--lockfile&#160;LOCKFILE</text><text class="terminal-1555771947-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-1555771947-line-13)">
+</text><text class="terminal-1555771947-r1" x="0" y="361.6" textLength="866.2" clip-path="url(#terminal-1555771947-line-14)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Path&#160;to&#160;the&#160;package&#160;lockfile&#160;to&#160;analyze.&#160;If&#160;not</text><text class="terminal-1555771947-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-1555771947-line-14)">
+</text><text class="terminal-1555771947-r1" x="0" y="386" textLength="915" clip-path="url(#terminal-1555771947-line-15)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;specified,&#160;an&#160;attempt&#160;will&#160;be&#160;made&#160;to&#160;automatically</text><text class="terminal-1555771947-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-1555771947-line-15)">
+</text><text class="terminal-1555771947-r1" x="0" y="410.4" textLength="866.2" clip-path="url(#terminal-1555771947-line-16)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;detect&#160;the&#160;lockfile.&#160;Some&#160;lockfile&#160;types&#160;(e.g.,</text><text class="terminal-1555771947-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-1555771947-line-16)">
+</text><text class="terminal-1555771947-r1" x="0" y="434.8" textLength="927.2" clip-path="url(#terminal-1555771947-line-17)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Python/pip&#160;`requirements.txt`)&#160;are&#160;ambiguous&#160;in&#160;that</text><text class="terminal-1555771947-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-1555771947-line-17)">
+</text><text class="terminal-1555771947-r1" x="0" y="459.2" textLength="878.4" clip-path="url(#terminal-1555771947-line-18)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;they&#160;can&#160;be&#160;named&#160;differently&#160;and&#160;may&#160;or&#160;may&#160;not</text><text class="terminal-1555771947-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-1555771947-line-18)">
+</text><text class="terminal-1555771947-r1" x="0" y="483.6" textLength="902.8" clip-path="url(#terminal-1555771947-line-19)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;contain&#160;strict&#160;dependencies.&#160;In&#160;these&#160;cases,&#160;it&#160;is</text><text class="terminal-1555771947-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-1555771947-line-19)">
+</text><text class="terminal-1555771947-r1" x="0" y="508" textLength="927.2" clip-path="url(#terminal-1555771947-line-20)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;best&#160;to&#160;specify&#160;an&#160;explicit&#160;lockfile&#160;path.&#160;(default:</text><text class="terminal-1555771947-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-1555771947-line-20)">
+</text><text class="terminal-1555771947-r1" x="0" y="532.4" textLength="353.8" clip-path="url(#terminal-1555771947-line-21)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;None)</text><text class="terminal-1555771947-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-1555771947-line-21)">
+</text><text class="terminal-1555771947-r1" x="0" y="556.8" textLength="890.6" clip-path="url(#terminal-1555771947-line-22)">&#160;&#160;-a,&#160;--all-deps&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Specify&#160;this&#160;flag&#160;to&#160;consider&#160;all&#160;dependencies&#160;in</text><text class="terminal-1555771947-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-1555771947-line-22)">
+</text><text class="terminal-1555771947-r1" x="0" y="581.2" textLength="951.6" clip-path="url(#terminal-1555771947-line-23)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;analysis&#160;results&#160;instead&#160;of&#160;just&#160;the&#160;newly&#160;added&#160;ones.</text><text class="terminal-1555771947-r1" x="976" y="581.2" textLength="12.2" clip-path="url(#terminal-1555771947-line-23)">
+</text><text class="terminal-1555771947-r1" x="0" y="605.6" textLength="488" clip-path="url(#terminal-1555771947-line-24)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;(default:&#160;False)</text><text class="terminal-1555771947-r1" x="976" y="605.6" textLength="12.2" clip-path="url(#terminal-1555771947-line-24)">
+</text><text class="terminal-1555771947-r1" x="0" y="630" textLength="902.8" clip-path="url(#terminal-1555771947-line-25)">&#160;&#160;-f,&#160;--force-analysis&#160;&#160;Specify&#160;this&#160;flag&#160;to&#160;force&#160;analysis,&#160;even&#160;when&#160;the</text><text class="terminal-1555771947-r1" x="976" y="630" textLength="12.2" clip-path="url(#terminal-1555771947-line-25)">
+</text><text class="terminal-1555771947-r1" x="0" y="654.4" textLength="805.2" clip-path="url(#terminal-1555771947-line-26)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;lockfile&#160;has&#160;not&#160;changed.&#160;(default:&#160;False)</text><text class="terminal-1555771947-r1" x="976" y="654.4" textLength="12.2" clip-path="url(#terminal-1555771947-line-26)">
+</text><text class="terminal-1555771947-r1" x="0" y="678.8" textLength="390.4" clip-path="url(#terminal-1555771947-line-27)">&#160;&#160;-k&#160;TOKEN,&#160;--phylum-token&#160;TOKEN</text><text class="terminal-1555771947-r1" x="976" y="678.8" textLength="12.2" clip-path="url(#terminal-1555771947-line-27)">
+</text><text class="terminal-1555771947-r1" x="0" y="703.2" textLength="890.6" clip-path="url(#terminal-1555771947-line-28)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Phylum&#160;user&#160;token.&#160;Can&#160;also&#160;specify&#160;this&#160;option&#x27;s</text><text class="terminal-1555771947-r1" x="976" y="703.2" textLength="12.2" clip-path="url(#terminal-1555771947-line-28)">
+</text><text class="terminal-1555771947-r1" x="0" y="727.6" textLength="890.6" clip-path="url(#terminal-1555771947-line-29)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;value&#160;by&#160;setting&#160;the&#160;`PHYLUM_API_KEY`&#160;environment</text><text class="terminal-1555771947-r1" x="976" y="727.6" textLength="12.2" clip-path="url(#terminal-1555771947-line-29)">
+</text><text class="terminal-1555771947-r1" x="0" y="752" textLength="927.2" clip-path="url(#terminal-1555771947-line-30)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;variable.&#160;The&#160;value&#160;specified&#160;with&#160;this&#160;option&#160;takes</text><text class="terminal-1555771947-r1" x="976" y="752" textLength="12.2" clip-path="url(#terminal-1555771947-line-30)">
+</text><text class="terminal-1555771947-r1" x="0" y="776.4" textLength="927.2" clip-path="url(#terminal-1555771947-line-31)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;precedence&#160;when&#160;both&#160;are&#160;provided.&#160;Leave&#160;this&#160;option</text><text class="terminal-1555771947-r1" x="976" y="776.4" textLength="12.2" clip-path="url(#terminal-1555771947-line-31)">
+</text><text class="terminal-1555771947-r1" x="0" y="800.8" textLength="927.2" clip-path="url(#terminal-1555771947-line-32)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;and&#160;it&#x27;s&#160;related&#160;environment&#160;variable&#160;unspecified&#160;to</text><text class="terminal-1555771947-r1" x="976" y="800.8" textLength="12.2" clip-path="url(#terminal-1555771947-line-32)">
+</text><text class="terminal-1555771947-r1" x="0" y="825.2" textLength="915" clip-path="url(#terminal-1555771947-line-33)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;either&#160;(1)&#160;use&#160;an&#160;existing&#160;token&#160;already&#160;set&#160;in&#160;the</text><text class="terminal-1555771947-r1" x="976" y="825.2" textLength="12.2" clip-path="url(#terminal-1555771947-line-33)">
+</text><text class="terminal-1555771947-r1" x="0" y="849.6" textLength="902.8" clip-path="url(#terminal-1555771947-line-34)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Phylum&#160;config&#160;file&#160;or&#160;(2)&#160;to&#160;manually&#160;populate&#160;the</text><text class="terminal-1555771947-r1" x="976" y="849.6" textLength="12.2" clip-path="url(#terminal-1555771947-line-34)">
+</text><text class="terminal-1555771947-r1" x="0" y="874" textLength="878.4" clip-path="url(#terminal-1555771947-line-35)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;token&#160;with&#160;a&#160;`phylum&#160;auth&#160;login`&#160;or&#160;`phylum&#160;auth</text><text class="terminal-1555771947-r1" x="976" y="874" textLength="12.2" clip-path="url(#terminal-1555771947-line-35)">
+</text><text class="terminal-1555771947-r1" x="0" y="898.4" textLength="878.4" clip-path="url(#terminal-1555771947-line-36)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;register`&#160;command&#160;after&#160;install.&#160;(default:&#160;None)</text><text class="terminal-1555771947-r1" x="976" y="898.4" textLength="12.2" clip-path="url(#terminal-1555771947-line-36)">
+</text><text class="terminal-1555771947-r1" x="976" y="922.8" textLength="12.2" clip-path="url(#terminal-1555771947-line-37)">
+</text><text class="terminal-1555771947-r1" x="0" y="947.2" textLength="366" clip-path="url(#terminal-1555771947-line-38)">Risk&#160;Domain&#160;Threshold&#160;Options:</text><text class="terminal-1555771947-r1" x="976" y="947.2" textLength="12.2" clip-path="url(#terminal-1555771947-line-38)">
+</text><text class="terminal-1555771947-r1" x="0" y="971.6" textLength="866.2" clip-path="url(#terminal-1555771947-line-39)">&#160;&#160;Thresholds&#160;for&#160;the&#160;five&#160;risk&#160;domains&#160;may&#160;already&#160;be&#160;set&#160;at&#160;the&#160;Phylum</text><text class="terminal-1555771947-r1" x="976" y="971.6" textLength="12.2" clip-path="url(#terminal-1555771947-line-39)">
+</text><text class="terminal-1555771947-r1" x="0" y="996" textLength="878.4" clip-path="url(#terminal-1555771947-line-40)">&#160;&#160;project&#160;level.&#160;They&#160;can&#160;be&#160;set&#160;differently&#160;here&#160;for&#160;CI&#160;environments&#160;to</text><text class="terminal-1555771947-r1" x="976" y="996" textLength="12.2" clip-path="url(#terminal-1555771947-line-40)">
+</text><text class="terminal-1555771947-r1" x="0" y="1020.4" textLength="902.8" clip-path="url(#terminal-1555771947-line-41)">&#160;&#160;&quot;fail&#160;the&#160;build.&quot;&#160;The&#160;default&#160;is&#160;to&#160;use&#160;the&#160;project&#160;level&#160;setting&#160;unless</text><text class="terminal-1555771947-r1" x="976" y="1020.4" textLength="12.2" clip-path="url(#terminal-1555771947-line-41)">
+</text><text class="terminal-1555771947-r1" x="0" y="1044.8" textLength="902.8" clip-path="url(#terminal-1555771947-line-42)">&#160;&#160;overridden&#160;by&#160;a&#160;value&#160;specified&#160;in&#160;this&#160;group.&#160;Values&#160;must&#160;be&#160;an&#160;integer</text><text class="terminal-1555771947-r1" x="976" y="1044.8" textLength="12.2" clip-path="url(#terminal-1555771947-line-42)">
+</text><text class="terminal-1555771947-r1" x="0" y="1069.2" textLength="927.2" clip-path="url(#terminal-1555771947-line-43)">&#160;&#160;between&#160;0&#160;and&#160;100,&#160;inclusive.&#160;Setting&#160;the&#160;value&#160;to&#160;zero&#160;(0)&#160;has&#160;the&#160;effect</text><text class="terminal-1555771947-r1" x="976" y="1069.2" textLength="12.2" clip-path="url(#terminal-1555771947-line-43)">
+</text><text class="terminal-1555771947-r1" x="0" y="1093.6" textLength="915" clip-path="url(#terminal-1555771947-line-44)">&#160;&#160;of&#160;disabling&#160;analysis&#160;against&#160;that&#160;risk&#160;domain.&#160;See&#160;&quot;Phylum&#160;Risk&#160;Domains&quot;</text><text class="terminal-1555771947-r1" x="976" y="1093.6" textLength="12.2" clip-path="url(#terminal-1555771947-line-44)">
+</text><text class="terminal-1555771947-r1" x="0" y="1118" textLength="927.2" clip-path="url(#terminal-1555771947-line-45)">&#160;&#160;documentation&#160;for&#160;more&#160;detail:&#160;https://docs.phylum.io/docs/phylum-package-</text><text class="terminal-1555771947-r1" x="976" y="1118" textLength="12.2" clip-path="url(#terminal-1555771947-line-45)">
+</text><text class="terminal-1555771947-r1" x="0" y="1142.4" textLength="244" clip-path="url(#terminal-1555771947-line-46)">&#160;&#160;score#risk-domains</text><text class="terminal-1555771947-r1" x="976" y="1142.4" textLength="12.2" clip-path="url(#terminal-1555771947-line-46)">
+</text><text class="terminal-1555771947-r1" x="976" y="1166.8" textLength="12.2" clip-path="url(#terminal-1555771947-line-47)">
+</text><text class="terminal-1555771947-r1" x="0" y="1191.2" textLength="597.8" clip-path="url(#terminal-1555771947-line-48)">&#160;&#160;-u&#160;VUL_THRESHOLD,&#160;--vul-threshold&#160;VUL_THRESHOLD</text><text class="terminal-1555771947-r1" x="976" y="1191.2" textLength="12.2" clip-path="url(#terminal-1555771947-line-48)">
+</text><text class="terminal-1555771947-r1" x="0" y="1215.6" textLength="939.4" clip-path="url(#terminal-1555771947-line-49)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;v(u)lnerability&#160;risk&#160;score&#160;threshold&#160;value.&#160;(default:</text><text class="terminal-1555771947-r1" x="976" y="1215.6" textLength="12.2" clip-path="url(#terminal-1555771947-line-49)">
+</text><text class="terminal-1555771947-r1" x="0" y="1240" textLength="353.8" clip-path="url(#terminal-1555771947-line-50)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;None)</text><text class="terminal-1555771947-r1" x="976" y="1240" textLength="12.2" clip-path="url(#terminal-1555771947-line-50)">
+</text><text class="terminal-1555771947-r1" x="0" y="1264.4" textLength="597.8" clip-path="url(#terminal-1555771947-line-51)">&#160;&#160;-m&#160;MAL_THRESHOLD,&#160;--mal-threshold&#160;MAL_THRESHOLD</text><text class="terminal-1555771947-r1" x="976" y="1264.4" textLength="12.2" clip-path="url(#terminal-1555771947-line-51)">
+</text><text class="terminal-1555771947-r1" x="0" y="1288.8" textLength="951.6" clip-path="url(#terminal-1555771947-line-52)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;(m)alicious&#160;Code&#160;risk&#160;score&#160;threshold&#160;value.&#160;(default:</text><text class="terminal-1555771947-r1" x="976" y="1288.8" textLength="12.2" clip-path="url(#terminal-1555771947-line-52)">
+</text><text class="terminal-1555771947-r1" x="0" y="1313.2" textLength="353.8" clip-path="url(#terminal-1555771947-line-53)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;None)</text><text class="terminal-1555771947-r1" x="976" y="1313.2" textLength="12.2" clip-path="url(#terminal-1555771947-line-53)">
+</text><text class="terminal-1555771947-r1" x="0" y="1337.6" textLength="597.8" clip-path="url(#terminal-1555771947-line-54)">&#160;&#160;-e&#160;ENG_THRESHOLD,&#160;--eng-threshold&#160;ENG_THRESHOLD</text><text class="terminal-1555771947-r1" x="976" y="1337.6" textLength="12.2" clip-path="url(#terminal-1555771947-line-54)">
+</text><text class="terminal-1555771947-r1" x="0" y="1362" textLength="915" clip-path="url(#terminal-1555771947-line-55)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;(e)ngineering&#160;risk&#160;score&#160;threshold&#160;value.&#160;(default:</text><text class="terminal-1555771947-r1" x="976" y="1362" textLength="12.2" clip-path="url(#terminal-1555771947-line-55)">
+</text><text class="terminal-1555771947-r1" x="0" y="1386.4" textLength="353.8" clip-path="url(#terminal-1555771947-line-56)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;None)</text><text class="terminal-1555771947-r1" x="976" y="1386.4" textLength="12.2" clip-path="url(#terminal-1555771947-line-56)">
+</text><text class="terminal-1555771947-r1" x="0" y="1410.8" textLength="597.8" clip-path="url(#terminal-1555771947-line-57)">&#160;&#160;-c&#160;LIC_THRESHOLD,&#160;--lic-threshold&#160;LIC_THRESHOLD</text><text class="terminal-1555771947-r1" x="976" y="1410.8" textLength="12.2" clip-path="url(#terminal-1555771947-line-57)">
+</text><text class="terminal-1555771947-r1" x="0" y="1435.2" textLength="939.4" clip-path="url(#terminal-1555771947-line-58)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;li(c)ense&#160;risk&#160;score&#160;threshold&#160;value.&#160;(default:&#160;None)</text><text class="terminal-1555771947-r1" x="976" y="1435.2" textLength="12.2" clip-path="url(#terminal-1555771947-line-58)">
+</text><text class="terminal-1555771947-r1" x="0" y="1459.6" textLength="597.8" clip-path="url(#terminal-1555771947-line-59)">&#160;&#160;-o&#160;AUT_THRESHOLD,&#160;--aut-threshold&#160;AUT_THRESHOLD</text><text class="terminal-1555771947-r1" x="976" y="1459.6" textLength="12.2" clip-path="url(#terminal-1555771947-line-59)">
+</text><text class="terminal-1555771947-r1" x="0" y="1484" textLength="927.2" clip-path="url(#terminal-1555771947-line-60)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;auth(o)r&#160;risk&#160;score&#160;threshold&#160;value.&#160;(default:&#160;None)</text><text class="terminal-1555771947-r1" x="976" y="1484" textLength="12.2" clip-path="url(#terminal-1555771947-line-60)">
+</text><text class="terminal-1555771947-r1" x="976" y="1508.4" textLength="12.2" clip-path="url(#terminal-1555771947-line-61)">
+</text><text class="terminal-1555771947-r1" x="0" y="1532.8" textLength="231.8" clip-path="url(#terminal-1555771947-line-62)">Phylum&#160;CLI&#160;Options:</text><text class="terminal-1555771947-r1" x="976" y="1532.8" textLength="12.2" clip-path="url(#terminal-1555771947-line-62)">
+</text><text class="terminal-1555771947-r1" x="0" y="1557.2" textLength="854" clip-path="url(#terminal-1555771947-line-63)">&#160;&#160;Use&#160;the&#160;options&#160;here&#160;to&#160;control&#160;the&#160;Phylum&#160;CLI&#160;version&#160;in&#160;use&#160;during</text><text class="terminal-1555771947-r1" x="976" y="1557.2" textLength="12.2" clip-path="url(#terminal-1555771947-line-63)">
+</text><text class="terminal-1555771947-r1" x="0" y="1581.6" textLength="890.6" clip-path="url(#terminal-1555771947-line-64)">&#160;&#160;analysis.&#160;Examples&#160;of&#160;when&#160;this&#160;may&#160;be&#160;useful&#160;are:&#160;for&#160;troubleshooting,</text><text class="terminal-1555771947-r1" x="976" y="1581.6" textLength="12.2" clip-path="url(#terminal-1555771947-line-64)">
+</text><text class="terminal-1555771947-r1" x="0" y="1606" textLength="854" clip-path="url(#terminal-1555771947-line-65)">&#160;&#160;maintaining&#160;a&#160;consistent&#160;evironment,&#160;ensuring&#160;the&#160;latest&#160;version,&#160;or</text><text class="terminal-1555771947-r1" x="976" y="1606" textLength="12.2" clip-path="url(#terminal-1555771947-line-65)">
+</text><text class="terminal-1555771947-r1" x="0" y="1630.4" textLength="890.6" clip-path="url(#terminal-1555771947-line-66)">&#160;&#160;reverting&#160;to&#160;a&#160;previous&#160;version&#160;when&#160;the&#160;installed&#160;one&#160;causes&#160;an&#160;issue.</text><text class="terminal-1555771947-r1" x="976" y="1630.4" textLength="12.2" clip-path="url(#terminal-1555771947-line-66)">
+</text><text class="terminal-1555771947-r1" x="976" y="1654.8" textLength="12.2" clip-path="url(#terminal-1555771947-line-67)">
+</text><text class="terminal-1555771947-r1" x="0" y="1679.2" textLength="463.6" clip-path="url(#terminal-1555771947-line-68)">&#160;&#160;-r&#160;VERSION,&#160;--phylum-release&#160;VERSION</text><text class="terminal-1555771947-r1" x="976" y="1679.2" textLength="12.2" clip-path="url(#terminal-1555771947-line-68)">
+</text><text class="terminal-1555771947-r1" x="0" y="1703.6" textLength="939.4" clip-path="url(#terminal-1555771947-line-69)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;The&#160;version&#160;of&#160;the&#160;Phylum&#160;CLI&#160;to&#160;install,&#160;when&#160;one&#160;is</text><text class="terminal-1555771947-r1" x="976" y="1703.6" textLength="12.2" clip-path="url(#terminal-1555771947-line-69)">
+</text><text class="terminal-1555771947-r1" x="0" y="1728" textLength="951.6" clip-path="url(#terminal-1555771947-line-70)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;not&#160;already&#160;installed.&#160;Can&#160;be&#160;specified&#160;as&#160;`latest`&#160;or</text><text class="terminal-1555771947-r1" x="976" y="1728" textLength="12.2" clip-path="url(#terminal-1555771947-line-70)">
+</text><text class="terminal-1555771947-r1" x="0" y="1752.4" textLength="951.6" clip-path="url(#terminal-1555771947-line-71)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;a&#160;specific&#160;tagged&#160;release,&#160;with&#160;or&#160;without&#160;the&#160;leading</text><text class="terminal-1555771947-r1" x="976" y="1752.4" textLength="12.2" clip-path="url(#terminal-1555771947-line-71)">
+</text><text class="terminal-1555771947-r1" x="0" y="1776.8" textLength="561.2" clip-path="url(#terminal-1555771947-line-72)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;`v`.&#160;(default:&#160;latest)</text><text class="terminal-1555771947-r1" x="976" y="1776.8" textLength="12.2" clip-path="url(#terminal-1555771947-line-72)">
+</text><text class="terminal-1555771947-r1" x="0" y="1801.2" textLength="341.6" clip-path="url(#terminal-1555771947-line-73)">&#160;&#160;-t&#160;TARGET,&#160;--target&#160;TARGET</text><text class="terminal-1555771947-r1" x="976" y="1801.2" textLength="12.2" clip-path="url(#terminal-1555771947-line-73)">
+</text><text class="terminal-1555771947-r1" x="0" y="1825.6" textLength="854" clip-path="url(#terminal-1555771947-line-74)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;The&#160;target&#160;platform&#160;type&#160;where&#160;the&#160;CLI&#160;will&#160;be</text><text class="terminal-1555771947-r1" x="976" y="1825.6" textLength="12.2" clip-path="url(#terminal-1555771947-line-74)">
+</text><text class="terminal-1555771947-r1" x="0" y="1850" textLength="805.2" clip-path="url(#terminal-1555771947-line-75)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;installed.&#160;(default:&#160;aarch64-apple-darwin)</text><text class="terminal-1555771947-r1" x="976" y="1850" textLength="12.2" clip-path="url(#terminal-1555771947-line-75)">
+</text><text class="terminal-1555771947-r1" x="0" y="1874.4" textLength="927.2" clip-path="url(#terminal-1555771947-line-76)">&#160;&#160;-i,&#160;--force-install&#160;&#160;&#160;Specify&#160;this&#160;flag&#160;to&#160;ensure&#160;the&#160;specified&#160;Phylum&#160;CLI</text><text class="terminal-1555771947-r1" x="976" y="1874.4" textLength="12.2" clip-path="url(#terminal-1555771947-line-76)">
+</text><text class="terminal-1555771947-r1" x="0" y="1898.8" textLength="841.8" clip-path="url(#terminal-1555771947-line-77)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;release&#160;version&#160;is&#160;the&#160;one&#160;that&#160;is&#160;installed.</text><text class="terminal-1555771947-r1" x="976" y="1898.8" textLength="12.2" clip-path="url(#terminal-1555771947-line-77)">
+</text><text class="terminal-1555771947-r1" x="0" y="1923.2" textLength="841.8" clip-path="url(#terminal-1555771947-line-78)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Otherwise,&#160;any&#160;existing&#160;version&#160;will&#160;be&#160;used.</text><text class="terminal-1555771947-r1" x="976" y="1923.2" textLength="12.2" clip-path="url(#terminal-1555771947-line-78)">
+</text><text class="terminal-1555771947-r1" x="0" y="1947.6" textLength="488" clip-path="url(#terminal-1555771947-line-79)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;(default:&#160;False)</text><text class="terminal-1555771947-r1" x="976" y="1947.6" textLength="12.2" clip-path="url(#terminal-1555771947-line-79)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/img/phylum-init_options.svg
+++ b/docs/img/phylum-init_options.svg
@@ -1,0 +1,178 @@
+<svg class="rich-terminal" viewBox="0 0 994 806.4" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-1090844768-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-1090844768-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-1090844768-r1 { fill: #c5c8c6 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-1090844768-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="755.4" />
+    </clipPath>
+    <clipPath id="terminal-1090844768-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-22">
+    <rect x="0" y="538.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-23">
+    <rect x="0" y="562.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-24">
+    <rect x="0" y="587.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-25">
+    <rect x="0" y="611.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-26">
+    <rect x="0" y="635.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-27">
+    <rect x="0" y="660.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-28">
+    <rect x="0" y="684.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1090844768-line-29">
+    <rect x="0" y="709.1" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="804.4" rx="8"/><text class="terminal-1090844768-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">phylum-init&#160;options</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1090844768-clip-terminal)">
+    
+    <g class="terminal-1090844768-matrix">
+    <text class="terminal-1090844768-r1" x="0" y="20" textLength="244" clip-path="url(#terminal-1090844768-line-0)">$&#160;phylum-init&#160;--help</text><text class="terminal-1090844768-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-1090844768-line-0)">
+</text><text class="terminal-1090844768-r1" x="0" y="44.4" textLength="780.8" clip-path="url(#terminal-1090844768-line-1)">usage:&#160;phylum-init&#160;[-h]&#160;[-V]&#160;[-r&#160;VERSION]&#160;[-t&#160;TARGET]&#160;[-k&#160;TOKEN]</text><text class="terminal-1090844768-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-1090844768-line-1)">
+</text><text class="terminal-1090844768-r1" x="0" y="68.8" textLength="646.6" clip-path="url(#terminal-1090844768-line-2)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;[--list-releases&#160;|&#160;--list-targets]</text><text class="terminal-1090844768-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-1090844768-line-2)">
+</text><text class="terminal-1090844768-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-1090844768-line-3)">
+</text><text class="terminal-1090844768-r1" x="0" y="117.6" textLength="390.4" clip-path="url(#terminal-1090844768-line-4)">Fetch&#160;and&#160;install&#160;the&#160;Phylum&#160;CLI</text><text class="terminal-1090844768-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-1090844768-line-4)">
+</text><text class="terminal-1090844768-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-1090844768-line-5)">
+</text><text class="terminal-1090844768-r1" x="0" y="166.4" textLength="97.6" clip-path="url(#terminal-1090844768-line-6)">options:</text><text class="terminal-1090844768-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-1090844768-line-6)">
+</text><text class="terminal-1090844768-r1" x="0" y="190.8" textLength="671" clip-path="url(#terminal-1090844768-line-7)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-1090844768-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-1090844768-line-7)">
+</text><text class="terminal-1090844768-r1" x="0" y="215.2" textLength="756.4" clip-path="url(#terminal-1090844768-line-8)">&#160;&#160;-V,&#160;--version&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;program&#x27;s&#160;version&#160;number&#160;and&#160;exit</text><text class="terminal-1090844768-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-1090844768-line-8)">
+</text><text class="terminal-1090844768-r1" x="0" y="239.6" textLength="463.6" clip-path="url(#terminal-1090844768-line-9)">&#160;&#160;-r&#160;VERSION,&#160;--phylum-release&#160;VERSION</text><text class="terminal-1090844768-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-1090844768-line-9)">
+</text><text class="terminal-1090844768-r1" x="0" y="264" textLength="878.4" clip-path="url(#terminal-1090844768-line-10)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;The&#160;version&#160;of&#160;the&#160;Phylum&#160;CLI&#160;to&#160;install.&#160;Can&#160;be</text><text class="terminal-1090844768-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-1090844768-line-10)">
+</text><text class="terminal-1090844768-r1" x="0" y="288.4" textLength="915" clip-path="url(#terminal-1090844768-line-11)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;specified&#160;as&#160;`latest`&#160;or&#160;a&#160;specific&#160;tagged&#160;release,</text><text class="terminal-1090844768-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-1090844768-line-11)">
+</text><text class="terminal-1090844768-r1" x="0" y="312.8" textLength="902.8" clip-path="url(#terminal-1090844768-line-12)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;with&#160;or&#160;without&#160;the&#160;leading&#160;`v`.&#160;(default:&#160;latest)</text><text class="terminal-1090844768-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-1090844768-line-12)">
+</text><text class="terminal-1090844768-r1" x="0" y="337.2" textLength="341.6" clip-path="url(#terminal-1090844768-line-13)">&#160;&#160;-t&#160;TARGET,&#160;--target&#160;TARGET</text><text class="terminal-1090844768-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-1090844768-line-13)">
+</text><text class="terminal-1090844768-r1" x="0" y="361.6" textLength="854" clip-path="url(#terminal-1090844768-line-14)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;The&#160;target&#160;platform&#160;type&#160;where&#160;the&#160;CLI&#160;will&#160;be</text><text class="terminal-1090844768-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-1090844768-line-14)">
+</text><text class="terminal-1090844768-r1" x="0" y="386" textLength="805.2" clip-path="url(#terminal-1090844768-line-15)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;installed.&#160;(default:&#160;aarch64-apple-darwin)</text><text class="terminal-1090844768-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-1090844768-line-15)">
+</text><text class="terminal-1090844768-r1" x="0" y="410.4" textLength="390.4" clip-path="url(#terminal-1090844768-line-16)">&#160;&#160;-k&#160;TOKEN,&#160;--phylum-token&#160;TOKEN</text><text class="terminal-1090844768-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-1090844768-line-16)">
+</text><text class="terminal-1090844768-r1" x="0" y="434.8" textLength="890.6" clip-path="url(#terminal-1090844768-line-17)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Phylum&#160;user&#160;token.&#160;Can&#160;also&#160;specify&#160;this&#160;option&#x27;s</text><text class="terminal-1090844768-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-1090844768-line-17)">
+</text><text class="terminal-1090844768-r1" x="0" y="459.2" textLength="890.6" clip-path="url(#terminal-1090844768-line-18)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;value&#160;by&#160;setting&#160;the&#160;`PHYLUM_API_KEY`&#160;environment</text><text class="terminal-1090844768-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-1090844768-line-18)">
+</text><text class="terminal-1090844768-r1" x="0" y="483.6" textLength="927.2" clip-path="url(#terminal-1090844768-line-19)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;variable.&#160;The&#160;value&#160;specified&#160;with&#160;this&#160;option&#160;takes</text><text class="terminal-1090844768-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-1090844768-line-19)">
+</text><text class="terminal-1090844768-r1" x="0" y="508" textLength="927.2" clip-path="url(#terminal-1090844768-line-20)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;precedence&#160;when&#160;both&#160;are&#160;provided.&#160;Leave&#160;this&#160;option</text><text class="terminal-1090844768-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-1090844768-line-20)">
+</text><text class="terminal-1090844768-r1" x="0" y="532.4" textLength="927.2" clip-path="url(#terminal-1090844768-line-21)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;and&#160;it&#x27;s&#160;related&#160;environment&#160;variable&#160;unspecified&#160;to</text><text class="terminal-1090844768-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-1090844768-line-21)">
+</text><text class="terminal-1090844768-r1" x="0" y="556.8" textLength="915" clip-path="url(#terminal-1090844768-line-22)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;either&#160;(1)&#160;use&#160;an&#160;existing&#160;token&#160;already&#160;set&#160;in&#160;the</text><text class="terminal-1090844768-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-1090844768-line-22)">
+</text><text class="terminal-1090844768-r1" x="0" y="581.2" textLength="902.8" clip-path="url(#terminal-1090844768-line-23)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Phylum&#160;config&#160;file&#160;or&#160;(2)&#160;to&#160;manually&#160;populate&#160;the</text><text class="terminal-1090844768-r1" x="976" y="581.2" textLength="12.2" clip-path="url(#terminal-1090844768-line-23)">
+</text><text class="terminal-1090844768-r1" x="0" y="605.6" textLength="878.4" clip-path="url(#terminal-1090844768-line-24)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;token&#160;with&#160;a&#160;`phylum&#160;auth&#160;login`&#160;or&#160;`phylum&#160;auth</text><text class="terminal-1090844768-r1" x="976" y="605.6" textLength="12.2" clip-path="url(#terminal-1090844768-line-24)">
+</text><text class="terminal-1090844768-r1" x="0" y="630" textLength="878.4" clip-path="url(#terminal-1090844768-line-25)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;register`&#160;command&#160;after&#160;install.&#160;(default:&#160;None)</text><text class="terminal-1090844768-r1" x="976" y="630" textLength="12.2" clip-path="url(#terminal-1090844768-line-25)">
+</text><text class="terminal-1090844768-r1" x="0" y="654.4" textLength="902.8" clip-path="url(#terminal-1090844768-line-26)">&#160;&#160;--list-releases&#160;&#160;&#160;&#160;&#160;&#160;&#160;List&#160;the&#160;Phylum&#160;CLI&#160;releases&#160;available&#160;to&#160;install.</text><text class="terminal-1090844768-r1" x="976" y="654.4" textLength="12.2" clip-path="url(#terminal-1090844768-line-26)">
+</text><text class="terminal-1090844768-r1" x="0" y="678.8" textLength="488" clip-path="url(#terminal-1090844768-line-27)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;(default:&#160;False)</text><text class="terminal-1090844768-r1" x="976" y="678.8" textLength="12.2" clip-path="url(#terminal-1090844768-line-27)">
+</text><text class="terminal-1090844768-r1" x="0" y="703.2" textLength="829.6" clip-path="url(#terminal-1090844768-line-28)">&#160;&#160;--list-targets&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;List&#160;the&#160;target&#160;platform&#160;types&#160;available&#160;for</text><text class="terminal-1090844768-r1" x="976" y="703.2" textLength="12.2" clip-path="url(#terminal-1090844768-line-28)">
+</text><text class="terminal-1090844768-r1" x="0" y="727.6" textLength="878.4" clip-path="url(#terminal-1090844768-line-29)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;installing&#160;a&#160;given&#160;Phylum&#160;CLI&#160;release.&#160;(default:</text><text class="terminal-1090844768-r1" x="976" y="727.6" textLength="12.2" clip-path="url(#terminal-1090844768-line-29)">
+</text><text class="terminal-1090844768-r1" x="0" y="752" textLength="366" clip-path="url(#terminal-1090844768-line-30)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;False)</text><text class="terminal-1090844768-r1" x="976" y="752" textLength="12.2" clip-path="url(#terminal-1090844768-line-30)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/script_options.md
+++ b/docs/script_options.md
@@ -2,7 +2,8 @@
 
 The command line options for the script entry points provided by this package are contained on this page.
 They are automatically updated with the [rich-codex] tool for each release.
-The output is stored as SVG files, which should allow for copy and paste functionality when viewed from most browsers.
+The output is stored as SVG files, which should allow for copy and paste functionality when viewed from most
+browsers (hint: it may be necessary to click on the image and bring up the raw SVG file in the browser by itself).
 
 [rich-codex]: https://ewels.github.io/rich-codex/
 

--- a/docs/script_options.md
+++ b/docs/script_options.md
@@ -1,0 +1,17 @@
+# Overview
+
+The command line options for the script entry points provided by this package are contained on this page.
+They are automatically updated with the [rich-codex] tool for each release.
+The output is stored as SVG files, which should allow for copy and paste functionality when viewed from most browsers.
+
+[rich-codex]: https://ewels.github.io/rich-codex/
+
+## `phylum-ci` Options
+
+<!-- RICH-CODEX {fake_command: "phylum-ci --help"} -->
+![`poetry run phylum-ci --help`](img/phylum-ci_options.svg "phylum-ci options")
+
+## `phylum-init` Options
+
+<!-- RICH-CODEX {fake_command: "phylum-init --help"} -->
+![`poetry run phylum-init --help`](img/phylum-init_options.svg "phylum-init options")

--- a/docs/sync/git_precommit.md
+++ b/docs/sync/git_precommit.md
@@ -119,10 +119,10 @@ The `args` key is the way to exert control over the execution of the Phylum anal
 The `phylum-ci` script entry point is called by the hook. It has a number of arguments that are all optional
 and defaulted to secure values. To view the arguments, their description, and default values, run the script
 with `--help` output as specified in the [Usage section of the top-level README.md][usage] or view the
-[source code][src] directly.
+[script options output][script_options] for the latest release.
 
 [usage]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md#usage
-[src]: https://github.com/phylum-dev/phylum-ci/blob/main/src/phylum/ci/cli.py
+[script_options]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/script_options.md
 
 ```yaml
         # NOTE: These are examples. Only one `args` key for the hook is expected

--- a/docs/sync/gitlab_ci.md
+++ b/docs/sync/gitlab_ci.md
@@ -108,8 +108,8 @@ will point to the image created for the latest released `phylum-ci` Python packa
 (e.g., `0.11.0-CLIv3.7.3`) is created for each release of the `phylum-ci` Python package and _should_ not change
 once published.
 
-However, to be certain that the image does not change...or be warned when it does because it won't be available anymore
-...use the SHA256 digest of the tag. The digest can be found by looking at the `phylumio/phylum-ci`
+However, to be certain that the image does not change...or be warned when it does because it won't be available
+anymore...use the SHA256 digest of the tag. The digest can be found by looking at the `phylumio/phylum-ci`
 [tags on Docker Hub][docker_image] or with the command:
 
 ```sh
@@ -153,20 +153,21 @@ The account used to create the token will be the one that appears to post the no
 Therefore, it might be worth looking into using a bot account, which is available for project and group access tokens.
 See the [GitLab Token Overview][gitlab_tokens] documentation for more info.
 
-Note, using `$CI_JOB_TOKEN` as the value will work in some situations because "API authentication uses the job token, by
-using the authorization of the user triggering the job." This is not recommended for anything other than temporary
-personal use in private repositories as there is a chance that depending on it will cause failures when attempting to do
-the same thing in different scenarios.
+Note, using `$CI_JOB_TOKEN` as the value will work in some situations because "API authentication uses the job token,
+by using the authorization of the user triggering the job." This is not recommended for anything other than temporary
+personal use in private repositories as there is a chance that depending on it will cause failures when attempting to
+do the same thing in different scenarios.
 
 A [Phylum token][phylum_tokens] with API access is required to perform analysis on project
 dependencies. [Contact Phylum][phylum_contact] or create an account and register to gain access.
 See also [`phylum auth register`][phylum_register] command documentation and consider
 using a bot or group account for this token.
 
-The values for the `GITLAB_TOKEN` and `PHYLUM_API_KEY` variables can come from a
-[CI/CD Variable](https://docs.gitlab.com/ee/ci/variables/index.html) or an
-[External Secret](https://docs.gitlab.com/ee/ci/secrets/index.html). Since they are sensitive, **care should be taken
-to protect them appropriately**.
+Values for the `GITLAB_TOKEN` and `PHYLUM_API_KEY` variables can come from a [CI/CD Variable] or an [External Secret].
+Since they are sensitive, **care should be taken to protect them appropriately**.
+
+[CI/CD Variable]: https://docs.gitlab.com/ee/ci/variables/index.html
+[External Secret]: https://docs.gitlab.com/ee/ci/secrets/index.html
 
 ```yaml
   variables:
@@ -191,11 +192,13 @@ to protect them appropriately**.
 
 ### Script arguments
 
-The script arguments to the Docker image are the way to exert control over the execution of the Phylum analysis. The
-`phylum-ci` script entry point is expected to be called. It has a number of arguments that are all optional and
-defaulted to secure values. To view the arguments, their description, and default values, run the script with `--help`
-output as specified in the [Usage section of the top-level README.md][usage] or view the
-[source code](https://github.com/phylum-dev/phylum-ci/blob/main/src/phylum/ci/cli.py) directly.
+The script arguments to the Docker image are the way to exert control over the execution of the Phylum analysis.
+The `phylum-ci` script entry point is expected to be called. It has a number of arguments that are all optional
+and defaulted to secure values. To view the arguments, their description, and default values,
+run the script with `--help` output as specified in the [Usage section of the top-level README.md][usage] or
+view the [script options output][script_options] for the latest release.
+
+[script_options]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/script_options.md
 
 ```yaml
   # NOTE: These are examples. Only one script entry line for `phylum-ci` is expected.

--- a/poetry.lock
+++ b/poetry.lock
@@ -15,10 +15,10 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-tests_no_zope = ["cloudpickle", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
-tests = ["cloudpickle", "zope.interface", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
-docs = ["sphinx-notfound-page", "zope.interface", "sphinx", "furo"]
-dev = ["cloudpickle", "pre-commit", "sphinx-notfound-page", "sphinx", "furo", "zope.interface", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "bleach"
@@ -33,8 +33,8 @@ six = ">=1.9.0"
 webencodings = "*"
 
 [package.extras]
-dev = ["mypy (==0.961)", "black (==22.3.0)", "wheel (==0.37.1)", "twine (==4.0.1)", "tox (==3.25.0)", "Sphinx (==4.3.2)", "pytest (==7.1.2)", "pip-tools (==6.6.2)", "hashin (==0.17.0)", "flake8 (==4.0.1)", "build (==0.8.0)"]
 css = ["tinycss2 (>=1.1.0,<1.2)"]
+dev = ["build (==0.8.0)", "flake8 (==4.0.1)", "hashin (==0.17.0)", "pip-tools (==6.6.2)", "pytest (==7.1.2)", "Sphinx (==4.3.2)", "tox (==3.25.0)", "twine (==4.0.1)", "wheel (==0.37.1)", "black (==22.3.0)", "mypy (==0.961)"]
 
 [[package]]
 name = "certifi"
@@ -106,7 +106,7 @@ optional = false
 python-versions = "*"
 
 [package.extras]
-test = ["hypothesis (==3.55.3)", "flake8 (==3.7.8)"]
+test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 
 [[package]]
 name = "connect-markdown-renderer"
@@ -219,9 +219,9 @@ typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-testing = ["importlib-resources (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-black (>=0.3.7)", "pytest-perf (>=0.9.2)", "flufl.flake8", "pyfakefs", "packaging", "pytest-enabler (>=1.3)", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=2.4)", "pytest (>=6)"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
-docs = ["rst.linker (>=1.9)", "jaraco.packaging (>=9)", "sphinx"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "importlib-resources"
@@ -235,8 +235,8 @@ python-versions = ">=3.7"
 zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-testing = ["pytest-mypy (>=0.9.1)", "pytest-black (>=0.3.7)", "pytest-enabler (>=1.3)", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=2.4)", "pytest (>=6)"]
-docs = ["jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "jaraco.packaging (>=9)", "sphinx"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "iniconfig"
@@ -255,6 +255,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "jarowinkler"
+version = "1.2.1"
+description = "library for fast approximate string matching using Jaro and Jaro-Winkler similarity"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "jeepney"
 version = "0.8.0"
 description = "Low-level, pure Python DBus protocol wrapper."
@@ -263,8 +271,28 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-trio = ["async-generator", "trio"]
-test = ["async-timeout", "trio", "testpath", "pytest-asyncio (>=0.17)", "pytest-trio", "pytest"]
+test = ["pytest", "pytest-trio", "pytest-asyncio (>=0.17)", "testpath", "trio", "async-timeout"]
+trio = ["trio", "async-generator"]
+
+[[package]]
+name = "jsonschema"
+version = "4.9.1"
+description = "An implementation of JSON Schema validation for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+attrs = ">=17.4.0"
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
+pkgutil-resolve-name = {version = ">=1.3.10", markers = "python_version < \"3.9\""}
+pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
+format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
 
 [[package]]
 name = "keyring"
@@ -281,8 +309,19 @@ pywin32-ctypes = {version = "<0.1.0 || >0.1.0,<0.1.1 || >0.1.1", markers = "sys_
 SecretStorage = {version = ">=3.2", markers = "sys_platform == \"linux\""}
 
 [package.extras]
-testing = ["pytest-mypy (>=0.9.1)", "pytest-black (>=0.3.7)", "pytest-enabler (>=1.3)", "pytest-cov", "flake8 (<5)", "pytest-flake8", "pytest-checkdocs (>=2.4)", "pytest (>=6)"]
-docs = ["jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "jaraco.packaging (>=9)", "sphinx"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "flake8 (<5)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+
+[[package]]
+name = "levenshtein"
+version = "0.20.2"
+description = "Python extension for computing string edit distances and similarities."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+rapidfuzz = ">=2.3.0,<3.0.0"
 
 [[package]]
 name = "markdown-it-py"
@@ -334,7 +373,15 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.extras]
-testing = ["coverage", "nose"]
+testing = ["nose", "coverage"]
+
+[[package]]
+name = "pkgutil-resolve-name"
+version = "1.3.10"
+description = "Resolve a name to an object."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "platformdirs"
@@ -345,8 +392,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-test = ["pytest (>=6)", "pytest-mock (>=3.6)", "pytest-cov (>=2.7)", "appdirs (==1.4.4)"]
-docs = ["sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)", "proselint (>=0.10.2)", "furo (>=2021.7.5b38)"]
+docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
+test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
 
 [[package]]
 name = "pluggy"
@@ -360,8 +407,8 @@ python-versions = ">=3.6"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
-testing = ["pytest-benchmark", "pytest"]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "py"
@@ -396,7 +443,15 @@ optional = false
 python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["jinja2", "railroad-diagrams"]
+diagrams = ["railroad-diagrams", "jinja2"]
+
+[[package]]
+name = "pyrsistent"
+version = "0.18.1"
+description = "Persistent/Functional/Immutable data structures"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
 
 [[package]]
 name = "pytest"
@@ -418,7 +473,7 @@ py = ">=1.8.2"
 tomli = ">=1.0.0"
 
 [package.extras]
-testing = ["xmlschema", "requests", "pygments (>=2.7.2)", "nose", "mock", "hypothesis (>=3.56)", "argcomplete"]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "pytest-github-actions-annotate-failures"
@@ -469,10 +524,10 @@ tomlkit = ">=0.10.0,<0.11.0"
 twine = ">=3,<4"
 
 [package.extras]
-test = ["mock (==1.3.0)", "responses (==0.13.3)", "pytest-mock (>=2,<3)", "pytest-xdist (>=1,<2)", "pytest (>=5,<6)", "coverage (>=5,<6)"]
-mypy = ["types-requests", "mypy"]
-docs = ["Jinja2 (==3.0.3)", "Sphinx (==1.3.6)"]
-dev = ["black", "isort", "tox"]
+dev = ["tox", "isort", "black"]
+docs = ["Sphinx (==1.3.6)", "Jinja2 (==3.0.3)"]
+mypy = ["mypy", "types-requests"]
+test = ["coverage (>=5,<6)", "pytest (>=5,<6)", "pytest-xdist (>=1,<2)", "pytest-mock (>=2,<3)", "responses (==0.13.3)", "mock (==1.3.0)"]
 
 [[package]]
 name = "pywin32-ctypes"
@@ -481,6 +536,28 @@ description = ""
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "pyyaml"
+version = "6.0"
+description = "YAML parser and emitter for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "rapidfuzz"
+version = "2.5.0"
+description = "rapid fuzzy string matching"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+jarowinkler = ">=1.2.0,<2.0.0"
+
+[package.extras]
+full = ["numpy"]
 
 [[package]]
 name = "readme-renderer"
@@ -513,8 +590,8 @@ idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "requests-toolbelt"
@@ -553,6 +630,71 @@ typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
+
+[[package]]
+name = "rich-cli"
+version = "1.8.0"
+description = "Command Line Interface to Rich"
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+click = ">=8.0.0,<9.0.0"
+requests = ">=2.0.0,<3.0.0"
+rich = ">=12.4.1,<13.0.0"
+rich-rst = ">=1.1.7,<2.0.0"
+textual = ">=0.1.18,<0.2.0"
+
+[[package]]
+name = "rich-click"
+version = "1.5.2"
+description = "Format click help output nicely with rich"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+click = ">=7"
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+rich = ">=10.7.0"
+
+[package.extras]
+dev = ["pre-commit"]
+typer = ["typer (>=0.4,<0.6)"]
+
+[[package]]
+name = "rich-codex"
+version = "1.2.2"
+description = "Generate rich images for the GitHub Action 'rich-codex'"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+GitPython = "*"
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+jsonschema = "*"
+levenshtein = ">=0.18.1"
+pyyaml = "*"
+rich = ">=12.4.3"
+rich-cli = "*"
+rich-click = ">=1.5"
+
+[package.extras]
+dev = ["pre-commit"]
+cairo = ["CairoSVG (>=2.5.2)"]
+
+[[package]]
+name = "rich-rst"
+version = "1.1.7"
+description = "A beautiful reStructuredText renderer for rich"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+docutils = "*"
 
 [[package]]
 name = "ruamel.yaml"
@@ -614,6 +756,18 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "textual"
+version = "0.1.18"
+description = "Text User Interface using Rich"
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+rich = ">=12.3.0,<13.0.0"
+typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9\""}
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -657,8 +811,8 @@ toml = ">=0.9.4"
 virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,<20.0.3 || >20.0.3,<20.0.4 || >20.0.4,<20.0.5 || >20.0.5,<20.0.6 || >20.0.6,<20.0.7 || >20.0.7"
 
 [package.extras]
-testing = ["pathlib2 (>=2.3.3)", "psutil (>=5.6.1)", "pytest-randomly (>=1.0.0)", "pytest-mock (>=1.10.0)", "pytest-cov (>=2.5.1)", "pytest (>=4.0.0)", "freezegun (>=0.3.11)", "flaky (>=3.4.0)"]
-docs = ["towncrier (>=18.5.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "sphinx (>=2.0.0)", "pygments-github-lexers (>=0.0.5)"]
+docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "towncrier (>=18.5.0)"]
+testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "psutil (>=5.6.1)", "pathlib2 (>=2.3.3)"]
 
 [[package]]
 name = "tox-gh-actions"
@@ -687,10 +841,10 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [package.extras]
-telegram = ["requests"]
-slack = ["slack-sdk"]
+dev = ["py-make (>=0.1.0)", "twine", "wheel"]
 notebook = ["ipywidgets (>=6)"]
-dev = ["wheel", "twine", "py-make (>=0.1.0)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
 
 [[package]]
 name = "twine"
@@ -748,9 +902,9 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
 [package.extras]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
-secure = ["ipaddress", "certifi", "idna (>=2.0.0)", "cryptography (>=1.3.4)", "pyOpenSSL (>=0.14)"]
-brotli = ["brotlipy (>=0.6.0)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
 
 [[package]]
 name = "virtualenv"
@@ -767,8 +921,8 @@ importlib-metadata = {version = ">=4.8.3", markers = "python_version < \"3.8\""}
 platformdirs = ">=2.4,<3"
 
 [package.extras]
-testing = ["pytest-timeout (>=2.1)", "pytest-randomly (>=3.10.3)", "pytest-mock (>=3.6.1)", "pytest-freezegun (>=0.4.2)", "pytest-env (>=0.6.2)", "pytest (>=7.0.1)", "packaging (>=21.3)", "flaky (>=3.7)", "coverage-enable-subprocess (>=1)", "coverage (>=6.2)"]
-docs = ["towncrier (>=21.9)", "sphinx-rtd-theme (>=1)", "sphinx-argparse (>=0.3.1)", "sphinx (>=5.1.1)", "proselint (>=0.13)"]
+docs = ["proselint (>=0.13)", "sphinx (>=5.1.1)", "sphinx-argparse (>=0.3.1)", "sphinx-rtd-theme (>=1)", "towncrier (>=21.9)"]
+testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=21.3)", "pytest (>=7.0.1)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.6.1)", "pytest-randomly (>=3.10.3)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "webencodings"
@@ -787,112 +941,30 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-testing = ["pytest-mypy (>=0.9.1)", "pytest-black (>=0.3.7)", "func-timeout", "jaraco.itertools", "pytest-enabler (>=1.3)", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=2.4)", "pytest (>=6)"]
-docs = ["jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "jaraco.packaging (>=9)", "sphinx"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "22dcaa94a88956d99d31b680a2befe9781ae7033cca5d4d44c6f312bba3d5c39"
+content-hash = "48fb7ad06ca7700745e7a43c12f55ace3e218fe2639fb4108b0dcccbba26db78"
 
 [metadata.files]
-atomicwrites = [
-    {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
-]
+atomicwrites = []
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
 ]
-bleach = [
-    {file = "bleach-5.0.1-py3-none-any.whl", hash = "sha256:085f7f33c15bd408dd9b17a4ad77c577db66d76203e5984b1bd59baeee948b2a"},
-    {file = "bleach-5.0.1.tar.gz", hash = "sha256:0d03255c47eb9bd2f26aa9bb7f2107732e7e8fe195ca2f64709fcf3b0a4a085c"},
-]
-certifi = [
-    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
-    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
-]
-cffi = [
-    {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
-    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"},
-    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914"},
-    {file = "cffi-1.15.1-cp27-cp27m-win32.whl", hash = "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3"},
-    {file = "cffi-1.15.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e"},
-    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162"},
-    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b"},
-    {file = "cffi-1.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21"},
-    {file = "cffi-1.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185"},
-    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd"},
-    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc"},
-    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f"},
-    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e"},
-    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4"},
-    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01"},
-    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e"},
-    {file = "cffi-1.15.1-cp310-cp310-win32.whl", hash = "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2"},
-    {file = "cffi-1.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d"},
-    {file = "cffi-1.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac"},
-    {file = "cffi-1.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83"},
-    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9"},
-    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c"},
-    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325"},
-    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c"},
-    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef"},
-    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8"},
-    {file = "cffi-1.15.1-cp311-cp311-win32.whl", hash = "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d"},
-    {file = "cffi-1.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104"},
-    {file = "cffi-1.15.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7"},
-    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6"},
-    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d"},
-    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a"},
-    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405"},
-    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e"},
-    {file = "cffi-1.15.1-cp36-cp36m-win32.whl", hash = "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf"},
-    {file = "cffi-1.15.1-cp36-cp36m-win_amd64.whl", hash = "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497"},
-    {file = "cffi-1.15.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375"},
-    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e"},
-    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82"},
-    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b"},
-    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c"},
-    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426"},
-    {file = "cffi-1.15.1-cp37-cp37m-win32.whl", hash = "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9"},
-    {file = "cffi-1.15.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045"},
-    {file = "cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3"},
-    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a"},
-    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5"},
-    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca"},
-    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02"},
-    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192"},
-    {file = "cffi-1.15.1-cp38-cp38-win32.whl", hash = "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314"},
-    {file = "cffi-1.15.1-cp38-cp38-win_amd64.whl", hash = "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5"},
-    {file = "cffi-1.15.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585"},
-    {file = "cffi-1.15.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"},
-    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415"},
-    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d"},
-    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984"},
-    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35"},
-    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27"},
-    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76"},
-    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3"},
-    {file = "cffi-1.15.1-cp39-cp39-win32.whl", hash = "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee"},
-    {file = "cffi-1.15.1-cp39-cp39-win_amd64.whl", hash = "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c"},
-    {file = "cffi-1.15.1.tar.gz", hash = "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"},
-]
-charset-normalizer = [
-    {file = "charset-normalizer-2.1.0.tar.gz", hash = "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"},
-    {file = "charset_normalizer-2.1.0-py3-none-any.whl", hash = "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5"},
-]
-click = [
-    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
-    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
-]
+bleach = []
+certifi = []
+cffi = []
+charset-normalizer = []
+click = []
 click-log = [
     {file = "click-log-0.4.0.tar.gz", hash = "sha256:3970f8570ac54491237bcdb3d8ab5e3eef6c057df29f8c3d1151a51a9c23b975"},
     {file = "click_log-0.4.0-py2.py3-none-any.whl", hash = "sha256:a43e394b528d52112af599f2fc9e4b7cf3c15f94e53581f74fa6867e68c91756"},
 ]
-colorama = [
-    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
-    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
-]
+colorama = []
 commonmark = [
     {file = "commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
     {file = "commonmark-0.9.1.tar.gz", hash = "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"},
@@ -901,42 +973,10 @@ connect-markdown-renderer = [
     {file = "connect-markdown-renderer-2.0.1.tar.gz", hash = "sha256:fbaefff195a6c347a7f89e75a09e78f6be35c903d72a2766c8f263ca75758757"},
     {file = "connect_markdown_renderer-2.0.1-py3-none-any.whl", hash = "sha256:8d726b947d877697a42f528799908481685bf0db6a17b4e6d715389bfae9cccd"},
 ]
-cryptography = [
-    {file = "cryptography-37.0.4-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:549153378611c0cca1042f20fd9c5030d37a72f634c9326e225c9f666d472884"},
-    {file = "cryptography-37.0.4-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:a958c52505c8adf0d3822703078580d2c0456dd1d27fabfb6f76fe63d2971cd6"},
-    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f721d1885ecae9078c3f6bbe8a88bc0786b6e749bf32ccec1ef2b18929a05046"},
-    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:3d41b965b3380f10e4611dbae366f6dc3cefc7c9ac4e8842a806b9672ae9add5"},
-    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:80f49023dd13ba35f7c34072fa17f604d2f19bf0989f292cedf7ab5770b87a0b"},
-    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2dcb0b3b63afb6df7fd94ec6fbddac81b5492513f7b0436210d390c14d46ee8"},
-    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:b7f8dd0d4c1f21759695c05a5ec8536c12f31611541f8904083f3dc582604280"},
-    {file = "cryptography-37.0.4-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:30788e070800fec9bbcf9faa71ea6d8068f5136f60029759fd8c3efec3c9dcb3"},
-    {file = "cryptography-37.0.4-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:190f82f3e87033821828f60787cfa42bff98404483577b591429ed99bed39d59"},
-    {file = "cryptography-37.0.4-cp36-abi3-win32.whl", hash = "sha256:b62439d7cd1222f3da897e9a9fe53bbf5c104fff4d60893ad1355d4c14a24157"},
-    {file = "cryptography-37.0.4-cp36-abi3-win_amd64.whl", hash = "sha256:f7a6de3e98771e183645181b3627e2563dcde3ce94a9e42a3f427d2255190327"},
-    {file = "cryptography-37.0.4-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bc95ed67b6741b2607298f9ea4932ff157e570ef456ef7ff0ef4884a134cc4b"},
-    {file = "cryptography-37.0.4-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:f8c0a6e9e1dd3eb0414ba320f85da6b0dcbd543126e30fcc546e7372a7fbf3b9"},
-    {file = "cryptography-37.0.4-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:e007f052ed10cc316df59bc90fbb7ff7950d7e2919c9757fd42a2b8ecf8a5f67"},
-    {file = "cryptography-37.0.4-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bc997818309f56c0038a33b8da5c0bfbb3f1f067f315f9abd6fc07ad359398d"},
-    {file = "cryptography-37.0.4-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:d204833f3c8a33bbe11eda63a54b1aad7aa7456ed769a982f21ec599ba5fa282"},
-    {file = "cryptography-37.0.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:75976c217f10d48a8b5a8de3d70c454c249e4b91851f6838a4e48b8f41eb71aa"},
-    {file = "cryptography-37.0.4-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:7099a8d55cd49b737ffc99c17de504f2257e3787e02abe6d1a6d136574873441"},
-    {file = "cryptography-37.0.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2be53f9f5505673eeda5f2736bea736c40f051a739bfae2f92d18aed1eb54596"},
-    {file = "cryptography-37.0.4-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:91ce48d35f4e3d3f1d83e29ef4a9267246e6a3be51864a5b7d2247d5086fa99a"},
-    {file = "cryptography-37.0.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:4c590ec31550a724ef893c50f9a97a0c14e9c851c85621c5650d699a7b88f7ab"},
-    {file = "cryptography-37.0.4.tar.gz", hash = "sha256:63f9c17c0e2474ccbebc9302ce2f07b55b3b3fcb211ded18a42d5764f5c10a82"},
-]
-distlib = [
-    {file = "distlib-0.3.5-py2.py3-none-any.whl", hash = "sha256:b710088c59f06338ca514800ad795a132da19fda270e3ce4affc74abf955a26c"},
-    {file = "distlib-0.3.5.tar.gz", hash = "sha256:a7f75737c70be3b25e2bee06288cec4e4c221de18455b2dd037fe2a795cab2fe"},
-]
-docutils = [
-    {file = "docutils-0.19-py3-none-any.whl", hash = "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"},
-    {file = "docutils-0.19.tar.gz", hash = "sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6"},
-]
-dotty-dict = [
-    {file = "dotty_dict-1.3.1-py3-none-any.whl", hash = "sha256:5022d234d9922f13aa711b4950372a06a6d64cb6d6db9ba43d0ba133ebfce31f"},
-    {file = "dotty_dict-1.3.1.tar.gz", hash = "sha256:4b016e03b8ae265539757a53eba24b9bfda506fb94fbce0bee843c6f05541a15"},
-]
+cryptography = []
+distlib = []
+docutils = []
+dotty-dict = []
 filelock = [
     {file = "filelock-3.8.0-py3-none-any.whl", hash = "sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4"},
     {file = "filelock-3.8.0.tar.gz", hash = "sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc"},
@@ -953,29 +993,208 @@ idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
-importlib-metadata = [
-    {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
-    {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
-]
-importlib-resources = [
-    {file = "importlib_resources-5.9.0-py3-none-any.whl", hash = "sha256:f78a8df21a79bcc30cfd400bdc38f314333de7c0fb619763f6b9dabab8268bb7"},
-    {file = "importlib_resources-5.9.0.tar.gz", hash = "sha256:5481e97fb45af8dcf2f798952625591c58fe599d0735d86b10f54de086a61681"},
-]
+importlib-metadata = []
+importlib-resources = []
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
-invoke = [
-    {file = "invoke-1.7.1-py3-none-any.whl", hash = "sha256:2dc975b4f92be0c0a174ad2d063010c8a1fdb5e9389d69871001118b4fcac4fb"},
-    {file = "invoke-1.7.1.tar.gz", hash = "sha256:7b6deaf585eee0a848205d0b8c0014b9bf6f287a8eb798818a642dff1df14b19"},
+invoke = []
+jarowinkler = [
+    {file = "jarowinkler-1.2.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e006017c2ab73533f96202bdeed7e510738a0ef7585f18cb2ab4122b15e8467e"},
+    {file = "jarowinkler-1.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d32c821e3aef70686c0726fad936adedf39f5f2985a2b9f525fe2da784f39490"},
+    {file = "jarowinkler-1.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:94fd891230a08f8b285c78c1799b1e4c44587746cb761e1914873fc2922c8e42"},
+    {file = "jarowinkler-1.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41b8c9eae4662fc96c71d9192ba6d30f43433ff4fd20398920c276245fe414ce"},
+    {file = "jarowinkler-1.2.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a7315dcbfeb73130b9343513cf147c1fc50bfae0988c2b03128fb424b84d3866"},
+    {file = "jarowinkler-1.2.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b440840e67574b4b069c0f298ebd02c1a4fe703b90863e044688d0cad01be636"},
+    {file = "jarowinkler-1.2.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3873cae784f744dab3c592aecacab8c584c3a5156dc402528b07372449559ae5"},
+    {file = "jarowinkler-1.2.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1859480ae1140e06e3c99886623711b0bbede53754201cad92e6c087e6f42123"},
+    {file = "jarowinkler-1.2.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:88e74b1fdbb4251d1ce42b0fd411f540d3da51a04d0b0440f77ddc6b613e4042"},
+    {file = "jarowinkler-1.2.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:df33e200e5ea7ce1d2c2253582f5aaccd5fcbb18b9f8c9e67bce000277cceb5f"},
+    {file = "jarowinkler-1.2.1-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:dfe72578d3f1c8e0da15685d0e3b75361866dda77fcee411b8402ec794a82cbf"},
+    {file = "jarowinkler-1.2.1-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:4a40c702154034815cd4b74f5c22b90c9741e562afb24592e1f3674b8cd661d1"},
+    {file = "jarowinkler-1.2.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8761c045f1310e682d2f32e17f5054ed7663289c90d63d9fb82af8c233ed1c95"},
+    {file = "jarowinkler-1.2.1-cp310-cp310-win32.whl", hash = "sha256:a06e89556baecd2fdcd77ea2f044acca4ffbfcf7f28d42dc9bffd1dc96fca8a8"},
+    {file = "jarowinkler-1.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:193bc642d46cfade301f5c7684b4254035f3a870e8f608f7a46a4c4d66cc625a"},
+    {file = "jarowinkler-1.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2e265c6a3c87872a4badd72d7e2beb4ef968b9d04f024f4ce3e6e4e048f767e1"},
+    {file = "jarowinkler-1.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d48b85ccdb4885b1f7c5ff14ac0a179e1e8d13fa7e2380557bc8cfa570f94750"},
+    {file = "jarowinkler-1.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:687d4af42b2fb0450ab0e4cc094ef33e5c42b5f77596b1bd40d4ecb2a18cf99f"},
+    {file = "jarowinkler-1.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a79bed41cdc671881d04ce1250498a8c5b1444761920a2cb569a09c07d39403d"},
+    {file = "jarowinkler-1.2.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:25a7fd1c00beb08f023c28fa8e6c27939daac4ae5d700b875dd0f2c6e352fdb7"},
+    {file = "jarowinkler-1.2.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0e242e7c2d65865cf81e98d35ce0d51f165e1739bcd1fffa450beb55ddea2aaa"},
+    {file = "jarowinkler-1.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0895225e4b3fcc1786c7298616f368b0e479cc9f7087ced7a9b2042808fe855"},
+    {file = "jarowinkler-1.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a84aac689fd95b45865122a36843f18aa0a58664c44558ea809060b200b1cf1"},
+    {file = "jarowinkler-1.2.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:de0b323a34205326351e5ab9ec103294365285b587e3dafe7361f78f735eaf02"},
+    {file = "jarowinkler-1.2.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:5037674a5b41aa22d7a9e1ad53e4560f2441c5584b514e333476db457e5644dc"},
+    {file = "jarowinkler-1.2.1-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:60f6c9889432382fc6ecaae3f29e59ec560152bd1d1246eaca6b8d63c5029cd5"},
+    {file = "jarowinkler-1.2.1-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:afbe29453712afe00bee3bb21f36fef7852129584c05039df40086cdfed9b95e"},
+    {file = "jarowinkler-1.2.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fefb9f8a51bbd3704a9b0fa9ca3a01a66b322e82ac75093bda56a7e108a97801"},
+    {file = "jarowinkler-1.2.1-cp311-cp311-win32.whl", hash = "sha256:892e7825acae0d4cd21b811e1996d976574e5e209785f644e5830ac4f86b12d7"},
+    {file = "jarowinkler-1.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:6cc53c9c2bda481d2184221d13121847b26271a90e2522c96169de7e3b00d704"},
+    {file = "jarowinkler-1.2.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:068e7785ad2bbca5092c13cdf2720a8a968ae46f0e2972f76faa5de5185d911b"},
+    {file = "jarowinkler-1.2.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fb7e227c991e0129daf3ca3794325c37aa490333ac6aa223eebb6dbe6b2c059"},
+    {file = "jarowinkler-1.2.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b30901cf2012c3aa01f5a9779cd6c7314167cf00750b76f3eba4872f61f830ba"},
+    {file = "jarowinkler-1.2.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cfa6ff2260707e522a814a93c3074337e016ce60493b6b2cb6aa1350aae6e375"},
+    {file = "jarowinkler-1.2.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ea7ae636db15ca1143382681b41ca77cc6743aa48772455de0d5a172159ea13"},
+    {file = "jarowinkler-1.2.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dc61a8667cb4601801a472732f43319feb16eea7145755415e64462ab660cdc5"},
+    {file = "jarowinkler-1.2.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:d0a3271494a2298c72372ee064f83445636c257b3c77e4bbe2045ad974c4982f"},
+    {file = "jarowinkler-1.2.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:f4ac432ffff5c2b119c1d231a37e27ca6b0f5f1fcc5f27f715127df265ba4706"},
+    {file = "jarowinkler-1.2.1-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:ea3d4521d90b0d8bf3174e97b039b5706935ea7830d5ad672363a85a57c30d9e"},
+    {file = "jarowinkler-1.2.1-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:40d17decb4a34be5f086cf3d492264003cd9412e85e4ad182a43b885ae89fa60"},
+    {file = "jarowinkler-1.2.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:d2ce7fe2a324f425d8639fbdd2b393432e70ff9cae5ddc16e8059b47d16be613"},
+    {file = "jarowinkler-1.2.1-cp36-cp36m-win32.whl", hash = "sha256:51f3d4bae8feac02776561e7d3bc8f449d41cde07203ef36fba49c60fc84921e"},
+    {file = "jarowinkler-1.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:0b8b7c178ff0b8089815938d9c9b3f2bc17ab785dc5590a3ee5413a980c4872c"},
+    {file = "jarowinkler-1.2.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2760ba9c3c702c68c1d6b04da50bfa2595de87cb2f57ca65d14abc9f5fa587bb"},
+    {file = "jarowinkler-1.2.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8dc8d23c9abc5e61b00917b1bc040a165096fe9d0a1b44aae92199d0c605cc3c"},
+    {file = "jarowinkler-1.2.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b1dcfcb35081a08f127ab843bc1a6fb540c7cc5d6670f0126e546e6060243cdd"},
+    {file = "jarowinkler-1.2.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:774b5f0e6daa07e1dae7539d4c691812f0f903fcdcc48d17ee225901ceec5767"},
+    {file = "jarowinkler-1.2.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:940ccc7d3f7fbd4cf220aab2ee106719976a408c13a56bf35d48db0d73d9467b"},
+    {file = "jarowinkler-1.2.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e7c34879601112fe728f167f099aea227a5a9790e85be09f079f85d94ece4af3"},
+    {file = "jarowinkler-1.2.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:3b6fce44c7bcbbaa38678cebc9fb0af0604aff234644976c6b7816257ce42420"},
+    {file = "jarowinkler-1.2.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:793f4fd23c7e361197f8a07a035c059b6254ff4998b1a54d5484e558b78f143a"},
+    {file = "jarowinkler-1.2.1-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:615c09d4ebe5417c201c4a00cff703d7d5c335350f36b8ae856d1644fe1a38e9"},
+    {file = "jarowinkler-1.2.1-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:90c624f1b660884415e0141a2c4fc8446fed00d3d795a9c8afafb6b6e304e8fd"},
+    {file = "jarowinkler-1.2.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:ff3de9898a05d7902ed129714f32a66ac79af175a918663831f430da16578573"},
+    {file = "jarowinkler-1.2.1-cp37-cp37m-win32.whl", hash = "sha256:9e4af981c50ee02eabe26b91091c51750dfef3a9ca4ae8fd9d5bde83ae802d27"},
+    {file = "jarowinkler-1.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:09730ced0acb262396465086174229ac40328fdee57a698d0c033cf1c7447039"},
+    {file = "jarowinkler-1.2.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a805a091d65f083da44f1bfdeef81818331ab76ae1475959077f41a94ee944ff"},
+    {file = "jarowinkler-1.2.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:641ef0750468eb17bfd3a4e4c25ae14d37ecbcc9d7b10abfcf86b3881b1aca3a"},
+    {file = "jarowinkler-1.2.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9d476d34dbcb4ed8cbfa1e5e7d865440f2c9781cf023d1c64e4d8ec16167b52a"},
+    {file = "jarowinkler-1.2.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41fad5783c09352a0bc1a0290fdbfd08d7301a6cf7c933c9b8b6fc0d07332aae"},
+    {file = "jarowinkler-1.2.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:245225d69ea54a4f3875c243a4448da235f31de2c8280fad597732815d22cc4b"},
+    {file = "jarowinkler-1.2.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:46b2106b56329699c2f775b65747940aaafd077dac124aae7864de4dcd7a79dd"},
+    {file = "jarowinkler-1.2.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ab4e24cbb27f4602e4b809397ee12138583132a0d3e80a92de1a5f150c9ca58"},
+    {file = "jarowinkler-1.2.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:088d1da357dc9781e85385e6437275e676333a30416d2b1cdde3936bb9abc80f"},
+    {file = "jarowinkler-1.2.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:5b9747dab72c7c6a25e98a68ca7e3ba3a9f3a3de574dc635c92fa4551bd58505"},
+    {file = "jarowinkler-1.2.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:fce17899e967489ba4b932dc53b7c408454c3e3873eab92c126a98ddb20cc246"},
+    {file = "jarowinkler-1.2.1-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:e0b822891ef854cf00c4df6269ddf04928d8f65c8741a8766839964cd8732c48"},
+    {file = "jarowinkler-1.2.1-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:9f76759af8d383b18466b90c0661e54eed41ff5d405ce437000147ba7e4e4d07"},
+    {file = "jarowinkler-1.2.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6f3213a9878c7f3c0e2a807275d38a9d9848a193dcb5ada748863a7a18a335f9"},
+    {file = "jarowinkler-1.2.1-cp38-cp38-win32.whl", hash = "sha256:dcfbdb72dcfe2a7a8439243f2c5dccf85be7bd81c65ba9f7ecd73a78aef4ad28"},
+    {file = "jarowinkler-1.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:9243e428655b956fa564708f037dffb28bc97dd699001c794344281774f3dfda"},
+    {file = "jarowinkler-1.2.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:78f946d11aeb92aea59e2dea380fc59d54dd22339f3fa79093b71c466057ecca"},
+    {file = "jarowinkler-1.2.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d259319d4e37539166a4080ce8ca64b2d9c5c54cd5c2d8136fcaf777186c5c71"},
+    {file = "jarowinkler-1.2.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:bc9b4a802cc69f8aeceed871e4caf1ae305ff0f2d55825d47117f367271d9111"},
+    {file = "jarowinkler-1.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:04a451348e72b1703902faae9456e53aff25d9428a674d61d9d42a12780da7ae"},
+    {file = "jarowinkler-1.2.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:27068fb2073a5dcb265411dd7c9beb2bf7fca5c5e1fb4de35eb2562bd89a6462"},
+    {file = "jarowinkler-1.2.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:84d5672a235c9b0fcdaf4236db78a7ec76384dee43e875016eb60d6365de72f4"},
+    {file = "jarowinkler-1.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:667351b515d4678ceb0e5f596febd38c446c6bc64de1545b2868cd739f4389da"},
+    {file = "jarowinkler-1.2.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:32eefc177aa6ca6f3aeb660b1923dd82527686f7a522e0267c877a511361bb25"},
+    {file = "jarowinkler-1.2.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:68efe1acfc3e920fc055c15dc139a8bb69ae0c292541a0985ab6df819133e80a"},
+    {file = "jarowinkler-1.2.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:116a5e8d8113b026f5c79a446c996282c70e6b1d2a9cc6fa335193a0a5d4fb11"},
+    {file = "jarowinkler-1.2.1-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:bf7c3f413c03320d452fb5c00d26177a1c3472c489e4c28f6d10c031a307f325"},
+    {file = "jarowinkler-1.2.1-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:46307dd8b0026f8062ff31fccd676dafd63f75f2bca4a29110b7b17bdf12d2c6"},
+    {file = "jarowinkler-1.2.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a0936d5d98ed56a157b81d36209c562a0e6d3995244ee3117859b5f64be9c653"},
+    {file = "jarowinkler-1.2.1-cp39-cp39-win32.whl", hash = "sha256:e61bf2306727e5152f9c67a62c02ef09039181dc0b9611c81266ae46ba695d63"},
+    {file = "jarowinkler-1.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:438ff34e4cf801562e87fdf0319d6deeb839aaaf4e4e1a7e300e28f365f52cd1"},
+    {file = "jarowinkler-1.2.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:d61b40b466c258386949329b40d97b2554f3cd4934756bf3931104da1d888236"},
+    {file = "jarowinkler-1.2.1-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:787a2c382e774c0d97a5ebc84c8051e72d82208ae124c8fc07dec09e3e69e885"},
+    {file = "jarowinkler-1.2.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f95cc000493db9aacdad56b7890964517a60c8cb275d546524b9669e32922c49"},
+    {file = "jarowinkler-1.2.1-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e90dabfc948838412082e308c37408d36948bb51844f97d3fc2698eaa0d7441e"},
+    {file = "jarowinkler-1.2.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:dbd784c599e6cb36b0f072ad5502ee98d256cee73d23adc6fa7c5c30d2c614f4"},
+    {file = "jarowinkler-1.2.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56f24f5778b2f5837459739573c3294b79f274f526ff1406fdb2160e81371db2"},
+    {file = "jarowinkler-1.2.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7049ef0ab6676837b200c7170492bae58d2780647c847f840615c72ae6ae8f8b"},
+    {file = "jarowinkler-1.2.1-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:92196b5238ac9063c91d8221dc38cb3a1c22c68b11e547b52ddaa120cd9a93d9"},
+    {file = "jarowinkler-1.2.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:926d9174c651b552193239557ff1da0044720d12dc2ad6fb754be29a46926ebb"},
+    {file = "jarowinkler-1.2.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b106de1e1122ebb1663720474be6fcdceffbdf6c2509e3c50d19401f73fe7d3"},
+    {file = "jarowinkler-1.2.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f571a597ce417cb0fd3647f1adbb69b5793d449b098410eb249de7994c107f88"},
+    {file = "jarowinkler-1.2.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9511fbbd8a3f6cb979cb35c637e43759607c7102f836aae755e4c2f29c033bac"},
+    {file = "jarowinkler-1.2.1.tar.gz", hash = "sha256:206364a885ce296f7f79c669734317f2741f6bbd964907e49e3b9ea0e9de5029"},
 ]
 jeepney = [
     {file = "jeepney-0.8.0-py3-none-any.whl", hash = "sha256:c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755"},
     {file = "jeepney-0.8.0.tar.gz", hash = "sha256:5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806"},
 ]
+jsonschema = [
+    {file = "jsonschema-4.9.1-py3-none-any.whl", hash = "sha256:8ebad55894c002585271af2d327d99339ef566fb085d9129b69e2623867c4106"},
+    {file = "jsonschema-4.9.1.tar.gz", hash = "sha256:408c4c8ed0dede3b268f7a441784f74206380b04f93eb2d537c7befb3df3099f"},
+]
 keyring = [
     {file = "keyring-23.8.2-py3-none-any.whl", hash = "sha256:10d2a8639663fe2090705a00b8c47c687cacdf97598ea9c11456679fa974473a"},
     {file = "keyring-23.8.2.tar.gz", hash = "sha256:0d9973f8891850f1ade5f26aafd06bb16865fbbae3fc56b0defb6a14a2624003"},
+]
+levenshtein = [
+    {file = "Levenshtein-0.20.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:015d4ab31919e5a95d20313231d872a40552479c822f379498709990901aec90"},
+    {file = "Levenshtein-0.20.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6c95e69a380d75fb32d80b9390ee4e0435e8690a5c0967103ade4f7bfcdbca6e"},
+    {file = "Levenshtein-0.20.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c8d0a6acd66510a6f756d172f380dc45ab42e41c61fe9283eb0597c21181876d"},
+    {file = "Levenshtein-0.20.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd58533ad81ff5751bbabb195b470ec6d81e187b1043064ad66cf60b086352a5"},
+    {file = "Levenshtein-0.20.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:49314dc37f2710aaa05124a88d7a2847be88b5ecb8fb80e39c4d66588fd992aa"},
+    {file = "Levenshtein-0.20.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:12b98f9dc52fd2153a80cb9fafd5bbe8e24d395874f1697a429c5062b91c58b1"},
+    {file = "Levenshtein-0.20.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f4af15d18677e6b84507ce27ac000d24478ea833523fcc1746ac06e750d9dc2"},
+    {file = "Levenshtein-0.20.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:678c63d6a27b3757caa5eb5d52dc36e62d4c52d6fd89f5dc826370c6c0df106b"},
+    {file = "Levenshtein-0.20.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:526a8e4a37b4b9a8e1e9c0f8d010601a4ab2e8007cd0e5e50d0367d4a6a98759"},
+    {file = "Levenshtein-0.20.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:90443cf65de92735dab3076c0f2d51b0dbcfa7ec0eb7be91cc31eafd40b1711d"},
+    {file = "Levenshtein-0.20.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:726f586ca653be14a40ddc0b0cea1c5bd22ffe0a4a61820009b582e9b2925b09"},
+    {file = "Levenshtein-0.20.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:1958963862b5ee88fa8eef2f3692b449ae4f5a8570a20220c91d187a14050141"},
+    {file = "Levenshtein-0.20.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c33139563e302222fcf6fc1f5c07efe48410d2abde2fb2a41e30ab189e04f28a"},
+    {file = "Levenshtein-0.20.2-cp310-cp310-win32.whl", hash = "sha256:3d79b604a762c0c0226beff157b54461d45e400a6c9bc393915e515bc32cd309"},
+    {file = "Levenshtein-0.20.2-cp310-cp310-win_amd64.whl", hash = "sha256:0fb3457ef40da66ef7521508464fa5692efdea3df7312a1d41488812c5764e48"},
+    {file = "Levenshtein-0.20.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:70b9314290d8894b5c1dc5536113e2f443cfaa02d49a306fe7d8ff25d7243327"},
+    {file = "Levenshtein-0.20.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:39c8181e7f03fe84197b7477de8af6eaedbafaebf4ab4d9b36d7ef1842d8c70d"},
+    {file = "Levenshtein-0.20.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6d2f76404d82949bc5db2f7b7dd3d86a21c214e18dbd714666fe16dd11eff473"},
+    {file = "Levenshtein-0.20.2-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e2f9d70cdb578c633ddd203206920b3b54f0fa703fb1fb314c1d54fbe65417af"},
+    {file = "Levenshtein-0.20.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4418053f58179cc7da39e0e88db4bca3722994be9d300d0dd65204247ab7e259"},
+    {file = "Levenshtein-0.20.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d2c9ce946063322149bfc4252d2b5f46c37893d986b42e39eb81bee2d7f37252"},
+    {file = "Levenshtein-0.20.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:940d248852019867e9574e01b9b017eaf72c01403223d092c0f79bca1519c7d3"},
+    {file = "Levenshtein-0.20.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:f73227d24d0acc7bc5b7d758069f61c3be3a7478cffa0ec9337c50e574c35aa0"},
+    {file = "Levenshtein-0.20.2-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:fd331a71bb024478003f700e88c609fb1424b31b95b08c5186f619c5987b79b0"},
+    {file = "Levenshtein-0.20.2-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:980bcc3870adc89306404f9f35671453dcb99afb1af3cefeabfe4f58a010ff21"},
+    {file = "Levenshtein-0.20.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:1bdb7292dc869452fb3eee296c1081c98f53e5b12c8faf55d49c864120b4bfaf"},
+    {file = "Levenshtein-0.20.2-cp36-cp36m-win32.whl", hash = "sha256:9cad97adf4a2b5ea744536f59e1e607685c9b5c27f2d173460e199321d00c755"},
+    {file = "Levenshtein-0.20.2-cp36-cp36m-win_amd64.whl", hash = "sha256:3838240ac3a10fdadeeb972ec09e5c90617c5ffd9f7afa22bac96503f9c0bd87"},
+    {file = "Levenshtein-0.20.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2a2b006e726c20d48e1248c21dca683d471f1c246959b0bf7e99f1cef92666e0"},
+    {file = "Levenshtein-0.20.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fbfff6dc79ae5c6da4088df00e9f7a009375bfcacafe2e4c1b79d16a12b2e03"},
+    {file = "Levenshtein-0.20.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:13a13873cc5106c976ebdff316c98b125701bc76a8a687d08fc7eecb134be3f9"},
+    {file = "Levenshtein-0.20.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:47bcad7a5bf5a8239fd95bdc3821e625b4ae5ba2ea3c211661ad66ea18984a20"},
+    {file = "Levenshtein-0.20.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07f83464cfb0623456742ed4c481f3b39dcc352805ffe75faf7f1a0ee2f25c36"},
+    {file = "Levenshtein-0.20.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:117d04d9f678c303e14bce25c38cbb9cd24432d12d2a951dc6be48ec7a2dd7a4"},
+    {file = "Levenshtein-0.20.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7fd13de9e39279f5e120eccacf4b370beac269191c65191f50cbe9bf7cc0b9ec"},
+    {file = "Levenshtein-0.20.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:bcc362e30be71392bdc62faa413c4db3569c0ca8aee041be3bfedb59bbddc516"},
+    {file = "Levenshtein-0.20.2-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:1cb301f1ddb73b2460836ee170569314f598e4d0ffa1e611a54f593de4afe495"},
+    {file = "Levenshtein-0.20.2-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:ff55924520386c1ff87c3a9a4b7ae84ed565716d149bb0a7295fa48bd88f735f"},
+    {file = "Levenshtein-0.20.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c0269e0c75145f1aeb0309e7d1dc987ddb8f06be76ca6d18ee7b9be16019ce36"},
+    {file = "Levenshtein-0.20.2-cp37-cp37m-win32.whl", hash = "sha256:78341278acbfd49292026c114bcedebf6bb353edd875910e5ab87fa958311c71"},
+    {file = "Levenshtein-0.20.2-cp37-cp37m-win_amd64.whl", hash = "sha256:2b766738cf2f7cb755e0cbc5ac2992a2671dcb45e2f9d313403b5d2d2a6e67c3"},
+    {file = "Levenshtein-0.20.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:c1750b6d1481905dd168be4c8c4f4bcea76122677aa9f29906783de1f314fa3a"},
+    {file = "Levenshtein-0.20.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ad171b053bbb7be938662f8369ed1adf73c9740ce926dc6585a4c5906efa495f"},
+    {file = "Levenshtein-0.20.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f9dfde9b8a0fb800334274250aa1d0e89b4773ea8969533c8c0ac438e292a884"},
+    {file = "Levenshtein-0.20.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8ff28da2ce2fe638f913f05b6080e08c3fa96a1a5f6f514d2d4e3cb5c6fee054"},
+    {file = "Levenshtein-0.20.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e291d107e488e695790c3787de2e37ef1841b89959477a9a168a261430981d76"},
+    {file = "Levenshtein-0.20.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:41528e4ee6c50fac3172240b0abac27ea741d12aebadd033cdf8173293910ef7"},
+    {file = "Levenshtein-0.20.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a46508a999875740b712b03ed0e51e04cff32ba82b8f25972fa78389e50eb1b1"},
+    {file = "Levenshtein-0.20.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:16347d00982756ddf4020717a2b41796f7a5cd2be325327b8dd05068e12beecf"},
+    {file = "Levenshtein-0.20.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:c57272e24152d0f81ea290b8a27d37d01b7381de30499f9749aed8ad95ca5ad5"},
+    {file = "Levenshtein-0.20.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5e830170ab054ef3b2bf139fe4556749593d8762946134aa2063323cf1f8b9b0"},
+    {file = "Levenshtein-0.20.2-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:7122286ffa5c332e4355bfd6e8c78a4ef8aef03a32e1aa3282dd73ea5109d29e"},
+    {file = "Levenshtein-0.20.2-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:f9a89f8f146f9e2f4dd15d8c87c262de0a37323f10208674ddb248a9d0977242"},
+    {file = "Levenshtein-0.20.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:7fc6cafe2b12effb8645e73c61f600ddc052b4927c6c68ffb0607fd173dbc12b"},
+    {file = "Levenshtein-0.20.2-cp38-cp38-win32.whl", hash = "sha256:40ae1e13231c53cfef78b2acfc5d54cfc8be3493e3504647ed716d6b15e472d5"},
+    {file = "Levenshtein-0.20.2-cp38-cp38-win_amd64.whl", hash = "sha256:420278380ff7c21f775a71df8ca3f3378bb9119fa9be927da09cdceaa11412df"},
+    {file = "Levenshtein-0.20.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6bdfda3e14228f50bb2aa466b800db2e171f13f8c674d563c9bba0bf85499a03"},
+    {file = "Levenshtein-0.20.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9de60b7531ee45608df9033f6e87315f1306ed8515fde8deb7240bb5049d762d"},
+    {file = "Levenshtein-0.20.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5cc11989c79f1914102cd26feb7dd56830d49b341a972467e500cdb0f99fa797"},
+    {file = "Levenshtein-0.20.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfa186d18bb3dc8a6258d3eec1efb4ffd8cb442a33df1245726d2b59894b55d"},
+    {file = "Levenshtein-0.20.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:34616a2cc0852731d1a6b9540b8e5697d2f531a3399d642d611a2b11db7afd42"},
+    {file = "Levenshtein-0.20.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:66cf3c05d4e5f788a7ebf997ac149901ab4dfeef1c9b92c4c58c272f4b4b53d9"},
+    {file = "Levenshtein-0.20.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06c531c53b57126c5c8e048e3ee8942cee95b9998ef5eeb1bd896a8658cb31f7"},
+    {file = "Levenshtein-0.20.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d082e57f385df5abdca295eaa6004d2b6aa16833b06a7f4c9ea241fc6adef85b"},
+    {file = "Levenshtein-0.20.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:bcec04fc8bde51c924028623458c8d766b8d7548dec89effba264cbcbf9d07a1"},
+    {file = "Levenshtein-0.20.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:649859cba069854b700a83f5de7e64111468bf07d2f6ad49c1d85cc87d0cc929"},
+    {file = "Levenshtein-0.20.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:5d9d7b4937a3947feb32a0884917a7b24556cdc1fbd7597d176a04e8d11a2f52"},
+    {file = "Levenshtein-0.20.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:71d1c3a8b3fdb4b994dbc9594db1f887a00e1d0d1bfd3b5ab2e8f3ed13f1d92a"},
+    {file = "Levenshtein-0.20.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:1bf7a4742338e689a4f362ea52a9a668b28f7a6f029cb3f44f81b0a22808e7f8"},
+    {file = "Levenshtein-0.20.2-cp39-cp39-win32.whl", hash = "sha256:0cfa3562aa965a703ac9d054ce01fa61876c58e2b20c7b0854bdccb4a6bb680e"},
+    {file = "Levenshtein-0.20.2-cp39-cp39-win_amd64.whl", hash = "sha256:4753084553464eaa20663d9a2736512c551f1ea2d4b5c156d9f86d9db85731b4"},
+    {file = "Levenshtein-0.20.2-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e32bd7a71b2e5c2256a6d71631ad288f878f5558809085a1a5d776c584c15cc"},
+    {file = "Levenshtein-0.20.2-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e986167e9334bfc201a1085827f2e80820603199d94eaa72f72972b9605437b"},
+    {file = "Levenshtein-0.20.2-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6dc0d843305dc6d0d64ec5b6c6af4e0fad1842742b0c6de6a86d44a533451fba"},
+    {file = "Levenshtein-0.20.2-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18531b16f0fdae8eb9152a490ffe7c4168dc851d96a798dd6d64e9d725a0c05b"},
+    {file = "Levenshtein-0.20.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e2a70e644d5e4e7382f2ea5e21555e0028ec1209b9cb99f96b5fecfd6ddae48"},
+    {file = "Levenshtein-0.20.2-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8e11534941e712a58192b3ef94d6c21844245554a2b9017eaba2ffc319180f6f"},
+    {file = "Levenshtein-0.20.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0bc9a18581bd647de8891cf6530125ec1f8dc3b4a714c53b33e0e798fb875030"},
+    {file = "Levenshtein-0.20.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:402caf5697b5313cb0dc453ea08c168feea5a9177b55e463480cb7a0fbfc4f1b"},
+    {file = "Levenshtein-0.20.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7eb5c6827037faefe10858d203a60c14b5cefdce23a9ab92e9292a7b0ee4071c"},
+    {file = "Levenshtein-0.20.2.tar.gz", hash = "sha256:e1528eb56d74146582aa4180a71c8808f0428fa0e08812c39923cac97faf414a"},
 ]
 markdown-it-py = [
     {file = "markdown-it-py-2.1.0.tar.gz", hash = "sha256:cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da"},
@@ -989,9 +1208,10 @@ packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
-pkginfo = [
-    {file = "pkginfo-1.8.3-py2.py3-none-any.whl", hash = "sha256:848865108ec99d4901b2f7e84058b6e7660aae8ae10164e015a6dcf5b242a594"},
-    {file = "pkginfo-1.8.3.tar.gz", hash = "sha256:a84da4318dd86f870a9447a8c98340aa06216bfc6f2b7bdc4b8766984ae1867c"},
+pkginfo = []
+pkgutil-resolve-name = [
+    {file = "pkgutil_resolve_name-1.3.10-py3-none-any.whl", hash = "sha256:ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e"},
+    {file = "pkgutil_resolve_name-1.3.10.tar.gz", hash = "sha256:357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174"},
 ]
 platformdirs = [
     {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
@@ -1013,18 +1233,32 @@ pygments = [
     {file = "Pygments-2.12.0-py3-none-any.whl", hash = "sha256:dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519"},
     {file = "Pygments-2.12.0.tar.gz", hash = "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb"},
 ]
-pyparsing = [
-    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
-    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
+pyparsing = []
+pyrsistent = [
+    {file = "pyrsistent-0.18.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:df46c854f490f81210870e509818b729db4488e1f30f2a1ce1698b2295a878d1"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d45866ececf4a5fff8742c25722da6d4c9e180daa7b405dc0a2a2790d668c26"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ed6784ceac462a7d6fcb7e9b663e93b9a6fb373b7f43594f9ff68875788e01e"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-win32.whl", hash = "sha256:e4f3149fd5eb9b285d6bfb54d2e5173f6a116fe19172686797c056672689daf6"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-win_amd64.whl", hash = "sha256:636ce2dc235046ccd3d8c56a7ad54e99d5c1cd0ef07d9ae847306c91d11b5fec"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e92a52c166426efbe0d1ec1332ee9119b6d32fc1f0bbfd55d5c1088070e7fc1b"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7a096646eab884bf8bed965bad63ea327e0d0c38989fc83c5ea7b8a87037bfc"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cdfd2c361b8a8e5d9499b9082b501c452ade8bbf42aef97ea04854f4a3f43b22"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-win32.whl", hash = "sha256:7ec335fc998faa4febe75cc5268a9eac0478b3f681602c1f27befaf2a1abe1d8"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-win_amd64.whl", hash = "sha256:6455fc599df93d1f60e1c5c4fe471499f08d190d57eca040c0ea182301321286"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:fd8da6d0124efa2f67d86fa70c851022f87c98e205f0594e1fae044e7119a5a6"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bfe2388663fd18bd8ce7db2c91c7400bf3e1a9e8bd7d63bf7e77d39051b85ec"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e3e1fcc45199df76053026a51cc59ab2ea3fc7c094c6627e93b7b44cdae2c8c"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-win32.whl", hash = "sha256:b568f35ad53a7b07ed9b1b2bae09eb15cdd671a5ba5d2c66caee40dbf91c68ca"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1b96547410f76078eaf66d282ddca2e4baae8964364abb4f4dcdde855cd123a"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:f87cc2863ef33c709e237d4b5f4502a62a00fab450c9e020892e8e2ede5847f5"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bc66318fb7ee012071b2792024564973ecc80e9522842eb4e17743604b5e045"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:914474c9f1d93080338ace89cb2acee74f4f666fb0424896fcfb8d86058bf17c"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-win32.whl", hash = "sha256:1b34eedd6812bf4d33814fca1b66005805d3640ce53140ab8bbb1e2651b0d9bc"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-win_amd64.whl", hash = "sha256:e24a828f57e0c337c8d8bb9f6b12f09dfdf0273da25fda9e314f0b684b415a07"},
+    {file = "pyrsistent-0.18.1.tar.gz", hash = "sha256:d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96"},
 ]
-pytest = [
-    {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},
-    {file = "pytest-7.1.2.tar.gz", hash = "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"},
-]
-pytest-github-actions-annotate-failures = [
-    {file = "pytest-github-actions-annotate-failures-0.1.7.tar.gz", hash = "sha256:c6af8f9d13f1f09ef4c104a30875a4975db131ddbba979c8e48fdc456c8dde1f"},
-    {file = "pytest_github_actions_annotate_failures-0.1.7-py2.py3-none-any.whl", hash = "sha256:c4a7346d1d95f731a6b53e9a45f10ca56593978149266dd7526876cce403ea38"},
-]
+pytest = []
+pytest-github-actions-annotate-failures = []
 python-gitlab = [
     {file = "python-gitlab-3.8.1.tar.gz", hash = "sha256:e1db25076520e118c7c26becb0d074a7a68127439870d43b8636342206b1e091"},
     {file = "python_gitlab-3.8.1-py3-none-any.whl", hash = "sha256:6d10de90f4fcb95ea92e301528d2442ac5094da9b7137fa1294614369679e791"},
@@ -1037,14 +1271,147 @@ pywin32-ctypes = [
     {file = "pywin32-ctypes-0.2.0.tar.gz", hash = "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942"},
     {file = "pywin32_ctypes-0.2.0-py2.py3-none-any.whl", hash = "sha256:9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98"},
 ]
+pyyaml = [
+    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
+    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
+    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
+    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
+    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
+    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
+    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
+    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
+    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
+    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
+    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
+    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
+    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
+    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
+    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
+]
+rapidfuzz = [
+    {file = "rapidfuzz-2.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bf1a356203c88b48f0b738f5797ec5d531e3015052cf0e695a4a7e0babb0362e"},
+    {file = "rapidfuzz-2.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:41f7781deecc8c8a1b419724c8f8d828b1c6751aa4359ec8d61e1cd3f4a0148d"},
+    {file = "rapidfuzz-2.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ef077d6287f0c3a14bbf25fb41dc6ff9cb5355780557b222b8c7eb8f8d8d6468"},
+    {file = "rapidfuzz-2.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3fe54d01372d3484546b988e4a1cc48630ca4fe85c838755eb24babfc0fad236"},
+    {file = "rapidfuzz-2.5.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:67efefcdb31eb9a88a3999514ffe9a707e1ba24c3eda990ee247c008f45d1a90"},
+    {file = "rapidfuzz-2.5.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:118e60b51e4f16fbdca39a88d300a1736e064eb5ab777eec97c7eaf45e53c434"},
+    {file = "rapidfuzz-2.5.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:681ad31c76b0ba27d5942ef287e416d82b8e8d317d3c5b0d6c744f47f7150aca"},
+    {file = "rapidfuzz-2.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f6a33106618360a837f4887e195ca66b77282ae32191286348ea3b2f698722e"},
+    {file = "rapidfuzz-2.5.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:0339f985a8392c28953e3e48511c1848cb516e8aaf730b1071deec4c9eb8b6f9"},
+    {file = "rapidfuzz-2.5.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:c7b7002bdcac445f3f13d15458a62da1bf1e21c08b1ba3357b37b3f58e6ffa36"},
+    {file = "rapidfuzz-2.5.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:7b2a6a989ff6062726ffc3e881e5738d006fa0d6be6b532ed4c020748a6122a0"},
+    {file = "rapidfuzz-2.5.0-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:35f2225d8827414866b1df2c885f6a5bf9622547928c052d4669464cb2c2d33c"},
+    {file = "rapidfuzz-2.5.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c74319635be9fceb85713bf864748ca96e4bc12081242a001c07567acd5a703e"},
+    {file = "rapidfuzz-2.5.0-cp310-cp310-win32.whl", hash = "sha256:398af48bca750be36ea40ac21d033d28bd581c59281d3ecb4e8d1c545e8f4b5b"},
+    {file = "rapidfuzz-2.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:17ac7e27932549eedba0deac0a69e4794ba9950404d9ea65464f7374052c29fc"},
+    {file = "rapidfuzz-2.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cf2c8d14f0439ffec6a36ed99e786fd9dcc9ee7ab6e3a77a5a883458988e88c7"},
+    {file = "rapidfuzz-2.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ec329c6db324d160192d49722962ff68b8bcdf9419ddbd57672e725345c2efe8"},
+    {file = "rapidfuzz-2.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0c48cb893985bc8ae15f250b788fe24da0f0df694ff98dc01274c1dd05545214"},
+    {file = "rapidfuzz-2.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:663d41a1948369792ce5f003f0d412e29cfe8f488396a2de380df717621bcae8"},
+    {file = "rapidfuzz-2.5.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d147051d5bb0dd30f5a5799bd0979d118efe266d2b8c1cc530a151c3c45956af"},
+    {file = "rapidfuzz-2.5.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4759490ab2f8b15117da7c3ff3818b3fa697dc80bfa5f6218741d79ef4719544"},
+    {file = "rapidfuzz-2.5.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3fa67c9fb26294f6e3a715ed0f7b7c22c9a9b356519fd75c081a576036f3c8ee"},
+    {file = "rapidfuzz-2.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:69da27b1de45ec301bd2ea416fecf27a772dee6e4109961acf92594a77a7d8cf"},
+    {file = "rapidfuzz-2.5.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b5e8bd94a142bf168ccd2a463e88c97825b518facce864c23e3d044bbdc28962"},
+    {file = "rapidfuzz-2.5.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:b135b1203a09439348289ee5a2a4173e2a50d5647b0056e8618c112ad69a1031"},
+    {file = "rapidfuzz-2.5.0-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:e763ff9b822e8036a39d6c31f5e4a4ffd49c6a6490662ec29f64b0f89acb2abd"},
+    {file = "rapidfuzz-2.5.0-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:79147c7e991df451d3a54ad4bb5f1891ca14bbce04e88c5e4955b9416fa8e6ec"},
+    {file = "rapidfuzz-2.5.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a8123ac72461ced3c125d2b511f2d50eac0b1fbf17b1d66c0d1be5459ae907c6"},
+    {file = "rapidfuzz-2.5.0-cp311-cp311-win32.whl", hash = "sha256:fc0aeac9893f0b3f6cefe99daaa79feb5b0717343de08f824081f29e543d6495"},
+    {file = "rapidfuzz-2.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:8b5075ab8f40c19093c722d0d962d7f9e9b375f5497c5c8fa9129186c871bc1a"},
+    {file = "rapidfuzz-2.5.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79cbb0d600a6b69bc8507400084f351f7a9509f0346e206efafc2ac69e7c9e2c"},
+    {file = "rapidfuzz-2.5.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2ba131db707fce93a25580784d13f9865487dff90ae1192e88a34ea6394077be"},
+    {file = "rapidfuzz-2.5.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d538395c3f6cf8370ca3d847d6d1d5eaff3dee1378e6dfae281a0be493307a3b"},
+    {file = "rapidfuzz-2.5.0-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cdf604fb6ca63a7810a6a61c6b8f1fe6e8281b15d8915fc403cfc0d0369514a0"},
+    {file = "rapidfuzz-2.5.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c441180bf8c89777093927ac18ca255982d4006e9e13ee5d8764d2f5451efae3"},
+    {file = "rapidfuzz-2.5.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17a165575a584671d537eb7b0c0076a18d4cdc6b60a351e92f0a8349819cd126"},
+    {file = "rapidfuzz-2.5.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:6d02a36eaec43d4c6ecfbe8bf8e7137db2c685f6a95a604414de83c0cf6b42a5"},
+    {file = "rapidfuzz-2.5.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:3a94a6d053c0a79b1fb042c078954211e7cab5f07316af56282cfda1c9df03f6"},
+    {file = "rapidfuzz-2.5.0-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:c77ad3acf62eaee05057ddaa576cf53737ac6292e2a9bc13f47785bee5c1c90f"},
+    {file = "rapidfuzz-2.5.0-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:ff26dfc00f91f0330e4fe1c725616bcc56aa82c1cb6d361ab0bb0ea63a4d2381"},
+    {file = "rapidfuzz-2.5.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:a4bbd70943ab52499499521e208ae4ce95ebae2c34c01d37afbbbb06b638769b"},
+    {file = "rapidfuzz-2.5.0-cp36-cp36m-win32.whl", hash = "sha256:32a252c38df2395e87a725bbc2e4eeab497bf0fedcf0afac03682a85b454f6ba"},
+    {file = "rapidfuzz-2.5.0-cp36-cp36m-win_amd64.whl", hash = "sha256:88451e721ea8e92bbf2021af5705367ca92aade57a46debdd50dbb8194dd7d00"},
+    {file = "rapidfuzz-2.5.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c0fbba746eaf3bbd4042266d7739ef9496fe09e190dd956a2c67b449dcb50baf"},
+    {file = "rapidfuzz-2.5.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8d5588d08f8df3a8832fd98cf6c67ff775f9b45b1e23b60d8d10e770cca7260f"},
+    {file = "rapidfuzz-2.5.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:016935bfd9e19011d012e80d7f42bc523ef244c7d9839d649fbe0d2e3f985ee3"},
+    {file = "rapidfuzz-2.5.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0b07b94a6be23cb918d19cda7f675f50d2d181f476b32b4d62b04ab5f1c6a74e"},
+    {file = "rapidfuzz-2.5.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e780f8664704052a3a36745314d8b816f117160ee9da56117e236e60f492b3a3"},
+    {file = "rapidfuzz-2.5.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39194055af928f188d70b1c98e0a274d3a8938e4e9447ab142b911b3274d71ba"},
+    {file = "rapidfuzz-2.5.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:a9bfc4cbe5ba2422e64727218797c91067cd4d3f9529704b86821351d4468699"},
+    {file = "rapidfuzz-2.5.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:0753a7d612d15ba0859d4fd74ad20a83bd6c5c794061904947b519ec7cc3d4b2"},
+    {file = "rapidfuzz-2.5.0-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:1fba0333de26c0070f2a7e4488bd5fb44732e199a9eb613b86ab1c544bb8a1cc"},
+    {file = "rapidfuzz-2.5.0-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:d83d3eb94a7bed800511479e874357ebaa3678e195786777eb5456088430f70e"},
+    {file = "rapidfuzz-2.5.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:0503250836245e9ab41a7de8b1db9020523c0bc65fa541cd9f32a72a39deb35c"},
+    {file = "rapidfuzz-2.5.0-cp37-cp37m-win32.whl", hash = "sha256:989b058eefa4b294d39484939238a3d7dbd0a63e4328d637476a7be33a350cf3"},
+    {file = "rapidfuzz-2.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:feb640c7465410102dcd84325894e58b98f9fe50353d29131d2309595b880bba"},
+    {file = "rapidfuzz-2.5.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5fd1253362623e9294c086f72ef81e1099dd1f1d495b0dd204077de4f10978ee"},
+    {file = "rapidfuzz-2.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7efe29f70c2d1c6e2579fe5b280bd2f6f54238379858d186acdbe2a226beeed4"},
+    {file = "rapidfuzz-2.5.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7b0d90b1a085b59d56283ec3af65197c618459c5bd6b443bd2d3c1b70ea328b8"},
+    {file = "rapidfuzz-2.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8a508a353be2f5a8de12119d469fc6e0bde6acb29965f301da0dae0f7791e7ee"},
+    {file = "rapidfuzz-2.5.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c122934bc76d0683c986453606c8d0b55ea1bc3e64bf1b73d09c8f798aae24d"},
+    {file = "rapidfuzz-2.5.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5fbf79685f33636044c545a0cdfb4db5e4261a2b9b1a31cb51a598283a96d8"},
+    {file = "rapidfuzz-2.5.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a2f4c7faa23eb57d93b6995aac40037ebb2602b54715a8540c9434436fbb044c"},
+    {file = "rapidfuzz-2.5.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3585f073a08d2b143dd6939b58cc68ae77bddc9ea2abaffc21c9d51278894998"},
+    {file = "rapidfuzz-2.5.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:59a22e09059ccac8a19fd6c1c4439a96d2597acdc1a54b8a8257d9332dfb0b58"},
+    {file = "rapidfuzz-2.5.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:d6c0d80d066c1ec20a7daf5b2881d935701137383e05b68031bfbb3db7221390"},
+    {file = "rapidfuzz-2.5.0-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:4f1168e9243ac7f1084820c7f9a61402efad0112e4bd3eedce0fb54e884e7fa8"},
+    {file = "rapidfuzz-2.5.0-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:443e9153e12c507c5ef50ee94b4294056e2f41b0ffb2585020f73d6d0fa6acd3"},
+    {file = "rapidfuzz-2.5.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:06bb5f94ef242b7fcd031231b055238b32c863ed9197f455b1d4dfd635cad739"},
+    {file = "rapidfuzz-2.5.0-cp38-cp38-win32.whl", hash = "sha256:77a3cab70bfa18ffeee0a35b00b829a7ed870ad85cf381ea257215e946b707a7"},
+    {file = "rapidfuzz-2.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:9f9dcb434065825b143721ea3e5b9ae3dd7b5451139f32d0348b95c529b1df7a"},
+    {file = "rapidfuzz-2.5.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:05bac8b013adad5951675fed36f8ff528b8977f13b134e32dd5afadc35880cc4"},
+    {file = "rapidfuzz-2.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d6f6dcac3e6cfc55aa9dcc7b1aaf32e4eb0ead120db95dfb9c28d2c4bcfa9098"},
+    {file = "rapidfuzz-2.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:460e82b449f08e2246aea83f40c294a15d62085567b21fb25e06ca30eabccd78"},
+    {file = "rapidfuzz-2.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b44f82624f57f99607b7e18224be203b31f774345d332465fda2ccf720022020"},
+    {file = "rapidfuzz-2.5.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:acdcfa617f95980524380a4b8b7be7f914d193887cb2aa095d2f5a7071219653"},
+    {file = "rapidfuzz-2.5.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:38ecdd77af6962e9d44b99f7561b34e9644d3403c694aca8ce80b7d845a92478"},
+    {file = "rapidfuzz-2.5.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f8e414ddfebb4d8daf7947158ba5431dc887e1d9c4a49b61a8b63b98a818f506"},
+    {file = "rapidfuzz-2.5.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c95adb8ffd1d7c9f69c2d25469a8e27c2454ab97e07569c61f7d267e69c27a9"},
+    {file = "rapidfuzz-2.5.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d33c4dd5c62b542aa94f37c24ef63d1bc613904ef2a073f4d722133f8e9df6f4"},
+    {file = "rapidfuzz-2.5.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:ba40e10f6613f6316f51e052855ccc8b9716bb9f0d0ecdab6117f65783acf966"},
+    {file = "rapidfuzz-2.5.0-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:adb2f3f8d4d4301d74279abd541d7bb71e82de738ab7be895e1ab525280851d8"},
+    {file = "rapidfuzz-2.5.0-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:b77e4de627d53df0a69fa2cc65c24be79bb49cabac07e24b6e68d4c7c546e2b9"},
+    {file = "rapidfuzz-2.5.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:7a249b7e972e9c7d43629c62b0f2b5576eb8c4c09ec784072f1a04d823e537b0"},
+    {file = "rapidfuzz-2.5.0-cp39-cp39-win32.whl", hash = "sha256:a832c23694c8a713116f00e7784d5af3473c664f87fd036f6c07532718436da5"},
+    {file = "rapidfuzz-2.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:5057396ce1c83d061677a3120113e7539fc8c28d3f261cbd62f93eaa0b0db8d1"},
+    {file = "rapidfuzz-2.5.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:bdc9dd0a65244c0ce06fd0657793ebcafbea8abe91315ddc360659a60f9305ba"},
+    {file = "rapidfuzz-2.5.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:95b992c6c5fc73a2a8b265dbc07729e8733597e927a8f185559d1f8eda2f7590"},
+    {file = "rapidfuzz-2.5.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:462066cb6f22c847458f41ef119c59f3a978b6e281c478f452fd5f2163b49030"},
+    {file = "rapidfuzz-2.5.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d8033fe51bb7947543d1b023dc849e95f60d107e7d06a2444c483145099311f2"},
+    {file = "rapidfuzz-2.5.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:1d16c1feb6ab0102a2ef1990596ffd3a3650bb63e4ec8278ac364e1316111139"},
+    {file = "rapidfuzz-2.5.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4107beda2e5ad165a9c305d2442b8250e7b2e119b37abe2d1cc581c0979e6c3e"},
+    {file = "rapidfuzz-2.5.0-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:498e1240c7e1b98ed30dbac66c2d076d6c78e003177c6acda8bc9559bd95c4e6"},
+    {file = "rapidfuzz-2.5.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7dc0e87c074fa650daf795ba84b2524c80d750a1e22a71e5d3cab09c628cc66"},
+    {file = "rapidfuzz-2.5.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:7f4751acbdc093ef849bf836cc01ea2c4c7380b42be673a50e915e5336bf1c67"},
+    {file = "rapidfuzz-2.5.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:315e08ede2fda9b8450ec49bb180b4884b304c79c4cd1d38c54e37e5575cf6ec"},
+    {file = "rapidfuzz-2.5.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bcf6e573fc618acdd9b26c8ed6cafd0474149e525bb39dc15b45770650292aa4"},
+    {file = "rapidfuzz-2.5.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1ddbb2536443a3fa2627930eae068c74269844ed5aac762b111d655285a9d14"},
+    {file = "rapidfuzz-2.5.0.tar.gz", hash = "sha256:4cf10538a1975747bffd7d3b6d2022ef6c8a8a69dd9adc0597f53a22ff01858d"},
+]
 readme-renderer = [
     {file = "readme_renderer-36.0-py3-none-any.whl", hash = "sha256:2c37e472ca96755caba6cc58bcbf673a5574bc033385a2ac91d85dfef2799876"},
     {file = "readme_renderer-36.0.tar.gz", hash = "sha256:f71aeef9a588fcbed1f4cc001ba611370e94a0cd27c75b1140537618ec78f0a2"},
 ]
-requests = [
-    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
-    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
-]
+requests = []
 requests-toolbelt = [
     {file = "requests-toolbelt-0.9.1.tar.gz", hash = "sha256:968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0"},
     {file = "requests_toolbelt-0.9.1-py2.py3-none-any.whl", hash = "sha256:380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f"},
@@ -1056,6 +1423,22 @@ rfc3986 = [
 rich = [
     {file = "rich-12.5.1-py3-none-any.whl", hash = "sha256:2eb4e6894cde1e017976d2975ac210ef515d7548bc595ba20e195fb9628acdeb"},
     {file = "rich-12.5.1.tar.gz", hash = "sha256:63a5c5ce3673d3d5fbbf23cd87e11ab84b6b451436f1b7f19ec54b6bc36ed7ca"},
+]
+rich-cli = [
+    {file = "rich-cli-1.8.0.tar.gz", hash = "sha256:7f99ed213fb18c25999b644335f74d2be621a3a68593359e7fc62e95fe7e9a8a"},
+    {file = "rich_cli-1.8.0-py3-none-any.whl", hash = "sha256:b27e585fd40924de0f71f28fa50a78ad3f3b24ead2ae5768490f6cf651026c2f"},
+]
+rich-click = [
+    {file = "rich-click-1.5.2.tar.gz", hash = "sha256:a57ca70242cb8b372a670eaa0b0be48f2440b66656deb4a56e6aadc1bbb79670"},
+    {file = "rich_click-1.5.2-py3-none-any.whl", hash = "sha256:131a94bed597eab9f1eda7eb41fb7275b6b60ae9e6defc3769277b70b104285d"},
+]
+rich-codex = [
+    {file = "rich-codex-1.2.2.tar.gz", hash = "sha256:1f6e1317517e4bf2ebf7a3cf4b67b8b754e1ae7fb72b479a93547c8f5fa0585b"},
+    {file = "rich_codex-1.2.2-py3-none-any.whl", hash = "sha256:4f8a1a2f875bbc052e1b30f203a025b00f51b71d32bfd41873b16b58d55416c6"},
+]
+rich-rst = [
+    {file = "rich-rst-1.1.7.tar.gz", hash = "sha256:898bd5defd6bde9fba819614575dc5bff18047af38ae1981de0c1e78f17bbfd5"},
+    {file = "rich_rst-1.1.7-py3-none-any.whl", hash = "sha256:9acf096a5902ef762498e5e510c15dab4ed92bb1f16b2f294f397e4f40048785"},
 ]
 "ruamel.yaml" = [
     {file = "ruamel.yaml-0.17.21-py3-none-any.whl", hash = "sha256:742b35d3d665023981bd6d16b3d24248ce5df75fdb4e2924e93a05c1f8b61ca7"},
@@ -1104,6 +1487,10 @@ smmap = [
     {file = "smmap-5.0.0-py3-none-any.whl", hash = "sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94"},
     {file = "smmap-5.0.0.tar.gz", hash = "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"},
 ]
+textual = [
+    {file = "textual-0.1.18-py3-none-any.whl", hash = "sha256:59110935418c597c1c50876edfd6799ad5b59d51a91ca6744fc45e36eb89638e"},
+    {file = "textual-0.1.18.tar.gz", hash = "sha256:b2883f8ed291de58b9aa73de6d24bbaae0174687487458a4eb2a7c188a2acf23"},
+]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
@@ -1116,10 +1503,7 @@ tomlkit = [
     {file = "tomlkit-0.10.2-py3-none-any.whl", hash = "sha256:905cf92c2111ef80d355708f47ac24ad1b6fc2adc5107455940088c9bbecaedb"},
     {file = "tomlkit-0.10.2.tar.gz", hash = "sha256:30d54c0b914e595f3d10a87888599eab5321a2a69abc773bbefff51599b72db6"},
 ]
-tox = [
-    {file = "tox-3.25.1-py2.py3-none-any.whl", hash = "sha256:c38e15f4733683a9cc0129fba078633e07eb0961f550a010ada879e95fb32632"},
-    {file = "tox-3.25.1.tar.gz", hash = "sha256:c138327815f53bc6da4fe56baec5f25f00622ae69ef3fe4e1e385720e22486f9"},
-]
+tox = []
 tox-gh-actions = [
     {file = "tox-gh-actions-2.9.1.tar.gz", hash = "sha256:2bbb681eccd3fd3573231a05f7acf228caae1e3f12397b5517b404417ab90aba"},
     {file = "tox_gh_actions-2.9.1-py2.py3-none-any.whl", hash = "sha256:90306a6a04a203e47f861b35dca215fc1f6b7ae80de942a050ace61e2eb2b4ea"},
@@ -1140,14 +1524,8 @@ types-urllib3 = [
     {file = "types-urllib3-1.26.22.tar.gz", hash = "sha256:b05af90e73889e688094008a97ca95788db8bf3736e2776fd43fb6b171485d94"},
     {file = "types_urllib3-1.26.22-py3-none-any.whl", hash = "sha256:09a8783e1002472e8d1e1f3792d4c5cca1fffebb9b48ee1512aae6d16fe186bc"},
 ]
-typing-extensions = [
-    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
-    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
-]
-urllib3 = [
-    {file = "urllib3-1.26.11-py2.py3-none-any.whl", hash = "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc"},
-    {file = "urllib3-1.26.11.tar.gz", hash = "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"},
-]
+typing-extensions = []
+urllib3 = []
 virtualenv = [
     {file = "virtualenv-20.16.3-py2.py3-none-any.whl", hash = "sha256:4193b7bc8a6cd23e4eb251ac64f29b4398ab2c233531e66e40b19a6b7b0d30c1"},
     {file = "virtualenv-20.16.3.tar.gz", hash = "sha256:d86ea0bb50e06252d79e6c241507cb904fcd66090c3271381372d6221a3970f9"},
@@ -1156,7 +1534,4 @@ webencodings = [
     {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
     {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
 ]
-zipp = [
-    {file = "zipp-3.8.1-py3-none-any.whl", hash = "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"},
-    {file = "zipp-3.8.1.tar.gz", hash = "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2"},
-]
+zipp = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,5 +91,8 @@ upload_to_release = true
 remove_dist = false
 # Setting build_command to false here b/c `poetry build -vvv` will be used prior to a PSR publish command
 build_command = false
+# Update the script options documentation automatically for each release
+pre_commit_command = "rich-codex --verbose --skip-git-checks --no-confirm"
+include_additional_files = "docs/img/phylum-ci_options.svg,docs/img/phylum-init_options.svg"
 commit_subject = "chore: bump to v{version}"
 commit_author = "phylum-bot <69485888+phylum-bot@users.noreply.github.com>"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ tox = "*"
 tox-gh-actions = "*"
 pytest-github-actions-annotate-failures = "*"
 python-semantic-release = "*"
+rich-codex = "*"
 types-requests = "*"
 # ---END---
 


### PR DESCRIPTION
Actions taken:

* Add initial page and SVG files for script options
  * The pre-commit config was also updated, to exclude SVG file types
* Update top-level `README.md` to include the options output
  * These are links to the "raw" GitHub content instead of relative links
    * Done so that the images will show up correctly on PyPI, Docker Hub, GHCR, etc.
* Point to script options in integration docs 
  * Pointing to a page with the latest script options is much nicer to users than telling them to look at the source code directly
  * There were also some formatting changes to allow the pages to display better on readme.com
* Add `rich-codex` as a dev dependency
  * This is really only a dependency needed for release
  * It could also have been left out of the `poetry` dependencies and installed directly during the release workflow instead, but this method allows for keeping tabs on the project via Phylum analysis of the lockfile
  * It also ensures that the pre-commit command run as part of the `semantic-release` will be available, regardless of how/where the `semantic-release` is initiated.
* Update the script options docs automatically for each release
  * This is done with the [`pre_commit_command`](https://python-semantic-release.readthedocs.io/en/latest/configuration.html#pre-commit-command) and `include_additional_files` options of the `semantic-release` tool configuration
    * It may look odd, but [apparently the way to specify additional files](https://github.com/relekang/python-semantic-release/blob/47130a40a1f24214caa71041bb5a645814538076/tests/test_vcs_helpers.py#L553-L578) in the YAML config is not with the expected `[]` list syntax but as a string of explicit paths separated by commas and no spaces

View the output here:

* [docs/script_options.md](https://github.com/phylum-dev/phylum-ci/blob/auto_doc_opt/docs/script_options.md)
* [`docs/img/phylum-ci_options.svg`](https://raw.githubusercontent.com/phylum-dev/phylum-ci/auto_doc_opt/docs/img/phylum-ci_options.svg)
  * Raw SVG image...where it should be possible to copy/paste text right from the browser
* [`docs/img/phylum-init_options.svg`](https://raw.githubusercontent.com/phylum-dev/phylum-ci/auto_doc_opt/docs/img/phylum-init_options.svg)
  * Raw SVG image
* [`README.md`](https://github.com/phylum-dev/phylum-ci/blob/auto_doc_opt/README.md)
  * (Contains links that will be broken until this branch is merged to `main`)

Closes #101

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [ ] ~Have you created sufficient tests?~
- [x] Have you updated all affected documentation?
