### PR TITLE
ci: allow for re-running the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,9 @@ jobs:
       # "reviewers" for that environment would be notified of the release and could check that the package verification
       # step(s) worked as intended before approving the release to proceed.
       - name: Verify the package
+        # Allow for re-running the workflow, with the same release package version, for situations where that package is
+        # already published to TestPyPI (e.g., failures due to TestPyPI being slow to recognize a published package).
+        if: ${{ success() || steps.publish_test_pypi.conclusion == 'failure' }}
         run: |
           pipx run \
             --index-url https://test.pypi.org/simple/ \


### PR DESCRIPTION
It is sometimes necessary to allow for re-running the release workflow,
with the same release package version. Specifically for situations
where that package is already published to TestPyPI and that step would
otherwise fail with an `HTTP Error 400: File already exists` error.

Some reasons why re-running the release workflow is useful:

* The step that publishes the package to TestPyPI succeeds but the
  following step that verifies the package fails because TestPyPI is
  slow to recognize a published package
  * This has already been observed
* Any step after publishing to TestPyPI, but before publishing to PyPI
  could fail and require a re-run to complete
  * This has not been observed...yet

The solution proposed here is to allow the step that accesses the
TestPyPI package to proceed even when the step to publish to that
repository has failed. The access will still fail if the package is not
present (as expected) but will succeed when it is present (due to a
previous workflow runs).

It is necessary to do this because it is not possible to overwrite or
change a package once it has been published to TestPyPI...at least not
with the same version. It is possible to delete or yank the package, but
then that package's version number is not available to be used again...
which makes it appear as though there is a "gap" in releases on the
production PyPI registry.
