### PR TITLE
fix: sanitize user input to guard against possible cmd injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pipx run --spec phylum phylum-init <options>
 pipx run --spec phylum phylum-ci <options>
 ```
 
-These installation methods require Python 3.7+ to run. The application requires a POSIX compliant shell in which to run.
+These installation methods require Python 3.7+ to run.
 For a self contained environment, consider using the Docker image as described below.
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ pipx run --spec phylum phylum-init <options>
 pipx run --spec phylum phylum-ci <options>
 ```
 
-These installation methods require Python 3.7+ to run. For a self contained environment, consider using the Docker
-image as described below.
+These installation methods require Python 3.7+ to run. The application requires a POSIX compliant shell in which to run.
+For a self contained environment, consider using the Docker image as described below.
 
 ### Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Topic :: Security",
     "Topic :: Software Development",
     "Topic :: Software Development :: Quality Assurance",
+    "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
     "Topic :: Security",
     "Topic :: Software Development",
     "Topic :: Software Development :: Quality Assurance",
-    "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",

--- a/src/phylum/ci/ci_azure.py
+++ b/src/phylum/ci/ci_azure.py
@@ -19,7 +19,6 @@ import sys
 import urllib.parse
 from argparse import Namespace
 from pathlib import Path
-from shlex import quote, split
 from typing import Optional
 
 import requests
@@ -113,7 +112,7 @@ class CIAzure(CIBase):
         if pr_tgt_branch.startswith(old_ref_prefix):
             pr_tgt_branch = pr_tgt_branch.replace(old_ref_prefix, new_ref_prefix, 1)
 
-        cmd = split(f"git merge-base {quote(pr_src_branch)} {quote(pr_tgt_branch)}")
+        cmd = ["git", "merge-base", pr_src_branch, pr_tgt_branch]
         try:
             common_ancestor_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
             print(f" [+] Common lockfile ancestor commit: {common_ancestor_commit}")
@@ -141,8 +140,8 @@ class CIAzure(CIBase):
         try:
             # `--exit-code` will make git exit with 1 if there were differences while 0 means no differences.
             # Any other exit code is an error and a reason to re-raise.
-            cmd = f"git diff --exit-code --quiet {pr_base_sha} -- {lockfile.resolve()}"
-            subprocess.run(cmd.split(), check=True)
+            cmd = ["git", "diff", "--exit-code", "--quiet", pr_base_sha, "--", str(lockfile.resolve())]
+            subprocess.run(cmd, check=True)
             return False
         except subprocess.CalledProcessError as err:
             if err.returncode == 1:

--- a/src/phylum/ci/ci_azure.py
+++ b/src/phylum/ci/ci_azure.py
@@ -19,6 +19,7 @@ import sys
 import urllib.parse
 from argparse import Namespace
 from pathlib import Path
+from shlex import quote, split
 from typing import Optional
 
 import requests
@@ -112,7 +113,7 @@ class CIAzure(CIBase):
         if pr_tgt_branch.startswith(old_ref_prefix):
             pr_tgt_branch = pr_tgt_branch.replace(old_ref_prefix, new_ref_prefix, 1)
 
-        cmd = f"git merge-base {pr_src_branch} {pr_tgt_branch}".split()
+        cmd = split(f"git merge-base {quote(pr_src_branch)} {quote(pr_tgt_branch)}")
         try:
             common_ancestor_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
             print(f" [+] Common lockfile ancestor commit: {common_ancestor_commit}")

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -14,6 +14,7 @@ import urllib.parse
 from abc import ABC, abstractmethod
 from argparse import Namespace
 from pathlib import Path
+from shlex import quote, split
 from typing import List, Optional, Tuple
 
 from packaging.version import Version
@@ -272,8 +273,8 @@ class CIBase(ABC):
         if not self.common_lockfile_ancestor_commit:
             return None
         try:
-            cmd_line = f"git rev-parse --verify {self.common_lockfile_ancestor_commit}:{self.lockfile.name}".split()
-            prev_lockfile_object = subprocess.run(cmd_line, check=True, capture_output=True, text=True).stdout.strip()
+            cmd = f"git rev-parse --verify {quote(self.common_lockfile_ancestor_commit)}:{quote(self.lockfile.name)}"
+            prev_lockfile_object = subprocess.run(split(cmd), check=True, capture_output=True, text=True).stdout.strip()
         except subprocess.CalledProcessError as err:
             # There could be a true error, but the working assumption when here is a previous version does not exist
             print(f" [?] There *may* be an issue with the attempt to get the previous lockfile object: {err}")

