### PR TITLE
feat: allow for creating projects

### DIFF
--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -9,6 +9,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import textwrap
 import urllib.parse
 from abc import ABC, abstractmethod
 from argparse import Namespace
@@ -96,6 +97,9 @@ class CIBase(ABC):
                     " [!] A lockfile is required and was not detected. Consider specifying one with `--lockfile`."
                 )
 
+        self._phylum_project = args.project
+        self._phylum_group = args.group
+
         # Ensure all pre-requisites are met and bail at the earliest opportunity when they aren't
         self._check_prerequisites()
         print(" [+] All pre-requisites met")
@@ -125,6 +129,16 @@ class CIBase(ABC):
     def is_lockfile_changed(self) -> bool:
         """Get the lockfile's modification status."""
         return self._lockfile_changed
+
+    @property
+    def phylum_project(self) -> str:
+        """Get the Phylum project."""
+        return self._phylum_project
+
+    @property
+    def phylum_group(self) -> str:
+        """Get the Phylum group."""
+        return self._phylum_group
 
     @property
     def phylum_project_file(self) -> Path:
@@ -179,7 +193,14 @@ class CIBase(ABC):
         if self.phylum_project_file.exists():
             print(f" [+] Existing `.phylum_project` file found at: {self.phylum_project_file}")
         else:
-            raise SystemExit(" [!] The `.phylum_project` file was not found at the current working directory")
+            if self.phylum_project:
+                print(f" [+] No existing `.phylum_project` file found at: {self.phylum_project_file}")
+                print(f" [+] A Phylum project will be created with the provided name: {self.phylum_project}")
+            else:
+                msg = """\
+                    [!] A `.phylum_project` file was not found at the current working directory.
+                    [!] Consider creating one by specifying `--project` and optionally with the `--group` option."""
+                raise SystemExit(textwrap.dedent(msg))
 
         if Version(self.args.version) < Version(MIN_CLI_VER_INSTALLED):
             raise SystemExit(f" [!] The CLI version must be at least {MIN_CLI_VER_INSTALLED}")

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -193,13 +193,13 @@ class CIBase(ABC):
         if self.phylum_project_file.exists():
             print(f" [+] Existing `.phylum_project` file found at: {self.phylum_project_file}")
         else:
+            print(f" [+] No existing `.phylum_project` file found at: {self.phylum_project_file}")
             if self.phylum_project:
-                print(f" [+] No existing `.phylum_project` file found at: {self.phylum_project_file}")
-                print(f" [+] A Phylum project will be created with the provided name: {self.phylum_project}")
+                print(f" [+] A Phylum project will be used (or created) with the provided name: {self.phylum_project}")
             else:
                 msg = """\
-                    [!] A `.phylum_project` file was not found at the current working directory.
-                    [!] Consider creating one by specifying `--project` and optionally with the `--group` option."""
+                    [!] No Phylum project could be determined!
+                    [!] Consider specifying one with `--project` and optionally with the `--group` option."""
                 raise SystemExit(textwrap.dedent(msg))
 
         if Version(self.args.version) < Version(MIN_CLI_VER_INSTALLED):

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -3,6 +3,7 @@ import argparse
 import json
 import os
 import pathlib
+import shlex
 import subprocess
 import sys
 from typing import List, Optional, Sequence, Tuple
@@ -59,6 +60,63 @@ def detect_ci_platform(args: argparse.Namespace, remainder: List[str]) -> CIBase
         ci_env = CINone(args)
 
     return ci_env
+
+
+def ensure_project(ci_env: CIBase) -> None:
+    """Ensure a Phylum project is created and in place.
+
+    When a project is specified through arguments, attempt to create that project,
+    overwriting any `.phylum_project` file that already exists.
+    Continue on without error when a specified project already exists.
+    When a group is specified through arguments, attempt to use that group.
+    """
+    if not ci_env.phylum_project:
+        return
+
+    cmd = f"{ci_env.cli_path} project create {ci_env.phylum_project}"
+    if ci_env.phylum_group:
+        ensure_group(ci_env)
+        print(f" [-] Using provided Phylum group: {ci_env.phylum_group}")
+        cmd = f"{ci_env.cli_path} project create --group {ci_env.phylum_group} {ci_env.phylum_project}"
+
+    print(f" [*] Creating a Phylum project with the name: {ci_env.phylum_project} ...")
+    if ci_env.phylum_project_file.exists():
+        print(f" [+] Overwriting existing `.phylum_project` file found at: {ci_env.phylum_project_file}")
+    try:
+        # The Phylum CLI will return a unique error code of 14 when a project that already exists is attempted to be
+        # created. This situation is recognized and allowed to happen since it means the project exists as expected.
+        # Any other exit code is an error and a reason to re-raise.
+        subprocess.run(shlex.split(cmd), check=True)
+    except subprocess.CalledProcessError as err:
+        if err.returncode == 14:
+            print(f" [-] Project {ci_env.phylum_project} already exists. Continuing with it ...")
+            return
+        print(f" [!] There was a problem creating the project with command: {cmd}")
+        raise
+
+
+def ensure_group(ci_env: CIBase) -> None:
+    """Ensure a Phylum group is created and in place.
+
+    When a group is specified through arguments, attempt to create that group.
+    Continue on without error when a specified group already exists.
+    """
+    if not ci_env.phylum_group:
+        return
+
+    print(f" [*] Creating a Phylum group with the name: {ci_env.phylum_group} ...")
+    cmd = f"{ci_env.cli_path} group create {ci_env.phylum_group}"
+    try:
+        # The Phylum CLI will return a unique error code of 14 when a group that already exists is attempted to be
+        # created. This situation is recognized and allowed to happen since it means the group exists as expected.
+        # Any other exit code is an error and a reason to re-raise.
+        subprocess.run(shlex.split(cmd), check=True)
+    except subprocess.CalledProcessError as err:
+        if err.returncode == 14:
+            print(f" [-] Group {ci_env.phylum_group} already exists. Continuing with it ...")
+            return
+        print(f" [!] There was a problem creating the group with command: {cmd}")
+        raise
 
 
 def get_phylum_analysis(ci_env: CIBase) -> dict:
@@ -137,6 +195,20 @@ def get_args(args: Optional[Sequence[str]] = None) -> Tuple[argparse.Namespace, 
             Leave this option and it's related environment variable unspecified to either (1) use an existing token
             already set in the Phylum config file or (2) to manually populate the token with a `phylum auth login` or
             `phylum auth register` command after install.""",
