### PR TITLE
feat!: provide a Docker image with glibc instead of musl libc

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@
 #   --fail-with-body \
 #   -H "Accept: application/vnd.github.v3+json" \
 #   -H "Authorization: token <PAT>" \
-#   -d '{"event_type":"build-push-docker-images","client_payload":{"CLI_version":"v3.5.0"}}' \
+#   -d '{"event_type":"build-push-docker-images","client_payload":{"CLI_version":"v3.8.0"}}' \
 #   https://api.github.com/repos/phylum-dev/phylum-ci/dispatches
 #
 # References:

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ version of the Phylum CLI, in the form of `<phylum-ci version>-CLIv<Phylum CLI v
 # Get the most current release of *both* `phylum-ci` and the Phylum CLI
 docker pull phylumio/phylum-ci:latest
 
-# Get the image with `phylum-ci` version 0.8.0 and Phylum CLI version 3.5.0
-docker pull phylumio/phylum-ci:0.8.0-CLIv3.5.0
+# Get the image with `phylum-ci` version 0.13.0 and Phylum CLI version 3.8.0
+docker pull phylumio/phylum-ci:0.13.0-CLIv3.8.0
 ```
 
 #### `phylum-init` Script Entry Point

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -52,9 +52,9 @@ to the repo (e.g., collaborators and orgs, people, teams given write access) and
 The release process leans heavily on the Python Semantic Release (PSR) package, which in turn is dependent on
 conventional commits to determine release versions. Poetry is used to build the release distributions in order to
 use them for "verification" purposes *before* creating a GitHub release and publishing to PyPI. PSR will bump the
-release version, tag the release, update the change log, and commit the changes back to the repository. PSR will also
-generate the GitHub release and populate it with the artifacts as built by `poetry`. Finally, PSR will upload the
-release to [PyPI](https://pypi.org).
+release version, tag the release, update the change log, run `rich-codex` to update the script options documentation,
+and commit the changes back to the repository. PSR will also generate the GitHub release and populate it with the
+artifacts as built by `poetry`. Finally, PSR will upload the release to [PyPI](https://pypi.org).
 
 Currently this workflow uses the `Production` environment, as configured in
 [the repo settings](https://github.com/phylum-dev/phylum-ci/settings/environments).

--- a/docs/sync/git_precommit.md
+++ b/docs/sync/git_precommit.md
@@ -155,7 +155,7 @@ with `--help` output as specified in the [Usage section of the top-level README.
         args: [--force-install]
 
         # Install a specific version of the Phylum CLI.
-        args: [--phylum-release=3.3.0, --force-install]
+        args: [--phylum-release=3.8.0, --force-install]
 
         # Mix and match for your specific use case.
         args: [-u=60, -m=60, -e=70, -c=90, -o=80, --lockfile=requirements-prod.txt, --all-deps]

--- a/docs/sync/gitlab_ci.md
+++ b/docs/sync/gitlab_ci.md
@@ -230,7 +230,7 @@ view the [script options output][script_options] for the latest release.
     - phylum-ci --force-install
 
     # Install a specific version of the Phylum CLI.
-    - phylum-ci --phylum-release 3.3.0 --force-install
+    - phylum-ci --phylum-release 3.8.0 --force-install
 
     # Mix and match for your specific use case.
     - phylum-ci -u 60 -m 60 -e 70 -c 90 -o 80 --lockfile requirements-prod.txt --all-deps

--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -1,7 +1,8 @@
 """Provide constants for use throughout the package."""
 
-# The release layout structure changed starting with v2.0.0 and support is only for the new layout
-MIN_SUPPORTED_CLI_VERSION = "v2.0.0"
+# Linux platform support in the CLI was changed from `unknown-linux-musl` to `unknown-linux-gnu` starting with
+# v3.8.0-rc2, changing the artifact names available to download and install in a non-backwards compatible manner.
+MIN_SUPPORTED_CLI_VERSION = "v3.8.0-rc2"
 
 # Keys are lowercase machine hardware names as returned from `uname -m`.
 # Values are the mapped rustc architecture.
@@ -15,7 +16,7 @@ SUPPORTED_ARCHES = {
 # Keys are lowercase operating system name as returned from `uname -s`.
 # Values are the mapped rustc platform, which is the vendor-os_type[-environment_type].
 SUPPORTED_PLATFORMS = {
-    "linux": "unknown-linux-musl",
+    "linux": "unknown-linux-gnu",
     "darwin": "apple-darwin",
 }
 


### PR DESCRIPTION
The basis for this change is due to how the Linux platform support in the CLI was changed from `unknown-linux-musl` to `unknown-linux-gnu` starting with v3.8.0-rc2, changing the artifact names available to download and install in a non-backwards compatible manner. This is also a breaking change in this repository as the `Dockerfile` had to migrate away from one based on a `python:3.10-alpine` base image to one based on `python:3.10-slim-bullseye`. The resulting docker image is ~113MB compressed (up from ~38MB) and ~327MB uncompressed (up from ~106MB). Documentation was also updated to account for the new minimum supported version of the CLI.

Closes #103

BREAKING CHANGE: Versions of the CLI older than v3.8.0-rc2 are no longer possible to install on Linux systems with the `phylum-init` script.

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
  - Manual tests were performed
    - The docker image was used locally
    - The docker image was used with `TestGHA` to confirm the `phylum-analyze-pr-action`
      - The [`maxrake/phylum-ci:slim` image on Docker Hub](https://hub.docker.com/layers/phylum-ci/maxrake/phylum-ci/slim/images/sha256-f78e1f67843343c8e45c803ceaaee324a29ef87d647f64e147e9da86875ee0fa?context=explore) was used
      - Action run times increased by ~4-5s...due to the increased download size
    - No GitLab tests were performed
- [x] Have you updated all affected documentation?
