### PR TITLE
feat: support GitLab branch pipelines

### DIFF
--- a/.github/workflows/phylum_analyze_pr.yml
+++ b/.github/workflows/phylum_analyze_pr.yml
@@ -1,4 +1,4 @@
-# This is a workflow for analyzing dependency lock files
+# This is a workflow for analyzing dependency lockfiles
 # in this repository with Phylum during pull requests.
 ---
 name: Phylum_analyze

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -194,7 +194,7 @@ class CIBase(ABC):
         """Post the output of the analysis in the means appropriate for the CI environment.
 
         Output in the form of comments on a pull/merge request should be unique and not added multiple times as
-        the review changes but the lock file doesn't.
+        the review changes but the lockfile doesn't.
         """
         raise NotImplementedError()
 

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -14,9 +14,12 @@ from pathlib import Path
 from typing import Optional
 
 import requests
+from connect.utils.terminal.markdown import render
 from phylum.ci.ci_base import CIBase
 from phylum.ci.constants import PHYLUM_HEADER
 from phylum.constants import REQ_TIMEOUT
+
+SHA1_ALL_ZEROES = "0000000000000000000000000000000000000000"
 
 
 class CIGitLab(CIBase):
@@ -25,6 +28,10 @@ class CIGitLab(CIBase):
     def __init__(self, args: Namespace) -> None:
         super().__init__(args)
         self.ci_platform_name = "GitLab CI"
+        if self.is_in_mr:
+            print(" [-] Pipeline context: merge request pipeline")
+        else:
+            print(" [-] Pipeline context: branch pipeline")
 
     def _check_prerequisites(self) -> None:
         """Ensure the necessary pre-requisites are met and bail when they aren't.
@@ -35,16 +42,37 @@ class CIGitLab(CIBase):
         """
         super()._check_prerequisites()
 
+        # References:
+        # https://github.com/watson/ci-info/blob/master/vendors.json
+        # https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
         if os.getenv("GITLAB_CI") != "true":
             raise SystemExit(" [!] Must be working within the GitLab CI environment")
 
         # A GitLab token with API access is required to use the API (e.g., to post notes/comments).
         # This can be a personal, project, or group access token...and possibly some other types as well.
         # See the GitLab Token Overview Documentation for info: https://docs.gitlab.com/ee/security/token_overview.html
-        gitlab_token = os.getenv("GITLAB_TOKEN")
-        if not gitlab_token:
+        gitlab_token = os.getenv("GITLAB_TOKEN", "")
+        if not gitlab_token and self.is_in_mr:
             raise SystemExit(" [!] A GitLab token with API access must be set at `GITLAB_TOKEN`")
         self._gitlab_token = gitlab_token
+
+    @property
+    def is_in_mr(self) -> bool:
+        """Indicate if the integration is operating in the context of a merge request pipeline.
+
+        GitLab CI allows for the possibility of running pipelines in different contexts:
+          * On every commit (e.g., branch pipelines)
+          * For merge requests (e.g., merge request pipelines)
+
+        Knowing when the context is within a merge request helps to ensure the logic used
+        to determine the lockfile changes is correct. It also helps to ensure output is not
+        attempted to be posted when NOT in the context of a review.
+        """
+        # References:
+        # https://github.com/watson/ci-info/blob/master/vendors.json
+        # https://docs.gitlab.com/ee/ci/pipelines/merge_request_pipelines.html
+        # docs.gitlab.com/ee/ci/variables/predefined_variables.html#predefined-variables-for-merge-request-pipelines
+        return bool(os.getenv("CI_MERGE_REQUEST_ID"))
 
     @property
     def gitlab_token(self) -> str:
@@ -54,9 +82,18 @@ class CIGitLab(CIBase):
     @property
     def phylum_label(self) -> str:
         """Get a custom label for use when submitting jobs with `phylum analyze`."""
-        mr_iid = os.getenv("CI_MERGE_REQUEST_IID", "unknown-IID")
-        mr_title = os.getenv("CI_MERGE_REQUEST_TITLE", "unknown-title")
-        label = f"{self.ci_platform_name}_MR#{mr_iid}_{mr_title}"
+        if self.is_in_mr:
+            mr_iid = os.getenv("CI_MERGE_REQUEST_IID", "unknown-IID")
+            mr_title = os.getenv("CI_MERGE_REQUEST_TITLE", "unknown-title")
+            label = f"{self.ci_platform_name}_MR#{mr_iid}_{mr_title}"
+        else:
+            current_branch = os.getenv("CI_COMMIT_BRANCH", "unknown-branch")
+            # This is the unique key that git uses to refer to the blob type data object for the lockfile.
+            # Reference: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
+            cmd = f"git hash-object {self.lockfile}".split()
+            lockfile_hash_object = subprocess.run(cmd, check=True, text=True, capture_output=True).stdout.strip()
+            label = f"{self.ci_platform_name}_{current_branch}_{lockfile_hash_object[:7]}"
+
         label = label.replace(" ", "-")
         return label
 
