### PR TITLE
feat: don't require serial processing of pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,5 +7,4 @@
   description: Run `phylum` on a dependency lockfile
   entry: phylum-ci
   language: python
-  require_serial: false
   stages: [commit]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,5 +7,5 @@
   description: Run `phylum` on a dependency lockfile
   entry: phylum-ci
   language: python
-  require_serial: true
+  require_serial: false
   stages: [commit]

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -69,10 +69,12 @@ class CIBase(ABC):
         provided_lockfile: Path = args.lockfile
         if provided_lockfile and provided_lockfile.exists() and provided_lockfile.stat().st_size:
             self._lockfile = provided_lockfile.resolve()
+            print(f" [-] Provided lockfile: {self._lockfile}")
         else:
             detected_lockfile = detect_lockfile()
             if detected_lockfile:
                 self._lockfile = detected_lockfile
+                print(f" [-] Detected lockfile: {self._lockfile}")
             else:
                 raise SystemExit(
                     " [!] A lockfile is required and was not detected. Consider specifying one with `--lockfile`."

--- a/src/phylum/ci/ci_precommit.py
+++ b/src/phylum/ci/ci_precommit.py
@@ -10,6 +10,7 @@ References:
 """
 import argparse
 import subprocess
+import sys
 from pathlib import Path
 from typing import List, Optional
 
@@ -38,14 +39,25 @@ class CIPreCommit(CIBase):
         extra_arg_paths = (Path(extra_arg).resolve() for extra_arg in self.extra_args)
 
         print(" [*] Checking extra args for valid pre-commit scenarios ...")
+
         # Allow for a pre-commit config set up to send all staged files to the hook
         if sorted(staged_files) == sorted(self.extra_args):
             print(" [+] The extra args provided exactly match the list of staged files")
+            if self.lockfile in extra_arg_paths:
+                return
+            print(" [+] The lockfile is not included in extra args...nothing to do")
+            sys.exit(0)
+
         # Allow for a pre-commit config set up to filter the files sent to the hook
-        elif all(extra_arg in staged_files for extra_arg in self.extra_args):
+        if all(extra_arg in staged_files for extra_arg in self.extra_args):
             print(" [+] All the extra args are staged files")
+            if self.lockfile in extra_arg_paths:
+                return
+            print(" [+] The lockfile is not included in extra args...nothing to do")
+            sys.exit(0)
+
         # Allow for cases where the lockfile is included or explicitly specified (e.g., `pre-commit run --all-files`)
-        elif self.lockfile in extra_arg_paths:
+        if self.lockfile in extra_arg_paths:
             print(" [+] The lockfile was included in the extra args")
         # NOTE: There is still the case where the lockfile is "accidentally" included as an extra argument. For example,
         #       `phylum-ci poetry.lock` was used instead of `phylum-ci --lockfile poetry.lock`, which is bad syntax but
@@ -54,8 +66,9 @@ class CIPreCommit(CIBase):
         #       acquire the command line from the parent process and inspect it for `pre-commit` usage. That is a
         #       heavyweight solution and one that will not be pursued until the need for it is more clear.
         else:
-            print(" [+] No valid pre-commit scenario found. Bailing ...")
-            raise SystemExit(f" [!] Unrecognized arguments: {' '.join(self.extra_args)}")
+            print(" [+] The lockfile was not included in the extra args...possible invalid pre-commit scenario")
+            print(f" [!] Unrecognized arguments: {' '.join(self.extra_args)}")
+            sys.exit(0)
 
     @property
     def phylum_label(self) -> str:

--- a/src/phylum/ci/ci_precommit.py
+++ b/src/phylum/ci/ci_precommit.py
@@ -44,16 +44,18 @@ class CIPreCommit(CIBase):
         if sorted(staged_files) == sorted(self.extra_args):
             print(" [+] The extra args provided exactly match the list of staged files")
             if self.lockfile in extra_arg_paths:
+                print(" [+] Valid pre-commit scenario found: lockfile found in extra arguments")
                 return
-            print(" [+] The lockfile is not included in extra args...nothing to do")
+            print(" [+] The lockfile is not included in extra args. Nothing to do. Exiting ...")
             sys.exit(0)
 
         # Allow for a pre-commit config set up to filter the files sent to the hook
         if all(extra_arg in staged_files for extra_arg in self.extra_args):
             print(" [+] All the extra args are staged files")
             if self.lockfile in extra_arg_paths:
+                print(" [+] Valid pre-commit scenario found: lockfile found in extra arguments")
                 return
-            print(" [+] The lockfile is not included in extra args...nothing to do")
+            print(" [+] The lockfile is not included in extra args. Nothing to do. Exiting ...")
             sys.exit(0)
 
         # Allow for cases where the lockfile is included or explicitly specified (e.g., `pre-commit run --all-files`)

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -34,8 +34,8 @@ def detect_ci_platform(args: argparse.Namespace, remainder: List[str]) -> CIBase
         ci_envs.append(CIGitHub(args))
 
     # Detect Python pre-commit environment
-    # This might be a naive strategy for detecting the `pre-commit` case, but there is at least
-    # an attempt, via a pre-requisite check, to ensure all the extra arguments are staged files.
+    # This might be a naive strategy for detecting the `pre-commit` case, but there is at least an attempt,
+    # via a pre-requisite check, to check the extra arguments for common/valid pre-commit usage patterns.
     if any(remainder):
         print(" [+] Extra arguments provided. Assuming a Python `pre-commit` working environment.")
         ci_envs.append(CIPreCommit(args, remainder))


### PR DESCRIPTION
This PR is meant to update the `pre-commit` hook so that it works in a more expected manner for users. It will allow for the native multiprocessing that `pre-commit` provides and not cause the hook to fail simply because one or more of the processes spawned by the tool were instantiated with a list of files (staged or not) that does not include the expected dependency lockfile. See issue #114 for more detail.

Closes #114

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] ~Have you created sufficient tests?~
  - Tests still don't exist for this integration
  - Manual testing was performed locally to verify each scenario
- [x] Have you updated all affected documentation?
