### PR TITLE
ci: stop using deprecated `set-output` workflow command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
           else
             poetry run semantic-release publish -v DEBUG
           fi
-          echo "::set-output name=url::https://pypi.org/project/phylum/${{ env.PHYLUM_REL_VER }}/"
+          echo "url=https://pypi.org/project/phylum/${{ env.PHYLUM_REL_VER }}/" >> $GITHUB_OUTPUT
 
       - name: Build docker image
         run: |


### PR DESCRIPTION
GitHub workflow commands `set-state` and `set-output` have been deprecated. The announcement and upgrade details can be found [on their blog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). This change makes the suggested upgrade. It won't be fully tested until the next release.
