### PR TITLE
fix: account for shallow fetch in Azure Pipelines integration

### DIFF
--- a/docs/sync/azure_pipelines.md
+++ b/docs/sync/azure_pipelines.md
@@ -84,6 +84,8 @@ jobs:
       vmImage: ubuntu-latest
     container: phylumio/phylum-ci:latest
     steps:
+      - checkout: self
+        fetchDepth: 0
       - script: phylum-ci
         displayName: Analyze dependencies with Phylum
         env:
@@ -130,8 +132,8 @@ jobs:
 ### Pool selection
 
 The pool is specified at the job level here because this is a [container job][container_job]. While Azure Pipelines
-allows container jobs for `windows-2019` and `ubuntu-*` base `vmImage`s, only `ubuntu-*` is supported by Phylum at this
-time. Keeping that restriction in mind, the pool can be specified at the pipeline or stage level instead.
+allows container jobs for `windows-2019` and `ubuntu-*` base `vmImage` images, only `ubuntu-*` is supported by Phylum
+at this time. Keeping that restriction in mind, the pool can be specified at the pipeline or stage level instead.
 See the [YAML schema pool definition][yaml_pool] documentation for more detail.
 
 [container_job]: https://learn.microsoft.com/azure/devops/pipelines/process/container-phases
@@ -187,6 +189,23 @@ Only the last tag reference, by SHA256 digest, is guaranteed to not have the und
 [step_target]: https://learn.microsoft.com/azure/devops/pipelines/process/tasks#step-target
 [yaml_job_container]: https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/jobs-job-container
 [yaml_resources]: https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/resources
+
+### Repository checkout
+
+The `phylum-ci` logic for determining changes in lockfiles requires git history beyond what is available in a shallow
+clone/checkout/fetch. To ensure the shallow fetch option is disabled for the pipeline, an explicit checkout step is
+specified here, with `fetchDepth` set to `0`. It is also possible to disable the shallow fetch option in the
+[pipeline settings UI][pipeline_settings]. See the [YAML schema steps.checkout definition][yaml_checkout] documentation
+for more detail.
+
+[pipeline_settings]: https://learn.microsoft.com/azure/devops/pipelines/repos/azure-repos-git#shallow-fetch
+[yaml_checkout]: https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/steps-checkout
+
+```yaml
+      # Reference: https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/steps-checkout
+      - checkout: self
+        fetchDepth: 0
+```
 
 ### Script arguments
 

--- a/src/phylum/ci/ci_azure.py
+++ b/src/phylum/ci/ci_azure.py
@@ -26,6 +26,19 @@ from phylum.ci.ci_base import CIBase, git_remote
 from phylum.ci.constants import PHYLUM_HEADER
 from phylum.constants import REQ_TIMEOUT
 
+PAT_ERR_MSG = """
+An Azure DevOps token with API access is required to use the API (e.g., to post comments).
+This can be the default `System.AccessToken` provided automatically at the start
+of each build for the scoped build identity or a personal access token (PAT).
+A PAT needs at least the `Pull Request Threads` scope (read & write).
+See the Azure DevOps documentation for using personal access tokens:
+  * https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate
+The `System.AccessToken` scoped build identity needs at least the `Contribute to pull requests` permission.
+See the Azure DevOps documentation for using the `System.AccessToken`:
+  * https://learn.microsoft.com/azure/devops/pipelines/build/variables#systemaccesstoken
+  * https://learn.microsoft.com/azure/devops/pipelines/process/access-tokens#job-authorization-scope
+"""
+
 
 class CIAzure(CIBase):
     """Provide methods for an Azure Pipelines CI environment."""
@@ -53,19 +66,9 @@ class CIAzure(CIBase):
             print(" [+] Not in a Pull Request pipeline. Nothing to do. Exiting ...")
             sys.exit(0)
 
-        # An Azure DevOps token with API access is required to use the API (e.g., to post notes/comments).
-        # This can be the default `System.AccessToken` provided automatically at the start
-        # of each build for the scoped build identity or a personal access token (PAT).
-        # A PAT needs at least the `Pull Request Threads` scope (read & write).
-        # See the Azure DevOps documentation for using personal access tokens:
-        #   * https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate
-        # The `System.AccessToken` scoped build identity needs at least the `Contribute to pull requests` permission.
-        # See the Azure DevOps documentation for using the `System.AccessToken`:
-        #   * https://learn.microsoft.com/azure/devops/pipelines/build/variables#systemaccesstoken
-        #   * https://learn.microsoft.com/azure/devops/pipelines/process/access-tokens#job-authorization-scope
         azure_token = os.getenv("AZURE_TOKEN")
         if not azure_token:
-            raise SystemExit(" [!] An Azure DevOps token with API access must be set at `AZURE_TOKEN`")
+            raise SystemExit(f" [!] An Azure DevOps token with API access must be set at `AZURE_TOKEN`: {PAT_ERR_MSG}")
         self._azure_token = azure_token
 
     @property
@@ -184,6 +187,8 @@ class CIAzure(CIBase):
         print(f" [-] The team project ID {team_project_id} maps to name: {team_project_name}")
         resp = requests.get(pr_threads_url, params=query_params, headers=headers, timeout=REQ_TIMEOUT)
         resp.raise_for_status()
+        if resp.status_code != requests.codes.OK:
+            raise SystemExit(f" [!] Are the permissions on the Azure DevOps token `AZURE_TOKEN` correct? {PAT_ERR_MSG}")
         pr_threads = resp.json()
 
         print(" [*] Checking pull request threads for existing comment content to avoid duplication ...")

--- a/src/phylum/ci/ci_azure.py
+++ b/src/phylum/ci/ci_azure.py
@@ -114,7 +114,9 @@ class CIAzure(CIBase):
             common_ancestor_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
             print(f" [+] Common lockfile ancestor commit: {common_ancestor_commit}")
         except subprocess.CalledProcessError as err:
+            ref_url = "https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/steps-checkout#shallow-fetch"
             print(f" [!] The common lockfile ancestor commit could not be found: {err}")
+            print(f" [!] Ensure shallow fetch is disabled for repo checkouts: {ref_url}")
             common_ancestor_commit = None
 
         return common_ancestor_commit


### PR DESCRIPTION
The documentation has been updated to be more clear about how to disable the shallow fetch option. There is also a better error message reminding users that shallow fetch should be disabled, with a link to more information about how to do so.

There is also an effort to provide more detail around Azure token failures. The places where having an Azure Token and having the correct permissions on that token have been updated to provide a more detailed error message when those criteria are not met.

Closes #134

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] ~Have you created sufficient tests?~
  - Tested manually with @furi0us333
- [x] Have you updated all affected documentation?
