### PR TITLE
docs: provide more hints about using the SVG files

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ no token exists and one will need to be manually created or set, after the CLI i
 
 The options for `phylum-init`, automatically updated to be current for the latest release:
 
-> **HINT:** Click on the image to bring up the raw SVG file, which should allow for search and copy/paste functionality.
+> **HINT:** Click on the image to bring up the SVG file, which should allow for search and copy/paste functionality.
 
 ![phylum-init options](https://raw.githubusercontent.com/phylum-dev/phylum-ci/main/docs/img/phylum-init_options.svg)
 
@@ -138,7 +138,7 @@ The current CI platforms/environments supported are:
 
 The options for `phylum-ci`, automatically updated to be current for the latest release:
 
-> **HINT:** Click on the image to bring up the raw SVG file, which should allow for search and copy/paste functionality.
+> **HINT:** Click on the image to bring up the SVG file, which should allow for search and copy/paste functionality.
 
 ![phylum-ci options](https://raw.githubusercontent.com/phylum-dev/phylum-ci/main/docs/img/phylum-ci_options.svg)
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ no token exists and one will need to be manually created or set, after the CLI i
 
 The options for `phylum-init`, automatically updated to be current for the latest release:
 
+> **HINT:** Click on the image to bring up the raw SVG file, which should allow for search and copy/paste functionality.
+
 ![phylum-init options](https://raw.githubusercontent.com/phylum-dev/phylum-ci/main/docs/img/phylum-init_options.svg)
 
 #### `phylum-ci` Script Entry Point
@@ -135,6 +137,8 @@ The current CI platforms/environments supported are:
     * Troubleshooting after submitting a PR/MR to a CI system and getting unexpected results
 
 The options for `phylum-ci`, automatically updated to be current for the latest release:
+
+> **HINT:** Click on the image to bring up the raw SVG file, which should allow for search and copy/paste functionality.
 
 ![phylum-ci options](https://raw.githubusercontent.com/phylum-dev/phylum-ci/main/docs/img/phylum-ci_options.svg)
 

--- a/docs/script_options.md
+++ b/docs/script_options.md
@@ -1,9 +1,10 @@
 # Overview
 
 The command line options for the script entry points provided by this package are contained on this page.
-They are automatically updated with the [rich-codex] tool for each release.
-The output is stored as SVG files, which should allow for copy and paste functionality when viewed from most
-browsers (hint: it may be necessary to click on the image and bring up the raw SVG file in the browser by itself).
+They are automatically updated with the [rich-codex] tool for each release. The output is stored as SVG files,
+which should allow for search and copy/paste functionality when viewed from most browsers.
+
+> **HINT:** Click on an image to bring up the raw SVG file, which should allow for search and copy/paste functionality.
 
 [rich-codex]: https://ewels.github.io/rich-codex/
 

--- a/docs/script_options.md
+++ b/docs/script_options.md
@@ -4,7 +4,7 @@ The command line options for the script entry points provided by this package ar
 They are automatically updated with the [rich-codex] tool for each release. The output is stored as SVG files,
 which should allow for search and copy/paste functionality when viewed from most browsers.
 
-> **HINT:** Click on an image to bring up the raw SVG file, which should allow for search and copy/paste functionality.
+> **HINT:** Click on an image to bring up the SVG file, which should allow for search and copy/paste functionality.
 
 [rich-codex]: https://ewels.github.io/rich-codex/
 


### PR DESCRIPTION
During conversations with a potential customer, feedback was provided to say that the top-level README was not clear enough on the use of SVG files to show the current script options help output. That is, they did not realize that the "images" were actually SVG files that, when clicked on and opened in raw form in the browser, would allow for search and copy/paste functionality. This change makes that hint more obvious by using a markdown quote box, with a bold **HINT** preface. Additionally, the hint is added to all the places the SVG files are displayed.

## Screenshots

View of the [README in the `hint_hint` branch](https://github.com/phylum-dev/phylum-ci/tree/hint_hint):

<img width="972" alt="image" src="https://user-images.githubusercontent.com/18729796/196245333-c3f8f954-13b5-4277-81a6-2b2da6c1602b.png">

---

Showing that search works from the [direct link](https://raw.githubusercontent.com/phylum-dev/phylum-ci/main/docs/img/phylum-init_options.svg) to the file that comes up when clicking on the SVG image from the top-level `README`:

<img width="1356" alt="image" src="https://user-images.githubusercontent.com/18729796/196245198-09cbfff5-45f6-494d-ba4f-c91c7b21f5a5.png">