--- a/src/phylum/ci/ci_github.py
+++ b/src/phylum/ci/ci_github.py
@@ -15,7 +15,6 @@ import os
 import subprocess
 from argparse import Namespace
 from pathlib import Path
-from shlex import quote, split
 from typing import Optional
 
 import requests
@@ -32,8 +31,8 @@ class CIGitHub(CIBase):
         # It is added before super().__init__(args) so that lockfile change detection will be set properly.
         # See https://github.com/actions/checkout/issues/766 (git CVE-2022-24765) for more detail.
         github_workspace = os.getenv("GITHUB_WORKSPACE", "/github/workspace")
-        cmd = f"git config --global --add safe.directory {quote(github_workspace)}"
-        subprocess.run(split(cmd), check=True)
+        cmd = ["git", "config", "--global", "--add", "safe.directory", github_workspace]
+        subprocess.run(cmd, check=True)
 
         super().__init__(args)
         self.ci_platform_name = "GitHub Actions"
@@ -116,8 +115,8 @@ class CIGitHub(CIBase):
         try:
             # `--exit-code` will make git exit with 1 if there were differences while 0 means no differences.
             # Any other exit code is an error and a reason to re-raise.
-            cmd = f"git diff --exit-code --quiet {quote(pr_base_sha)} -- {lockfile.resolve()}"
-            subprocess.run(split(cmd), check=True)
+            cmd = ["git", "diff", "--exit-code", "--quiet", pr_base_sha, "--", str(lockfile.resolve())]
+            subprocess.run(cmd, check=True)
             return False
         except subprocess.CalledProcessError as err:
             if err.returncode == 1:

--- a/src/phylum/ci/ci_github.py
+++ b/src/phylum/ci/ci_github.py
@@ -15,6 +15,7 @@ import os
 import subprocess
 from argparse import Namespace
 from pathlib import Path
+from shlex import quote, split
 from typing import Optional
 
 import requests
@@ -31,8 +32,8 @@ class CIGitHub(CIBase):
         # It is added before super().__init__(args) so that lockfile change detection will be set properly.
         # See https://github.com/actions/checkout/issues/766 (git CVE-2022-24765) for more detail.
         github_workspace = os.getenv("GITHUB_WORKSPACE", "/github/workspace")
-        cmd = f"git config --global --add safe.directory {github_workspace}"
-        subprocess.run(cmd.split(), check=True)
+        cmd = f"git config --global --add safe.directory {quote(github_workspace)}"
+        subprocess.run(split(cmd), check=True)
 
         super().__init__(args)
         self.ci_platform_name = "GitHub Actions"
@@ -115,8 +116,8 @@ class CIGitHub(CIBase):
         try:
             # `--exit-code` will make git exit with 1 if there were differences while 0 means no differences.
             # Any other exit code is an error and a reason to re-raise.
-            cmd = f"git diff --exit-code --quiet {pr_base_sha} -- {lockfile.resolve()}"
-            subprocess.run(cmd.split(), check=True)
+            cmd = f"git diff --exit-code --quiet {quote(pr_base_sha)} -- {lockfile.resolve()}"
+            subprocess.run(split(cmd), check=True)
             return False
         except subprocess.CalledProcessError as err:
             if err.returncode == 1:

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -12,6 +12,7 @@ import subprocess
 from argparse import Namespace
 from functools import lru_cache
 from pathlib import Path
+from shlex import quote, split
 from typing import Optional
 
 import requests
@@ -125,7 +126,7 @@ class CIGitLab(CIBase):
             default_branch = os.getenv("CI_DEFAULT_BRANCH", "HEAD")
             # This is a best effort attempt since it is finding the merge base between the current commit
             # and the default branch instead of finding the exact commit from which the branch was created.
-            cmd = f"git merge-base HEAD refs/remotes/{remote}/{default_branch}".split()
+            cmd = split(f"git merge-base HEAD refs/remotes/{quote(remote)}/{quote(default_branch)}")
             try:
                 common_ancestor_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
             except subprocess.CalledProcessError as err:
