### PR TITLE
chore: specify GitHub REST API version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,8 @@
 # curl \
 #   -X POST \
 #   --fail-with-body \
-#   -H "Accept: application/vnd.github.v3+json" \
+#   -H "Accept: application/vnd.github+json" \
+#   -H "X-GitHub-Api-Version: 2022-11-28" \
 #   -H "Authorization: token <PAT>" \
 #   -d '{"event_type":"build-push-docker-images","client_payload":{"CLI_version":"v3.8.0"}}' \
 #   https://api.github.com/repos/phylum-dev/phylum-ci/dispatches
@@ -49,7 +50,8 @@ jobs:
           REL_VER_WITH_v=$( \
             curl \
               --silent \
-              -H "Accept: application/vnd.github.v3+json" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
               https://api.github.com/repos/phylum-dev/phylum-ci/releases/latest \
             | \
             jq \

--- a/src/phylum/ci/ci_github.py
+++ b/src/phylum/ci/ci_github.py
@@ -21,7 +21,7 @@ import requests
 
 from phylum.ci.ci_base import CIBase
 from phylum.ci.constants import PHYLUM_HEADER
-from phylum.constants import REQ_TIMEOUT
+from phylum.constants import GITHUB_API_VERSION, REQ_TIMEOUT
 
 PAT_ERR_MSG = """
 A GitHub token with API access is required to use the API (e.g., to post comments).
@@ -158,7 +158,8 @@ def post_github_comment(comments_url: str, github_token: str, comment: str) -> N
     or if the most recently posted Phylum comment does not contain the same content.
     """
     headers = {
-        "Accept": "application/vnd.github.v3+json",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
         "Authorization": f"token {github_token}",
     }
 

--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -51,5 +51,9 @@ SUPPORTED_LOCKFILES = {
 }
 
 # Timeout value, in seconds, to tell the Python Requests package to stop waiting for a response.
-# Reference: https://2.python-requests.org/en/master/user/quickstart/#timeouts
+# Reference: https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts
 REQ_TIMEOUT: float = 10.0
+
+# GitHub API version to use when making requests to the REST API.
+# Reference: https://docs.github.com/rest/overview/api-versions
+GITHUB_API_VERSION = "2022-11-28"

--- a/src/phylum/init/cli.py
+++ b/src/phylum/init/cli.py
@@ -19,6 +19,7 @@ from ruamel.yaml import YAML
 
 from phylum import __version__
 from phylum.constants import (
+    GITHUB_API_VERSION,
     MIN_CLI_VER_FOR_INSTALL,
     REQ_TIMEOUT,
     SUPPORTED_ARCHES,
@@ -87,7 +88,10 @@ def get_latest_version():
     # API Reference: https://docs.github.com/en/rest/releases/releases#get-the-latest-release
     github_api_url = "https://api.github.com/repos/phylum-dev/cli/releases/latest"
 
-    headers = {"Accept": "application/vnd.github+json"}
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+    }
     req = requests.get(github_api_url, headers=headers, timeout=REQ_TIMEOUT)
     req.raise_for_status()
     req_json = req.json()
@@ -105,7 +109,10 @@ def supported_releases() -> List[str]:
     # API Reference: https://docs.github.com/en/rest/releases/releases#list-releases
     github_api_url = "https://api.github.com/repos/phylum-dev/cli/releases"
 
-    headers = {"Accept": "application/vnd.github+json"}
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+    }
     query_params = {"per_page": 100}
     req = requests.get(github_api_url, headers=headers, params=query_params, timeout=REQ_TIMEOUT)
     req.raise_for_status()
@@ -147,7 +154,10 @@ def supported_targets(release_tag: str) -> List[str]:
     # API Reference: https://docs.github.com/en/rest/releases/releases#get-a-release-by-tag-name
     github_api_url = f"https://api.github.com/repos/phylum-dev/cli/releases/tags/{release_tag}"
 
-    headers = {"Accept": "application/vnd.github+json"}
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+    }
     req = requests.get(github_api_url, headers=headers, timeout=REQ_TIMEOUT)
     req.raise_for_status()
     req_json = req.json()


### PR DESCRIPTION
As of 28 November 2022, the GitHub REST API is versioned with a new calver scheme. The recommendation from GitHub is to update all integrations that make use of this API to be explicit about the version in use. This change does just that for the `phylum-ci` repo. Since all the calls work with the same version at this point, a constant was added to allow for a single source for changing to new/different versions in the future.

References:
* [Blog Post](https://github.blog/2022-11-28-to-infinity-and-beyond-enabling-the-future-of-githubs-rest-api-with-api-versioning/)
* ["API Versions" documentation](https://docs.github.com/rest/overview/api-versions)
