### PR TITLE
fix: sanitize user input to guard against possible cmd injection

### DIFF
--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -8,6 +8,7 @@ import json
 import os
 import shutil
 import subprocess
+import shlex
 import tempfile
 import urllib.parse
 from abc import ABC, abstractmethod
@@ -209,7 +210,7 @@ class CIBase(ABC):
         if not self.cli_path:
             raise SystemExit(" [!] Phylum CLI path is unknown. Try using the `init_cli` method first.")
         try:
-            cmd = f"{self.cli_path} parse {self.lockfile}".split()
+            cmd = f"{self.cli_path} parse {shlex.quote(self.lockfile)}".split()
             parse_result = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
         except subprocess.CalledProcessError as err:
             print(f" [!] There was an error running the command: {' '.join(err.cmd)}")
@@ -245,7 +246,7 @@ class CIBase(ABC):
 
         with tempfile.NamedTemporaryFile(mode="w+") as prev_lockfile_fd:
             try:
-                cmd = f"git cat-file blob {prev_lockfile_object}"
+                cmd = f"git cat-file blob {shlex.quote(prev_lockfile_object)}"
                 prev_lockfile_contents = subprocess.run(cmd.split(), check=True, capture_output=True, text=True).stdout
                 prev_lockfile_fd.write(prev_lockfile_contents)
                 prev_lockfile_fd.flush()
@@ -256,7 +257,7 @@ class CIBase(ABC):
                 print(" [!] Due to error, assuming no previous lockfile packages. Please report this as a bug.")
                 return []
             try:
-                cmd = f"{self.cli_path} parse {prev_lockfile_fd.name}"
+                cmd = f"{self.cli_path} parse {shlex.quote(prev_lockfile_fd.name)}"
                 parse_result = subprocess.run(cmd.split(), check=True, capture_output=True, text=True).stdout.strip()
             except subprocess.CalledProcessError as err:
                 print(f" [!] There was an error running the command: {' '.join(err.cmd)}")

--- a/src/phylum/ci/ci_github.py
+++ b/src/phylum/ci/ci_github.py
@@ -12,6 +12,7 @@ GitHub References:
 """
 import json
 import os
+import shlex
 import subprocess
 from argparse import Namespace
 from pathlib import Path
@@ -31,7 +32,7 @@ class CIGitHub(CIBase):
         # It is added before super().__init__(args) so that lockfile change detection will be set properly.
         # See https://github.com/actions/checkout/issues/766 (git CVE-2022-24765) for more detail.
         github_workspace = os.getenv("GITHUB_WORKSPACE", "/github/workspace")
-        cmd = f"git config --global --add safe.directory {github_workspace}"
+        cmd = f"git config --global --add safe.directory {shlex.quote(github_workspace)}"
         subprocess.run(cmd.split(), check=True)
 
         super().__init__(args)
@@ -115,7 +116,7 @@ class CIGitHub(CIBase):
         try:
             # `--exit-code` will make git exit with 1 if there were differences while 0 means no differences.
             # Any other exit code is an error and a reason to re-raise.
-            cmd = f"git diff --exit-code --quiet {pr_base_sha} -- {lockfile.resolve()}"
+            cmd = f"git diff --exit-code --quiet {shlex.quote(pr_base_sha)} -- {shlex.quote(lockfile.resolve())}"
             subprocess.run(cmd.split(), check=True)
             return False
         except subprocess.CalledProcessError as err:

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -9,6 +9,7 @@ GitLab References:
 """
 import os
 import subprocess
+import shlex
 from argparse import Namespace
 from pathlib import Path
 from typing import Optional
@@ -82,7 +83,7 @@ class CIGitLab(CIBase):
         try:
             # `--exit-code` will make git exit with 1 if there were differences while 0 means no differences.
             # Any other exit code is an error and a reason to re-raise.
