### PR TITLE
feat: change supported maven lockfile to `effective-pom.xml`

### DIFF
--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -42,7 +42,7 @@ SUPPORTED_LOCKFILES = {
     # C#
     "*.csproj": "nuget",
     # Java
-    "pom.xml": "mvn",
+    "effective-pom.xml": "mvn",
     "gradle.lockfile": "gradle",
 }
 


### PR DESCRIPTION
It turns out that the proper lockfile to use for the Java maven ecosystem is `effective-pom.xml` instead of `pom.xml`. The CLI parses `effective-pom.xml` files more effectively than `pom.xml`. Documentation has already been updated and this change will ensure that the integrations will work, with less effort, for `mvn` users. It was always possible to be explicit about the lockfile to analyze, but this change will make `effective-pom.xml` a default for Java environments that already have the file...so it won't need to be specified with the `--lockfile` option.