@@ -146,8 +147,8 @@ class CIGitLab(CIBase):
         try:
             # `--exit-code` will make git exit with 1 if there were differences while 0 means no differences.
             # Any other exit code is an error and a reason to re-raise.
-            cmd = f"git diff --exit-code --quiet {diff_base_sha} -- {lockfile.resolve()}"
-            subprocess.run(cmd.split(), check=True)
+            cmd = f"git diff --exit-code --quiet {quote(diff_base_sha)} -- {lockfile.resolve()}"
+            subprocess.run(split(cmd), check=True)
             return False
         except subprocess.CalledProcessError as err:
             if err.returncode == 1:

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -12,7 +12,6 @@ import subprocess
 from argparse import Namespace
 from functools import lru_cache
 from pathlib import Path
-from shlex import quote, split
 from typing import Optional
 
 import requests
@@ -93,7 +92,7 @@ class CIGitLab(CIBase):
             current_branch = os.getenv("CI_COMMIT_BRANCH", "unknown-branch")
             # This is the unique key that git uses to refer to the blob type data object for the lockfile.
             # Reference: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
-            cmd = f"git hash-object {self.lockfile}".split()
+            cmd = ["git", "hash-object", str(self.lockfile)]
             lockfile_hash_object = subprocess.run(cmd, check=True, text=True, capture_output=True).stdout.strip()
             label = f"{self.ci_platform_name}_{current_branch}_{lockfile_hash_object[:7]}"
 
@@ -126,7 +125,7 @@ class CIGitLab(CIBase):
             default_branch = os.getenv("CI_DEFAULT_BRANCH", "HEAD")
             # This is a best effort attempt since it is finding the merge base between the current commit
             # and the default branch instead of finding the exact commit from which the branch was created.
-            cmd = split(f"git merge-base HEAD refs/remotes/{quote(remote)}/{quote(default_branch)}")
+            cmd = ["git", "merge-base", "HEAD", f"refs/remotes/{remote}/{default_branch}"]
             try:
                 common_ancestor_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
             except subprocess.CalledProcessError as err:
@@ -147,8 +146,8 @@ class CIGitLab(CIBase):
         try:
             # `--exit-code` will make git exit with 1 if there were differences while 0 means no differences.
             # Any other exit code is an error and a reason to re-raise.
-            cmd = f"git diff --exit-code --quiet {quote(diff_base_sha)} -- {lockfile.resolve()}"
-            subprocess.run(split(cmd), check=True)
+            cmd = ["git", "diff", "--exit-code", "--quiet", diff_base_sha, "--", str(lockfile.resolve())]
+            subprocess.run(cmd, check=True)
             return False
         except subprocess.CalledProcessError as err:
             if err.returncode == 1:

--- a/src/phylum/ci/ci_none.py
+++ b/src/phylum/ci/ci_none.py
@@ -7,6 +7,7 @@ This is also the fallback implementation to use when no known CI platform is det
 import argparse
 import subprocess
 from pathlib import Path
+from shlex import quote, split
 from typing import Optional
 
 from connect.utils.terminal.markdown import render
@@ -53,7 +54,7 @@ class CINone(CIBase):
     def common_lockfile_ancestor_commit(self) -> Optional[str]:
         """Find the common lockfile ancestor commit."""
         remote = git_remote()
-        cmd = f"git merge-base HEAD refs/remotes/{remote}/HEAD".split()
+        cmd = split(f"git merge-base HEAD refs/remotes/{quote(remote)}/HEAD")
         try:
             common_ancestor_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
         except subprocess.CalledProcessError as err:
