### PR TITLE
feat!: allow docker image use for non-root users

### DIFF
--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -24,7 +24,7 @@ from phylum.ci.constants import (
     PROJECT_THRESHOLD_OPTIONS,
     SUCCESS_COMMENT,
 )
-from phylum.constants import SUPPORTED_LOCKFILES, TOKEN_ENVVAR_NAME
+from phylum.constants import MIN_CLI_VER_INSTALLED, SUPPORTED_LOCKFILES, TOKEN_ENVVAR_NAME
 from phylum.init.cli import get_phylum_bin_path
 from phylum.init.cli import main as phylum_init
 from ruamel.yaml import YAML
@@ -155,7 +155,7 @@ class CIBase(ABC):
 
         The current pre-requisites for *all* CI environments/platforms are:
           * A `.phylum_project` file exists at the working directory
-          * Phylum CLI v3.3.0+, to make use of the `parse` command
+          * A Phylum CLI version with the `parse` command
           * Have `git` installed and available for use on the PATH
         """
         print(" [+] Confirming pre-requisites ...")
@@ -165,10 +165,8 @@ class CIBase(ABC):
         else:
             raise SystemExit(" [!] The `.phylum_project` file was not found at the current working directory")
 
-        # The `parse` command was available in the pre-releases, but it makes the
-        # error message cleaner to only mention the release version.
-        if Version(self.args.version) < Version("v3.3.0-rc1"):
-            raise SystemExit(" [!] The CLI version must be at least v3.3.0")
+        if Version(self.args.version) < Version(MIN_CLI_VER_INSTALLED):
+            raise SystemExit(f" [!] The CLI version must be at least {MIN_CLI_VER_INSTALLED}")
 
         if shutil.which("git"):
             print(" [+] `git` binary found on the PATH")
@@ -296,8 +294,8 @@ class CIBase(ABC):
                     phylum_init(install_args)
                 else:
                     print(" [+] Attempting to use existing version ...")
-                    if Version(str(cli_version)) < Version("v3.2.0"):
-                        raise SystemExit(" [!] The existing CLI version must be greater than v3.2.0")
+                    if Version(str(cli_version)) < Version(MIN_CLI_VER_INSTALLED):
+                        raise SystemExit(f" [!] The existing CLI version must be at least {MIN_CLI_VER_INSTALLED}")
                     print(" [+] Version checks succeeded. Using existing version.")
 
         cli_path, cli_version = get_phylum_bin_path()

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -283,7 +283,7 @@ class CIBase(ABC):
             "--phylum-token", self.args.token,
         ]
         # fmt: on
-        cli_path, cli_version = get_phylum_bin_path(version=specified_version)
+        cli_path, cli_version = get_phylum_bin_path()
         if cli_path is None:
             print(f" [+] Existing Phylum CLI instance not found. Installing version `{specified_version}` ...")
             phylum_init(install_args)
@@ -300,7 +300,7 @@ class CIBase(ABC):
                         raise SystemExit(" [!] The existing CLI version must be greater than v3.2.0")
                     print(" [+] Version checks succeeded. Using existing version.")
 
-        cli_path, cli_version = get_phylum_bin_path(version=specified_version)
+        cli_path, cli_version = get_phylum_bin_path()
         print(f" [+] Using Phylum CLI instance: {cli_version} at {str(cli_path)}")
 
         self._cli_path = cli_path

--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -1,8 +1,13 @@
 """Provide constants for use throughout the package."""
 
+# This is the minimum CLI version supported for new installs.
 # Linux platform support in the CLI was changed from `unknown-linux-musl` to `unknown-linux-gnu` starting with
 # v3.8.0-rc2, changing the artifact names available to download and install in a non-backwards compatible manner.
-MIN_SUPPORTED_CLI_VERSION = "v3.8.0-rc2"
+MIN_CLI_VER_FOR_INSTALL = "v3.8.0-rc2"
+
+# This is the minimum CLI version supported for existing installs.
+# The `parse` command was added to the CLI in v3.3.0-rc1 and is relied upon to normalize packages in lockfiles.
+MIN_CLI_VER_INSTALLED = "v3.3.0-rc1"
 
 # Keys are lowercase machine hardware names as returned from `uname -m`.
 # Values are the mapped rustc architecture.

--- a/src/phylum/init/cli.py
+++ b/src/phylum/init/cli.py
@@ -17,7 +17,7 @@ from packaging.utils import canonicalize_version
 from packaging.version import InvalidVersion, Version
 from phylum import __version__
 from phylum.constants import (
-    MIN_SUPPORTED_CLI_VERSION,
+    MIN_CLI_VER_FOR_INSTALL,
     REQ_TIMEOUT,
     SUPPORTED_ARCHES,
     SUPPORTED_PLATFORMS,
@@ -121,7 +121,7 @@ def is_supported_version(version: str) -> bool:
     """Predicate for determining if a given version is supported."""
     try:
         provided_version = Version(canonicalize_version(version))
-        min_supported_version = Version(MIN_SUPPORTED_CLI_VERSION)
+        min_supported_version = Version(MIN_CLI_VER_FOR_INSTALL)
     except InvalidVersion as err:
         raise ValueError("An invalid version was provided") from err
 


### PR DESCRIPTION
The Dockerfile has been updated to install the `phylum` package in a
Python virtual environment, which is accessible by non-root users of the
image. These changes were inspired by the Python `black` project, which
did basically the same thing: https://github.com/psf/black/pull/3202

The `phylum-init` script was updated to provide a hidden option
for installing the CLI in a globally accessible directory. That option
is meant to be used in very limited circumstances, namely the Dockerfile
for image creation.

The minimum supported CLI version is currently v3.8.0-rc2 and enough
time has passed that CLI versions prior to v2.2.0 are no longer expected
to exist in the wild. That is when the Phylum config and binary paths
changed, to adhere to the XDG Base Directory Spec. This change removes
support for use of these legacy CLI version paths.

Some refactoring was done to make it easier to update the minimum
supported CLI versions as they progress and make changes that require
different minimum versions for both new and existing installations.

BREAKING CHANGE: CLI installs prior to v2.2.0 are no longer supported.

Closes #118

## Checklist

- [x] Does this PR have an associated issue?
- [x] Have you ensured that you have met the expected acceptance criteria?
  - GHA integration was tested with `TestGHA`
  - GitLab integration was tested manually
- [x] ~Have you created sufficient tests?~
  - Still no automated tests
- [x] Have you updated all affected documentation?

## Screenshots

Both `root` and non-root users have access to the `phylum-ci` and `phylum` binaries now:

<img width="1527" alt="image" src="https://user-images.githubusercontent.com/18729796/190027834-58e239f6-f48b-415e-80c2-015e5584aa90.png">

---

`root` can continue to use `phylum-ci` but non-root users must have an corresponding user account created in the container layer to work:

<img width="1532" alt="image" src="https://user-images.githubusercontent.com/18729796/190028181-1042e8f0-eb83-4e7a-92a2-15028f579c7f.png">

---

Using this image in Azure Pipelines, where the user `vsts_azpcontainer` is created during Job provisioning and used...successfully this time to run `phylum-ci`:

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/18729796/190028591-0c017c04-5d52-4f4b-ac19-48cfe6b06e4a.png">