@@ -64,25 +101,34 @@ class CIGitLab(CIBase):
     def common_lockfile_ancestor_commit(self) -> Optional[str]:
         """Find the common lockfile ancestor commit."""
         # Reference: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
-        return os.getenv("CI_MERGE_REQUEST_DIFF_BASE_SHA")
+        if self.is_in_mr:
+            common_ancestor_commit = os.getenv("CI_MERGE_REQUEST_DIFF_BASE_SHA")
+        else:
+            # CI_COMMIT_BEFORE_SHA contains the previous latest commit present on the branch. It will be
+            # all zeroes in merge request pipelines and for the first commit in pipelines for branches.
+            common_ancestor_commit = os.getenv("CI_COMMIT_BEFORE_SHA")
+            if common_ancestor_commit == SHA1_ALL_ZEROES:
+                print(" [-] Detected first commit in branch")
+
+        return common_ancestor_commit
 
     def _is_lockfile_changed(self, lockfile: Path) -> bool:
         """Predicate for detecting if the given lockfile has changed."""
-        mr_src_branch = os.getenv("CI_MERGE_REQUEST_SOURCE_BRANCH_NAME")
-        mr_tgt_branch = os.getenv("CI_MERGE_REQUEST_TARGET_BRANCH_NAME")
-        mr_diff_base_sha = os.getenv("CI_MERGE_REQUEST_DIFF_BASE_SHA")
-        print(f" [+] CI_MERGE_REQUEST_SOURCE_BRANCH_NAME: {mr_src_branch}")
-        print(f" [+] CI_MERGE_REQUEST_TARGET_BRANCH_NAME: {mr_tgt_branch}")
-        print(f" [+] CI_MERGE_REQUEST_DIFF_BASE_SHA: {mr_diff_base_sha}")
+        diff_base_sha = self.common_lockfile_ancestor_commit
+        print(f" [+] The common lockfile ancestor commit: {diff_base_sha}")
 
         # Assume no change when there isn't enough information to tell
-        if mr_diff_base_sha is None:
+        if diff_base_sha is None:
             return False
+
+        # When the lockfile is part of the first commit in a branch, it should be considered changed since it is new
+        if diff_base_sha == SHA1_ALL_ZEROES:
+            return True
 
         try:
             # `--exit-code` will make git exit with 1 if there were differences while 0 means no differences.
             # Any other exit code is an error and a reason to re-raise.
-            cmd = f"git diff --exit-code --quiet {mr_diff_base_sha} -- {lockfile.resolve()}"
+            cmd = f"git diff --exit-code --quiet {diff_base_sha} -- {lockfile.resolve()}"
             subprocess.run(cmd.split(), check=True)
             return False
         except subprocess.CalledProcessError as err:
@@ -92,39 +138,45 @@ class CIGitLab(CIBase):
             raise
 
     def post_output(self) -> None:
-        """Post the output of the analysis as a note (comment) on the GitLab CI Merge Request (MR)."""
-        # API Reference: https://docs.gitlab.com/ee/api/notes.html#merge-requests
-        gitlab_api_v4_root_url = os.getenv("CI_API_V4_URL")
-        mr_project_id = os.getenv("CI_MERGE_REQUEST_PROJECT_ID")
-        mr_iid = os.getenv("CI_MERGE_REQUEST_IID")
-        # This is the same endpoint for listing all MR notes (GET) and creating new ones (POST)
-        base_mr_notes_api_endpoint = f"/projects/{mr_project_id}/merge_requests/{mr_iid}/notes"
-        url = f"{gitlab_api_v4_root_url}{base_mr_notes_api_endpoint}"
-        headers = {"PRIVATE-TOKEN": self.gitlab_token}
+        """Post the output of the analysis.
 
-        print(f" [*] Getting all current merge request notes with GET URL: {url} ...")
-        req = requests.get(url, headers=headers, timeout=REQ_TIMEOUT)
-        req.raise_for_status()
-        mr_notes = req.json()
+        Post output directly in the logs regardless of the pipeline context.
+        Post output as a note (comment) on the GitLab CI Merge Request (MR) when operating in a merge request pipeline.
+        """
+        print(f" [+] Analysis output:\n{render(self.analysis_output)}")
+        if self.is_in_mr:
+            # API Reference: https://docs.gitlab.com/ee/api/notes.html#merge-requests
+            gitlab_api_v4_root_url = os.getenv("CI_API_V4_URL")
+            mr_project_id = os.getenv("CI_MERGE_REQUEST_PROJECT_ID")
+            mr_iid = os.getenv("CI_MERGE_REQUEST_IID")
+            # This is the same endpoint for listing all MR notes (GET) and creating new ones (POST)
+            base_mr_notes_api_endpoint = f"/projects/{mr_project_id}/merge_requests/{mr_iid}/notes"
+            url = f"{gitlab_api_v4_root_url}{base_mr_notes_api_endpoint}"
+            headers = {"PRIVATE-TOKEN": self.gitlab_token}
 
