### PR TITLE
ci: allow for TestPyPI publish failures in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,9 @@ jobs:
 
       - name: Publish to TestPyPI
         id: publish_test_pypi
+        # Allow for re-running the workflow, with the same release package version, for situations where that package is
+        # already published to TestPyPI (e.g., failures due to TestPyPI being slow to recognize a published package).
+        continue-on-error: true
         run: poetry publish --repository testpypi --username __token__ --password ${{ secrets.TESTPYPI_API_TOKEN }}
 
       # This step is currently only verifying that the package uploaded to TestPyPI can be installed and run from there.
@@ -118,9 +121,6 @@ jobs:
       # "reviewers" for that environment would be notified of the release and could check that the package verification
       # step(s) worked as intended before approving the release to proceed.
       - name: Verify the package
-        # Allow for re-running the workflow, with the same release package version, for situations where that package is
-        # already published to TestPyPI (e.g., failures due to TestPyPI being slow to recognize a published package).
-        if: ${{ success() || steps.publish_test_pypi.conclusion == 'failure' }}
         run: |
           pipx run \
             --index-url https://test.pypi.org/simple/ \


### PR DESCRIPTION
The release workflow step that publishes the package to the TestPyPI
registry should be allowed to continue on error since there are times
when it is expected to fail (e.g., when re-running the workflow). The
following step will still provide the gating function for the package
verification on the TestPyPI registry. That is, if the verification step
fails, the job will still fail.

This is a response to the last PR, #109, which [resulted in an overall
job/workflow failure](https://github.com/phylum-dev/phylum-ci/runs/8000722044?check_suite_focus=true). The `Publish to TestPyPI` step failed (as expected)
and the `Verify the package` step succeeded (as expected), but the
remaining steps were skipped because of the first step failure.

Reference: [continue-on-error](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error)