-            cmd = f"git diff --exit-code --quiet {mr_diff_base_sha} -- {lockfile.resolve()}"
+            cmd = f"git diff --exit-code --quiet {shlex.quote(mr_diff_base_sha)} -- {shlex.quote(lockfile.resolve())}"
             subprocess.run(cmd.split(), check=True)
             return False
         except subprocess.CalledProcessError as err:

--- a/src/phylum/ci/ci_none.py
+++ b/src/phylum/ci/ci_none.py
@@ -6,6 +6,7 @@ This is also the fallback implementation to use when no known CI platform is det
 """
 import argparse
 import subprocess
+import shlex
 from pathlib import Path
 from typing import Optional
 
@@ -42,7 +43,7 @@ class CINone(CIBase):
 
         # This is the unique key that git uses to refer to the blob type data object for the lockfile.
         # Reference: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
-        cmd = f"git hash-object {self.lockfile}".split()
+        cmd = f"git hash-object {shlex.quote(self.lockfile)}".split()
         lockfile_hash_object = subprocess.run(cmd, check=True, text=True, capture_output=True).stdout.strip()
         label = f"{self.ci_platform_name}_{current_branch}_{lockfile_hash_object[:7]}"
         label = label.replace(" ", "-")
@@ -75,7 +76,7 @@ class CINone(CIBase):
         https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-emgitdiffemltoptionsgtltcommitgtltcommitgt--ltpathgt82308203
         """
         remote = git_remote()
-        cmd = f"git diff --exit-code --quiet refs/remotes/{remote}/HEAD... -- {lockfile.resolve()}".split()
+        cmd = f"git diff --exit-code --quiet refs/remotes/{remote}/HEAD... -- {shlex.quote(lockfile.resolve())}".split()
         try:
             # `--exit-code` will make git exit with with 1 if there were differences while 0 means no differences.
             # Any other exit code is an error and a reason to re-raise.

--- a/src/phylum/ci/ci_precommit.py
+++ b/src/phylum/ci/ci_precommit.py
@@ -11,6 +11,7 @@ References:
 import argparse
 import subprocess
 import sys
+import shlex
 from pathlib import Path
 from typing import List, Optional
 
@@ -80,7 +81,7 @@ class CIPreCommit(CIBase):
 
         # This is the unique key that git uses to refer to the blob type data object for the lockfile.
         # Reference: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
-        cmd = f"git hash-object {self.lockfile}".split()
+        cmd = f"git hash-object {shlex.quote(self.lockfile)}".split()
         lockfile_hash_object = subprocess.run(cmd, check=True, text=True, capture_output=True).stdout.strip()
         label = f"{self.ci_platform_name}_{current_branch}_{lockfile_hash_object[:7]}"
         label = label.replace(" ", "-")

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -4,6 +4,7 @@ import json
 import os
 import pathlib
 import subprocess
+import shlex
 import sys
 from typing import List, Optional, Sequence, Tuple
 
@@ -64,7 +65,7 @@ def detect_ci_platform(args: argparse.Namespace, remainder: List[str]) -> CIBase
 def get_phylum_analysis(ci_env: CIBase) -> dict:
     """Analyze a project lockfile from a given CI environment with the phylum CLI and return the analysis."""
     print(" [*] Performing analysis ...")
-    cmd = f"{ci_env.cli_path} analyze -l {ci_env.phylum_label} --verbose --json {ci_env.lockfile}".split()
+    cmd = f"{ci_env.cli_path} analyze -l {shlex.quote(ci_env.phylum_label)} --verbose --json {shlex.quote(ci_env.lockfile)}".split()
     try:
         analysis_result = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout
     except subprocess.CalledProcessError as err:


### PR DESCRIPTION
Many subprocess cmd executions in phylum-ci do not escape user input either via lockfile path, branch name or environment variables before executing, leading to potential command injection vulnerabilities.

This PR adds shlex.quote to the instances I could find, but might not be exhaustive.