-        print(" [*] Checking existing merge request notes for existing content to avoid duplication ...")
-        if not mr_notes:
-            print(" [+] No existing merge request notes found.")
-        # NOTE: The API defaults to returning the notes in descending order by the `created_at` field.
-        #       Detecting Phylum notes is done simply by looking for those notes that start with a known string value.
-        #       We only care about the most recent Phylum note.
-        for mr_note in mr_notes:
-            if mr_note.get("body", "").lstrip().startswith(PHYLUM_HEADER.strip()):
-                print(" [+] The most recently posted Phylum merge request note was found.")
-                if mr_note.get("body", "") == self.analysis_output:
-                    print(" [+] It contains the same content as the current analysis. Nothing to do.")
-                    return
-                print(" [+] It does not contain the same content as the current analysis.")
-                break
+            print(f" [*] Getting all current merge request notes with GET URL: {url} ...")
+            req = requests.get(url, headers=headers, timeout=REQ_TIMEOUT)
+            req.raise_for_status()
+            mr_notes = req.json()
 
-        # If we got here, then the most recent Phylum MR note does not match the current analysis output or
-        # there were no Phylum MR notes. Either way, create a new MR note.
-        data = {"body": self.analysis_output}
-        print(f" [*] Creating new merge request note with POST URL: {url} ...")
-        response = requests.post(url, data=data, headers=headers, timeout=REQ_TIMEOUT)
-        response.raise_for_status()
+            print(" [*] Checking existing merge request notes for existing content to avoid duplication ...")
+            if not mr_notes:
+                print(" [+] No existing merge request notes found.")
+            # NOTE: The API defaults to returning the notes in descending order by the `created_at` field.
+            #       Detecting Phylum notes is done simply by looking for notes that start with a known string value.
+            #       We only care about the most recent Phylum note.
+            for mr_note in mr_notes:
+                if mr_note.get("body", "").lstrip().startswith(PHYLUM_HEADER.strip()):
+                    print(" [+] The most recently posted Phylum merge request note was found.")
+                    if mr_note.get("body", "") == self.analysis_output:
+                        print(" [+] It contains the same content as the current analysis. Nothing to do.")
+                        return
+                    print(" [+] It does not contain the same content as the current analysis.")
+                    break
+
+            # If we got here, then the most recent Phylum MR note does not match the current analysis output or
+            # there were no Phylum MR notes. Either way, create a new MR note.
+            data = {"body": self.analysis_output}
+            print(f" [*] Creating new merge request note with POST URL: {url} ...")
+            response = requests.post(url, data=data, headers=headers, timeout=REQ_TIMEOUT)
+            response.raise_for_status()


### PR DESCRIPTION
The ability to recognize when operating in the context of a branch pipeline was encapsulated with a class property. This property was only added to the GitLab integration at this time. It may make sense to extract this property up to the base class, if and when additional environments are modified to work in the same way. The logic was updated to account for the differences between branch pipelines and merge request pipelines, with the preference (order of operations) tending towards merge request pipelines. Output from the analysis will be posted to the log file of either pipeline type, but posting a note to the MR will only happen now when operating in a merge request pipeline. Due to this change, it is now no longer required to have a GitLab token available at all times since it is not required for branch pipelines.

The documentation has been updated to match the changes in the integration. It accounts for the possibility of running the integration in the context of both merge request pipelines and now branch pipelines. The Job Control section was updated to better show how to enable one or the other pipeline, or both...but without creating duplicate running pipelines.

Closes #132

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] ~Have you created sufficient tests?~
  - No automated tests
  - Confirmed with manual test cases
- [x] Have you updated all affected documentation?

## Screenshots

Branch pipelines are running now:

<img width="1285" alt="image" src="https://user-images.githubusercontent.com/18729796/194418675-bac87d8b-6d19-46e3-badb-3535ee311d19.png">
-and-
<img width="1285" alt="image" src="https://user-images.githubusercontent.com/18729796/194418473-283d8b3a-976e-46ca-8bc4-95a6fde01b3a.png">
-and-
<img width="1285" alt="image" src="https://user-images.githubusercontent.com/18729796/194418992-17732fc6-71a7-4492-a011-15cc1c353ce2.png">

---

Logs from creating a new branch (which triggers a branch pipeline):

<img width="1874" alt="image" src="https://user-images.githubusercontent.com/18729796/194420177-2c03b79f-9ca1-480e-8947-e97d99d153a4.png">

NOTE: The way the "first commit in branch" is detected and handled does not feel quite right. It likely should not cause the entire lockfile to be analyzed...especially since it did not change at all, given that the only thing that happened was that the branch was created. Looking into this...

---

Logs from the same branch, but after committing a single change to add a known bad dep:

<img width="1874" alt="image" src="https://user-images.githubusercontent.com/18729796/194420596-5cd07036-9cc9-4a56-84eb-943914711e8b.png">

---

(merge request pipelines still function as before)