### PR TITLE
feat: add `go.sum` and `Cargo.lock` as supported lockfiles

### DIFF
--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -48,6 +48,10 @@ SUPPORTED_LOCKFILES = {
     # Java
     "effective-pom.xml": "mvn",
     "gradle.lockfile": "gradle",
+    # Go
+    "go.sum": "go",
+    # Rust
+    "Cargo.lock": "cargo",
 }
 
 # Timeout value, in seconds, to tell the Python Requests package to stop waiting for a response.


### PR DESCRIPTION
The auto-detection feature for finding known dependency lockfiles was updated to include `go.sum` and `Cargo.lock`. Both of these lockfiles are now supported by Phylum and active in production.

Closes #142

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [ ] ~Have you created sufficient tests?~
  - No tests for this yet
- [x] Have you updated all affected documentation?
  - The relevant documentation is in the CLI repo...and has [already been updated](https://docs.phylum.io/docs/analyzing-dependencies)
