### PR TITLE
fix: issue summary entries repeated in output

### DIFF
--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -470,7 +470,7 @@ class CIBase(ABC):
         """
         failed_flag = False
         risk_vectors = package_result.get("riskVectors", {})
-        issue_flags = []
+        issue_flags: List = []
 
         fail_string = f"\n### Package: `{package_result.get('name')}@{package_result.get('version')}` failed.\n"
         fail_string += "|Risk Domain|Identified Score|Requirement|Requirement Source|\n"
@@ -479,10 +479,10 @@ class CIBase(ABC):
         for threshold_option, risk_domain in PROJECT_THRESHOLD_OPTIONS.items():
             pti = self._get_project_threshold_info(project_thresholds, threshold_option)
             # The `RiskDomain` dataclass and this logic can be simplified once the API standardizes the use of names
-            # so that risk domains are referenced with the same name everywhere (e.g., vulnerability/vulnerabilities
-            # and malicious_code/malicious)
+            # so that risk domains are referenced with the same name everywhere (e.g., malicious_code/malicious):
+            # https://github.com/phylum-dev/api/issues/499
             vul = None
-            potential_names = [risk_domain.package_name, risk_domain.project_name]
+            potential_names = {risk_domain.package_name, risk_domain.project_name}
             for potential_name in potential_names:
                 vul = risk_vectors.get(potential_name)
                 if vul is not None:

--- a/src/phylum/ci/constants.py
+++ b/src/phylum/ci/constants.py
@@ -79,7 +79,7 @@ INCOMPLETE_COMMENT_TEMPLATE = string.Template(
 #   * key name returned from a Phylum analysis as known by the overall project threshold mapping
 #   * key name returned from a Phylum analysis as known by an individual package riskVectors mapping
 PROJECT_THRESHOLD_OPTIONS = {
-    "vul_threshold": RiskDomain("Software Vulnerability", "vulnerability", "vulnerabilities"),
+    "vul_threshold": RiskDomain("Software Vulnerability", "vulnerability", "vulnerability"),
     "mal_threshold": RiskDomain("Malicious Code", "malicious", "malicious_code"),
     "eng_threshold": RiskDomain("Engineering", "engineering", "engineering"),
     "lic_threshold": RiskDomain("License", "license", "license"),

--- a/src/phylum/ci/git.py
+++ b/src/phylum/ci/git.py
@@ -23,7 +23,7 @@ def git_remote() -> str:
 def git_set_remote_head(remote: str) -> None:
     """Set the remote HEAD ref for a given remote.
 
-    Some CI environment do not set the remote HEAD. Use this function to do so.
+    Some CI environments do not set the remote HEAD. Use this function to do so.
     It assumes git credentials are available to run the command.
     """
     print(" [*] Automatically setting the remote HEAD ref ...")


### PR DESCRIPTION
It turns out that the possible risk domain names are mostly the same between how they are referenced between the project and package levels. The list of potential names was getting added to the list of flags, *without* checking for duplicates first. This was corrected by using a set instead of a list for the potential names. Additionally, the difference between `vulnerabilities` and `vulnerability` was confirmed to have been corrected in phylum-dev/api#424 and thus that entry was updated here as well. So, the only remaining difference is between `malicious_code` and `malicious`, which is being tracked with phylum-dev/api#499

Fixes #174

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [ ] ~Have you created sufficient tests?~
- [x] Have you updated all affected documentation?

## Screenshots

Output from running the command: `poetry run phylum-ci -afl reqs.txt -p delme_repeat_check -u 100 -m 100 -e 100 -c 100 -o 100`

<img width="1369" alt="image" src="https://user-images.githubusercontent.com/18729796/208203189-9b372b78-8856-4a87-958c-e7d91170ae30.png">