@@ -75,7 +76,7 @@ class CINone(CIBase):
         https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-emgitdiffemltoptionsgtltcommitgtltcommitgt--ltpathgt82308203
         """
         remote = git_remote()
-        cmd = f"git diff --exit-code --quiet refs/remotes/{remote}/HEAD... -- {lockfile.resolve()}".split()
+        cmd = split(f"git diff --exit-code --quiet refs/remotes/{quote(remote)}/HEAD... -- {lockfile.resolve()}")
         try:
             # `--exit-code` will make git exit with with 1 if there were differences while 0 means no differences.
             # Any other exit code is an error and a reason to re-raise.

--- a/src/phylum/ci/ci_none.py
+++ b/src/phylum/ci/ci_none.py
@@ -7,7 +7,6 @@ This is also the fallback implementation to use when no known CI platform is det
 import argparse
 import subprocess
 from pathlib import Path
-from shlex import quote, split
 from typing import Optional
 
 from connect.utils.terminal.markdown import render
@@ -38,12 +37,12 @@ class CINone(CIBase):
     @property
     def phylum_label(self) -> str:
         """Get a custom label for use when submitting jobs with `phylum analyze`."""
-        cmd = "git branch --show-current".split()
+        cmd = ["git", "branch", "--show-current"]
         current_branch = subprocess.run(cmd, check=True, text=True, capture_output=True).stdout.strip()
 
         # This is the unique key that git uses to refer to the blob type data object for the lockfile.
         # Reference: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
-        cmd = f"git hash-object {self.lockfile}".split()
+        cmd = ["git", "hash-object", str(self.lockfile)]
         lockfile_hash_object = subprocess.run(cmd, check=True, text=True, capture_output=True).stdout.strip()
         label = f"{self.ci_platform_name}_{current_branch}_{lockfile_hash_object[:7]}"
         label = label.replace(" ", "-")
@@ -54,7 +53,7 @@ class CINone(CIBase):
     def common_lockfile_ancestor_commit(self) -> Optional[str]:
         """Find the common lockfile ancestor commit."""
         remote = git_remote()
-        cmd = split(f"git merge-base HEAD refs/remotes/{quote(remote)}/HEAD")
+        cmd = ["git", "merge-base", "HEAD", f"refs/remotes/{remote}/HEAD"]
         try:
             common_ancestor_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
         except subprocess.CalledProcessError as err:
@@ -76,7 +75,7 @@ class CINone(CIBase):
         https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-emgitdiffemltoptionsgtltcommitgtltcommitgt--ltpathgt82308203
         """
         remote = git_remote()
-        cmd = split(f"git diff --exit-code --quiet refs/remotes/{quote(remote)}/HEAD... -- {lockfile.resolve()}")
+        cmd = ["git", "diff", "--exit-code", "--quiet", f"refs/remotes/{remote}/HEAD...", "--", str(lockfile.resolve())]
         try:
             # `--exit-code` will make git exit with with 1 if there were differences while 0 means no differences.
             # Any other exit code is an error and a reason to re-raise.

