### PR TITLE
fix: script options auto update still can't find package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,9 @@ jobs:
       - name: Revert to original version
         run: poetry version ${{ env.PHYLUM_ORIGINAL_VER }}
 
+      - name: Update script options documentation
+        run: poetry run rich-codex --verbose --skip-git-checks --no-confirm
+
       - name: Use Python Semantic Release to publish release
         id: psr_release
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,7 @@ upload_to_release = true
 remove_dist = false
 # Setting build_command to false here b/c `poetry build -vvv` will be used prior to a PSR publish command
 build_command = false
-# Update the script options documentation automatically for each release
-pre_commit_command = "poetry run rich-codex --verbose --skip-git-checks --no-confirm"
+# The `pre_commit_command` option has proven troublesome so these files get updated in the release workflow instead
 include_additional_files = "docs/img/phylum-ci_options.svg,docs/img/phylum-init_options.svg"
 commit_subject = "chore: bump to v{version}"
 commit_author = "phylum-bot <69485888+phylum-bot@users.noreply.github.com>"


### PR DESCRIPTION
The last release showed that the script options documentation auto-
update feature is still broken. Instead of creating an updated SVG
file(s) for the script options, a stack trace was produced as output
instead, with the following error:

`ModuleNotFoundError: No module named 'phylum'`

A fix was attempted with #107 but could not be fully verified until the
release was made. The belief now is that the `python-semantic-release`
package does not provide enough control over running commands with the
`pre_commit_command` option in the config file.

This change attempts to run the command in the release workflow, as it's
own step, *before* the Python semantic-release step. Everything needed
to run the `rich-codex` command exists in the workflow environment at
the point the step is run. The code for the `python-semantic-release`
package was examined and it appears to properly handle
additional/changed files with the `include_additional_files` config
option.

It would have been nice to have everything specified in the config, but
this approach should work. The next bugfix release will tell the tale...

Links (updated from #107):
* [bad output](https://github.com/phylum-dev/phylum-ci/blob/v0.13.1/docs/script_options.md)
  * These images have since been reverted on `main` to ensure
    current documentation is correct
* [logs from the release workflow](https://github.com/phylum-dev/phylum-ci/runs/7982747996?check_suite_focus=true#step:16:113)