### PR TITLE
fix: script options auto update can't find package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ remove_dist = false
 # Setting build_command to false here b/c `poetry build -vvv` will be used prior to a PSR publish command
 build_command = false
 # Update the script options documentation automatically for each release
-pre_commit_command = "rich-codex --verbose --skip-git-checks --no-confirm"
+pre_commit_command = "poetry run rich-codex --verbose --skip-git-checks --no-confirm"
 include_additional_files = "docs/img/phylum-ci_options.svg,docs/img/phylum-init_options.svg"
 commit_subject = "chore: bump to v{version}"
 commit_author = "phylum-bot <69485888+phylum-bot@users.noreply.github.com>"


### PR DESCRIPTION
The last release showed that the script options documentation auto-
update feature was broken. Instead of creating an updated SVG file(s)
for the script options, a stack trace was produced as output instead,
with the following error:

`ModuleNotFoundError: No module named 'phylum'`

The belief is that the `python-semantic-release` package, which uses the
`invoke` package under the hood to run commands, issued a command
outside of the `poetry` environment and therefore did not have access to
the installed local `phylum` package.

This change attempts to correct for that oversight by ensuring the
command is run within the poetry environment where the `phylum` package
is installed. It is an _attempt_ because it still may not work and it
won't be possible to tell for sure until the next release. If that
happens, there are alternative solutions available to pursue.

Links:
* [bad output](https://github.com/phylum-dev/phylum-ci/blob/v0.13.0/docs/script_options.md)
  * These images have since been reverted on `main` to ensure
    current documentation is correct
* [logs from the release workflow](https://github.com/phylum-dev/phylum-ci/runs/7956777344?check_suite_focus=true)