--- a/src/phylum/ci/ci_precommit.py
+++ b/src/phylum/ci/ci_precommit.py
@@ -34,7 +34,7 @@ class CIPreCommit(CIBase):
         """
         super()._check_prerequisites()
 
-        cmd = "git diff --cached --name-only".split()
+        cmd = ["git", "diff", "--cached", "--name-only"]
         staged_files = subprocess.run(cmd, check=True, text=True, capture_output=True).stdout.strip().split("\n")
         extra_arg_paths = (Path(extra_arg).resolve() for extra_arg in self.extra_args)
 
@@ -75,12 +75,12 @@ class CIPreCommit(CIBase):
     @property
     def phylum_label(self) -> str:
         """Get a custom label for use when submitting jobs with `phylum analyze`."""
-        cmd = "git branch --show-current".split()
+        cmd = ["git", "branch", "--show-current"]
         current_branch = subprocess.run(cmd, check=True, text=True, capture_output=True).stdout.strip()
 
         # This is the unique key that git uses to refer to the blob type data object for the lockfile.
         # Reference: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
-        cmd = f"git hash-object {self.lockfile}".split()
+        cmd = ["git", "hash-object", str(self.lockfile)]
         lockfile_hash_object = subprocess.run(cmd, check=True, text=True, capture_output=True).stdout.strip()
         label = f"{self.ci_platform_name}_{current_branch}_{lockfile_hash_object[:7]}"
         label = label.replace(" ", "-")
@@ -90,7 +90,7 @@ class CIPreCommit(CIBase):
     @property
     def common_lockfile_ancestor_commit(self) -> Optional[str]:
         """Find the common lockfile ancestor commit."""
-        cmd = "git rev-parse --verify HEAD".split()
+        cmd = ["git", "rev-parse", "--verify", "HEAD"]
         try:
             common_ancestor_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
         except subprocess.CalledProcessError as err:

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -90,6 +90,9 @@ def ensure_project(ci_env: CIBase) -> None:
     elif ret.returncode == 14:
         print(f" [-] Project {ci_env.phylum_project} already exists. Continuing with it ...")
     else:
+        # TODO: Use the `shlex.join` method, introduced in Python 3.8, to produce a shell-escaped string
+        #       to protect against injection vulnerabilities (e.g., users copy/pasting the output here).
+        #       https://github.com/phylum-dev/phylum-ci/issues/18
         print(f" [!] There was a problem creating the project with command: {' '.join(cmd)}")
         ret.check_returncode()
 
@@ -105,6 +108,9 @@ def get_phylum_analysis(ci_env: CIBase) -> dict:
             cmd.extend(["--group", ci_env.phylum_group])
     cmd.extend(["--verbose", "--json", str(ci_env.lockfile)])
 
+    # TODO: Use the `shlex.join` method, introduced in Python 3.8, to produce a shell-escaped string
+    #       to protect against injection vulnerabilities (e.g., users copy/pasting the output here).
+    #       https://github.com/phylum-dev/phylum-ci/issues/18
     print(f" [*] Performing analysis with command: {' '.join(cmd)} ...")
     try:
         analysis_result = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -98,7 +98,7 @@ def ensure_project(ci_env: CIBase) -> None:
 def get_phylum_analysis(ci_env: CIBase) -> dict:
     """Analyze a project lockfile from a given CI environment with the phylum CLI and return the analysis."""
     # Build up the analyze command based on the provided inputs
-    cmd = f"{ci_env.cli_path} analyze -l {ci_env.phylum_label}"
+    cmd = f"{ci_env.cli_path} analyze -l {shlex.quote(ci_env.phylum_label)}"
     if ci_env.phylum_project:
         cmd = f"{cmd} --project {ci_env.phylum_project}"
         # A group can not be specified without a project

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -3,7 +3,6 @@ import argparse
 import json
 import os
 import pathlib
-import shlex
 import subprocess
 import sys
 from typing import List, Optional, Sequence, Tuple
@@ -73,16 +72,16 @@ def ensure_project(ci_env: CIBase) -> None:
     if not ci_env.phylum_project:
         return
 
-    cmd = f"{ci_env.cli_path} project create {ci_env.phylum_project}"
+    cmd = [str(ci_env.cli_path), "project", "create", ci_env.phylum_project]
     if ci_env.phylum_group:
         print(f" [-] Using Phylum group: {ci_env.phylum_group}")
-        cmd = f"{ci_env.cli_path} project create --group {ci_env.phylum_group} {ci_env.phylum_project}"
+        cmd = [str(ci_env.cli_path), "project", "create", "--group", ci_env.phylum_group, ci_env.phylum_project]
 
     print(f" [*] Creating a Phylum project with the name: {ci_env.phylum_project} ...")
     if ci_env.phylum_project_file.exists():
         print(f" [+] Overwriting existing `.phylum_project` file found at: {ci_env.phylum_project_file}")
 
-    ret = subprocess.run(shlex.split(cmd), check=False)
+    ret = subprocess.run(cmd, check=False)
     # The Phylum CLI will return a unique error code of 14 when a project that already
     # exists is attempted to be created. This situation is recognized and allowed to happen
     # since it means the project exists as expected. Any other exit code is an error.
@@ -91,24 +90,24 @@ def ensure_project(ci_env: CIBase) -> None:
     elif ret.returncode == 14:
         print(f" [-] Project {ci_env.phylum_project} already exists. Continuing with it ...")
     else:
-        print(f" [!] There was a problem creating the project with command: {cmd}")
+        print(f" [!] There was a problem creating the project with command: {' '.join(cmd)}")
         ret.check_returncode()
 
 
 def get_phylum_analysis(ci_env: CIBase) -> dict:
     """Analyze a project lockfile from a given CI environment with the phylum CLI and return the analysis."""
     # Build up the analyze command based on the provided inputs
-    cmd = f"{ci_env.cli_path} analyze -l {shlex.quote(ci_env.phylum_label)}"
+    cmd = [str(ci_env.cli_path), "analyze", "-l", ci_env.phylum_label]
     if ci_env.phylum_project:
-        cmd = f"{cmd} --project {ci_env.phylum_project}"
+        cmd.extend(["--project", ci_env.phylum_project])
         # A group can not be specified without a project
         if ci_env.phylum_group:
-            cmd = f"{cmd} --group {ci_env.phylum_group}"
-    cmd = f"{cmd} --verbose --json {ci_env.lockfile}"
+            cmd.extend(["--group", ci_env.phylum_group])
+    cmd.extend(["--verbose", "--json", str(ci_env.lockfile)])
 
-    print(f" [*] Performing analysis with command: {cmd} ...")
+    print(f" [*] Performing analysis with command: {' '.join(cmd)} ...")
     try:
-        analysis_result = subprocess.run(shlex.split(cmd), check=True, capture_output=True, text=True).stdout
+        analysis_result = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout
     except subprocess.CalledProcessError as err:
         # The Phylum project can set the CLI to "fail the build" if threshold requirements are not met.
         # This causes the return code to be non-zero and lands us here. Check for this case to proceed.
@@ -183,15 +182,11 @@ def get_args(args: Optional[Sequence[str]] = None) -> Tuple[argparse.Namespace, 
     analysis_group.add_argument(
         "-p",
         "--project",
-        # NOTE: The method of using the shlex module is known to be compatible with UNIX shells.
-        #       It may not function as desired for other operating systems and/or shell types.
-        type=shlex.quote,
         help="Name of a Phylum project to create and use to perform the analysis.",
     )
     analysis_group.add_argument(
         "-g",
         "--group",
-        type=shlex.quote,
         help="Optional group name, which will be the owner of the project. Only used when a project is also specified.",
     )
 

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -3,6 +3,7 @@ import argparse
 import json
 import os
 import pathlib
+import shlex
 import subprocess
 import sys
 from typing import List, Optional, Sequence, Tuple
@@ -90,10 +91,8 @@ def ensure_project(ci_env: CIBase) -> None:
     elif ret.returncode == 14:
         print(f" [-] Project {ci_env.phylum_project} already exists. Continuing with it ...")
     else:
-        # TODO: Use the `shlex.join` method, introduced in Python 3.8, to produce a shell-escaped string
-        #       to protect against injection vulnerabilities (e.g., users copy/pasting the output here).
-        #       https://github.com/phylum-dev/phylum-ci/issues/18
-        print(f" [!] There was a problem creating the project with command: {' '.join(cmd)}")
+        shell_escaped_cmd = " ".join(shlex.quote(arg) for arg in cmd)
+        print(f" [!] There was a problem creating the project with command: {shell_escaped_cmd}")
         ret.check_returncode()
 
 
@@ -108,10 +107,8 @@ def get_phylum_analysis(ci_env: CIBase) -> dict:
             cmd.extend(["--group", ci_env.phylum_group])
     cmd.extend(["--verbose", "--json", str(ci_env.lockfile)])
 
-    # TODO: Use the `shlex.join` method, introduced in Python 3.8, to produce a shell-escaped string
-    #       to protect against injection vulnerabilities (e.g., users copy/pasting the output here).
-    #       https://github.com/phylum-dev/phylum-ci/issues/18
-    print(f" [*] Performing analysis with command: {' '.join(cmd)} ...")
+    shell_escaped_cmd = " ".join(shlex.quote(arg) for arg in cmd)
+    print(f" [*] Performing analysis with command: {shell_escaped_cmd}")
     try:
         analysis_result = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout
     except subprocess.CalledProcessError as err:

--- a/src/phylum/init/cli.py
+++ b/src/phylum/init/cli.py
@@ -50,8 +50,8 @@ def get_expected_phylum_bin_path():
 
 def get_phylum_cli_version(cli_path: Path) -> str:
     """Get the version of the installed and active Phylum CLI and return it."""
-    cmd = f"{cli_path} --version"
-    version = subprocess.run(cmd.split(), check=True, capture_output=True, text=True).stdout.strip().lower()
+    cmd = [str(cli_path), "--version"]
+    version = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip().lower()
 
     # Starting with Python 3.9, the str.removeprefix() method was introduced to do this same thing
     prefix = "phylum "
@@ -269,7 +269,7 @@ def setup_token(token):
     # The phylum CLI settings.yaml file won't exist upon initial install
     # but running a command will trigger the CLI to generate it
     if not phylum_settings_path.exists():
-        cmd = f"{phylum_bin_path} version".split()
+        cmd = [str(phylum_bin_path), "version"]
         subprocess.run(cmd, check=True)
 
     yaml = YAML()
@@ -280,7 +280,7 @@ def setup_token(token):
         yaml.dump(settings_dict, f)
 
     # Check that the token was setup correctly by using it to display the current auth status
-    cmd = f"{phylum_bin_path} auth status".split()
+    cmd = [str(phylum_bin_path), "auth", "status"]
     subprocess.run(cmd, check=True)
 
 
@@ -395,18 +395,18 @@ def main(args=None):
         # Reference: https://github.com/phylum-dev/cli/pull/671
         if args.global_install:
             # Current assumptions for this method:
-            #   * the /usr/local/bin directory exists, has proper permissions, is on the PATH for all users
+            #   * the /usr/local/bin directory exists, has proper permissions, and is on the PATH for all users
             #   * the install is on a system with glibc
-            cmd = "install -m 0755 phylum /usr/local/bin/phylum".split()
+            cmd = ["install", "-m", "0755", "phylum", "/usr/local/bin/phylum"]
         else:
-            cmd = "sh install.sh".split()
+            cmd = ["sh", "install.sh"]
         subprocess.run(cmd, check=True, cwd=extracted_dir)
 
     process_token_option(args)
 
     # Check to ensure everything is working
     phylum_bin_path, _ = get_phylum_bin_path()
-    cmd = f"{phylum_bin_path} --help".split()
+    cmd = [str(phylum_bin_path), "--help"]
     subprocess.run(cmd, check=True)
 
     return 0


### PR DESCRIPTION
This change backs out the use of the `shlex` module to quote the parts
of any command line that can possibly come from user supplied input.
Explicit lists of command line arguments are used instead. Every element
of each list is a single string, regardless of whitespace contained
within. This is true for both static string literals and variables,
whether they came from user input or not. Therefore, each element in the
list will be considered a separate token/argument when supplied to a
`subprocess.run` call. Every instance of `subprocess.run` was reviewed
and updated to this new format.

Fixes #143

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] ~Have you created sufficient tests?~
  - No automated tests
  - Manual testing was performed to help ensure no regressions
- [x] Have you updated all affected documentation?

## Screenshots

The same sequence of commands as outlined in #143, but this time with no program halt or stack trace displayed:

```sh
../phylum-ci  6  18 on  weird_shlex [!?] is 📦 v0.17.0 via 🐍 v3.10.6
❯ git config --global --get safe.directory

../phylum-ci  6  18 on  weird_shlex [!?] is 📦 v0.17.0 via 🐍 v3.10.6
✖ 1 ❯ GITHUB_ACTIONS=true GITHUB_WORKSPACE="/github/workspace/good;env" poetry run phylum-ci -afl poetry.lock
 [+] CI environment detected: GitHub Actions
 [-] Provided lockfile: /Users/maxrake/dev/phylum/phylum-ci/poetry.lock
 [+] Confirming pre-requisites ...
 [+] Existing `.phylum_project` file found at: /Users/maxrake/dev/phylum/phylum-ci/.phylum_project
 [+] `git` binary found on the PATH
 [!] A GitHub token with API access must be set at `GITHUB_TOKEN` environment variable

../phylum-ci  6  18 on  weird_shlex [!?] is 📦 v0.17.0 via 🐍 v3.10.6 took 2s
✖ 1 ❯ git config --global --get safe.directory
/github/workspace/good;env

../phylum-ci  6  18 on  weird_shlex [!?] is 📦 v0.17.0 via 🐍 v3.10.6
❯ GITHUB_ACTIONS=true GITHUB_WORKSPACE="/github/workspace/bad; env" poetry run phylum-ci -afl poetry.lock
 [+] CI environment detected: GitHub Actions
 [-] Provided lockfile: /Users/maxrake/dev/phylum/phylum-ci/poetry.lock
 [+] Confirming pre-requisites ...
 [+] Existing `.phylum_project` file found at: /Users/maxrake/dev/phylum/phylum-ci/.phylum_project
 [+] `git` binary found on the PATH
 [!] A GitHub token with API access must be set at `GITHUB_TOKEN` environment variable

../phylum-ci  6  18 on  weird_shlex [!?] is 📦 v0.17.0 via 🐍 v3.10.6 took 2s
✖ 1 ❯ git config --global --get safe.directory
/github/workspace/bad; env
```