+    )
+    analysis_group.add_argument(
+        "-p",
+        "--project",
+        # NOTE: The method of using the shlex module is known to be compatible with UNIX shells.
+        #       It may not function as desired for other operating systems and/or shell types.
+        type=shlex.quote,
+        help="Name of a Phylum project to create and use to perform the analysis.",
+    )
+    analysis_group.add_argument(
+        "-g",
+        "--group",
+        type=shlex.quote,
+        help="Optional group name, which will be the owner of the project. Only used when a project is also specified.",
     )
 
     threshold_group = parser.add_argument_group(
@@ -234,6 +306,9 @@ def main(args: Optional[Sequence[str]] = None) -> int:
 
     # Check for the existence of the CLI and install it if needed
     ci_env.init_cli()
+
+    # Ensure a Phylum project is created and in place
+    ensure_project(ci_env)
 
     # Analyze current project lockfile with phylum CLI
     analysis = get_phylum_analysis(ci_env)


### PR DESCRIPTION
This change adds options to specify a project and, optionally, a group to go with that project. The group option is ignored if the project option is not populated.

When the project option is provided, a project will be created, overwriting any existing `.phylum_project` file. If a group is provided, it will also be created. If the provided project and group already exist, they will be used.

Output is provided to inform users about the new options when the integration fails as a result of a missing `.phylum_project` file.

Closes #136

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] ~Have you created sufficient tests?~
  - No automated tests
  - Manual tests have been performed locally, with the `CINone` integration
  - Additional manual tests with `CIGitLab` (and maybe more?) still need to be performed
- [x] Have you updated all affected documentation?

## Screenshots

Specifying a project and group, neither of which exists (failure expected):

<img width="1617" alt="image" src="https://user-images.githubusercontent.com/18729796/194932973-a27203eb-2004-481f-bfe7-50b50b8b707c.png">

---

Specifying a project that does not exist, but a group that does:

<img width="1617" alt="image" src="https://user-images.githubusercontent.com/18729796/194933602-a4393e81-ffeb-4c0d-9658-39dcf9c4163f.png">

---

Specifying a project that does not exist, but no group:

<img width="1617" alt="image" src="https://user-images.githubusercontent.com/18729796/194933719-46b5650f-cf77-4341-8312-b831e82dfb74.png">

---

Specifying a project and group, both of which already exist independently, but are not tied together (failure expected):

<img width="1617" alt="image" src="https://user-images.githubusercontent.com/18729796/194935227-bb4fee8b-3cb9-4f0a-825e-fc2594328251.png">

---

Specifying a project and group, both of which already exist and are tied together:

<img width="1617" alt="image" src="https://user-images.githubusercontent.com/18729796/194935337-d1e15dbb-001d-4440-ba39-73765aec24c2.png">

---

Specifying a group that doesn't exist, but NOT specifying a project (no project is created):

<img width="1617" alt="image" src="https://user-images.githubusercontent.com/18729796/194935523-a224666f-9f01-4860-8edb-44a6cb3e6946.png">

---

Running the integration in a directory without a `.phylum_project` file and without specifying the `--project` option:

<img width="1026" alt="image" src="https://user-images.githubusercontent.com/18729796/194935780-1cbf7a19-fc34-4998-a804-f4e501da8643.png">
