### PR TITLE
ci: install current project in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install the project with poetry
         run: |
           poetry env use python${{ matrix.python-version }}
-          poetry install --verbose --no-root
+          poetry install --verbose
 
       - name: Set PHYLUM_ORIGINAL_VER value
         run: echo "PHYLUM_ORIGINAL_VER=$(poetry version --short)" >> $GITHUB_ENV


### PR DESCRIPTION
The release workflow needs the current project (`phylum`) to be
installed now that it gets used by the `rich-codex` tool to update the
script options documentation automatically. Making this change may mean
slightly more time is taken to install the project in CI. It may also
affect the Python cache used in the workflow.

This change is expected to fix the errors seen [in the script_options.md](https://github.com/phylum-dev/phylum-ci/blob/v0.13.2/docs/script_options.md)
file, where the `phylum` module is not found.
