### PR TITLE
feat!: improve experience around GitHub rate limiting API requests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,6 +52,7 @@ jobs:
               --silent \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               https://api.github.com/repos/phylum-dev/phylum-ci/releases/latest \
             | \
             jq \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,7 @@ jobs:
             --cache-from phylumio/phylum-ci:latest \
             --build-arg PKG_SRC=dist/phylum-*.whl \
             --build-arg PKG_NAME=phylum-*.whl \
+            --build-arg GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             .
 
       - name: Test docker image built from dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,9 +83,12 @@ jobs:
           poetry install --verbose --no-root --sync
 
       - name: Build docker image from source
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: docker build --tag phylum-ci:from-src --build-arg GITHUB_TOKEN --cache-from phylumio/phylum-ci:latest .
+        run: |
+          docker build \
+            --tag phylum-ci:from-src \
+            --cache-from phylumio/phylum-ci:latest \
+            --build-arg GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            .
 
       - name: Test docker image built from source
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,7 @@ jobs:
         shell: bash
     env:
       DOCKER_BUILDKIT: 1
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,6 @@ jobs:
         shell: bash
     env:
       DOCKER_BUILDKIT: 1
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v3
@@ -84,7 +83,9 @@ jobs:
           poetry install --verbose --no-root --sync
 
       - name: Build docker image from source
-        run: docker build --tag phylum-ci:from-src --cache-from phylumio/phylum-ci:latest .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: docker build --tag phylum-ci:from-src --build-arg GITHUB_TOKEN --cache-from phylumio/phylum-ci:latest .
 
       - name: Test docker image built from source
         run: |

--- a/.phylum_project
+++ b/.phylum_project
@@ -1,6 +1,6 @@
 id: 56f7f1b0-7f63-47a4-9f5e-8194772b2e13
 name: phylum-ci
-created_at: 2022-12-14T13:12:18.954539-06:00
+created_at: 2022-12-30T10:24:24.678837-06:00
 group_name: phylum_bot
-lockfile: poetry.lock
 lockfile_type: poetry
+lockfile_path: poetry.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,11 @@ FROM python:3.11-slim-bullseye
 # When not defined, the value will default to `latest`.
 ARG CLI_VER
 
+# GITHUB_TOKEN is an optional build argument that can be used to provide a
+# GitHub Personal Access Token (PAT) in order to make authenticated requests
+# and therefore increase the API rate limit.
+ARG GITHUB_TOKEN
+
 LABEL maintainer="Phylum, Inc. <engineering@phylum.io>"
 LABEL org.opencontainers.image.source="https://github.com/phylum-dev/phylum-ci"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,14 @@
 #
 # $ docker build --tag phylum-ci --build-arg CLI_VER=v3.8.0 .
 #
+# Another build arg is exposed to optionally specify a GitHub Personal Access Token (PAT):
+#
+# $ docker build --tag phylum-ci --build-arg GITHUB_TOKEN .
+#
+# Providing a build argument like this (without a value) works when there is already an
+# environment variable defined with the same name. Providing a GitHub PAT is useful to
+# make authenticated requests and therefore increase the API rate limit.
+#
 # To make use of BuildKit's inline layer caching feature, add the `BUILDKIT_INLINE_CACHE`
 # build argument to any instance of building an image. Then, that image can be used
 # locally or remotely (if it was pushed to a repository) to warm the build cache by using

--- a/src/phylum/ci/ci_azure.py
+++ b/src/phylum/ci/ci_azure.py
@@ -32,7 +32,7 @@ from phylum.ci.ci_base import CIBase
 from phylum.ci.ci_github import post_github_comment
 from phylum.ci.constants import PHYLUM_HEADER
 from phylum.ci.git import git_default_branch_name, git_hash_object, git_remote
-from phylum.constants import REQ_TIMEOUT
+from phylum.constants import PHYLUM_USER_AGENT, REQ_TIMEOUT
 
 AZURE_PAT_ERR_MSG = """
 An Azure DevOps token with API access is required to use the API (e.g., to post comments).
@@ -322,7 +322,10 @@ def post_azure_comment(azure_token: str, comment: str) -> None:
     b64_ado_pat = base64.b64encode(bytes(f":{azure_token}", encoding="ascii")).decode(encoding="ascii")
 
     query_params = {"api-version": api_version}
-    headers = {"Authorization": f"Basic {b64_ado_pat}"}
+    headers = {
+        "User-Agent": PHYLUM_USER_AGENT,
+        "Authorization": f"Basic {b64_ado_pat}",
+    }
 
     query_params_encoded = urllib.parse.urlencode(query_params, safe="/", quote_via=urllib.parse.quote)
     print(f" [*] Getting list of all current PR threads with GET URL: {pr_threads_url}?{query_params_encoded} ...")

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -21,7 +21,7 @@ from backports.cached_property import cached_property
 from phylum.ci.ci_base import CIBase
 from phylum.ci.constants import PHYLUM_HEADER
 from phylum.ci.git import git_default_branch_name, git_hash_object, git_remote
-from phylum.constants import REQ_TIMEOUT
+from phylum.constants import PHYLUM_USER_AGENT, REQ_TIMEOUT
 
 
 @lru_cache(maxsize=1)
@@ -184,7 +184,10 @@ class CIGitLab(CIBase):
         # This is the same endpoint for listing all MR notes (GET) and creating new ones (POST)
         base_mr_notes_api_endpoint = f"/projects/{mr_project_id}/merge_requests/{mr_iid}/notes"
         url = f"{gitlab_api_v4_root_url}{base_mr_notes_api_endpoint}"
-        headers = {"PRIVATE-TOKEN": self.gitlab_token}
+        headers = {
+            "User-Agent": PHYLUM_USER_AGENT,
+            "PRIVATE-TOKEN": self.gitlab_token,
+        }
 
         print(f" [*] Getting all current merge request notes with GET URL: {url} ...")
         req = requests.get(url, headers=headers, timeout=REQ_TIMEOUT)

--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -57,7 +57,3 @@ SUPPORTED_LOCKFILES = {
 # Timeout value, in seconds, to tell the Python Requests package to stop waiting for a response.
 # Reference: https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts
 REQ_TIMEOUT: float = 10.0
-
-# GitHub API version to use when making requests to the REST API.
-# Reference: https://docs.github.com/rest/overview/api-versions
-GITHUB_API_VERSION = "2022-11-28"

--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -1,4 +1,5 @@
 """Provide constants for use throughout the package."""
+from phylum import __version__
 
 # This is the minimum CLI version supported for new installs.
 # `--label` was added as a long form option to the analyze command starting with v3.12.0
@@ -57,3 +58,7 @@ SUPPORTED_LOCKFILES = {
 # Timeout value, in seconds, to tell the Python Requests package to stop waiting for a response.
 # Reference: https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts
 REQ_TIMEOUT: float = 10.0
+
+# User-Agent header to use when making web requests, to identify this tool instead of falling
+# back to the default provided by the Python Requests package (e.g., `python-requests/2.28.1`).
+PHYLUM_USER_AGENT = f"phylum-ci/{__version__}"

--- a/src/phylum/github.py
+++ b/src/phylum/github.py
@@ -1,0 +1,122 @@
+"""Provide methods for interacting with the GitHub API."""
+import os
+import textwrap
+import time
+from typing import Optional
+
+import requests
+
+from phylum import __version__
+from phylum.constants import REQ_TIMEOUT
+
+# GitHub API version to use when making requests to the REST API.
+# Reference: https://docs.github.com/rest/overview/api-versions
+GITHUB_API_VERSION = "2022-11-28"
+
+# These are the default headers that are included in all GitHub API requests
+DEFAULT_HEADERS = {
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": GITHUB_API_VERSION,
+    "User-Agent": f"phylum-ci/{__version__}",
+}
+
+# Reference URL for how to create a GitHub Personal Access Token (PAT)
+PAT_REF = "https://docs.github.com/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token"
+
+
+def get_headers(github_token: Optional[str] = None) -> dict[str, str]:
+    """Get the headers to use for a GitHub API request.
+
+    Authenticated requests are made by providing a GitHub token. The token can be passed by parameter
+    or set with the `GITHUB_TOKEN` environment variable. Preference is given to the parameter.
+    """
+    # Start with the default headers
+    headers = DEFAULT_HEADERS.copy()
+
+    # Add an authorization header if a GitHub token is provided
+    if github_token is None:
+        # Even requests that do not require authorization can be made with authentication by providing the token as
+        # an environment variable. This may be useful to bypass/extend the rate limit for unauthenticated requests.
+        github_token = os.getenv("GITHUB_TOKEN")
+    if github_token:
+        # `Bearer` or `token` should work here, but `Bearer` appears to be more comprehensive, allowing for JWTs too.
+        # Reference: https://docs.github.com/rest/overview/resources-in-the-rest-api#oauth2-token-sent-in-a-header
+        headers["Authorization"] = f"Bearer {github_token}"
+
+    return headers
+
+
+def github_request(
+    api_url: str,
+    params: Optional[dict] = None,
+    github_token: Optional[str] = None,
+    timeout: float = REQ_TIMEOUT,
+) -> dict:
+    """Make a request to a given GitHub API endpoint and return the response.
+
+    A limited amount of specific failure cases are checked to provide detailed information to users.
+    All failure cases cause the system to exit with a failure code and a detailed message.
+
+    Valid GitHub API requests will return a JSON-formatted response body, which is returned as a Python dict.
+    """
+    headers = get_headers(github_token=github_token)
+
+    print(f" [*] Making request to GitHub API URL: {api_url}")
+    resp = requests.get(api_url, headers=headers, params=params, timeout=timeout)
+
+    # The returned headers of any GitHub API request can be viewed to see the current rate limit status.
+    # Reference: https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limit-http-headers
+    rate_limit_remaining = resp.headers.get("x-ratelimit-remaining", "unknown")
+    rate_limit = resp.headers.get("x-ratelimit-limit", "unknown")
+    rate_limit_reset_header = int(resp.headers.get("x-ratelimit-reset", "0"))
+    current_time = time.asctime(time.localtime())
+    if not rate_limit_reset_header:
+        print(" [!] `x-ratelimit-reset` header not available; using 1 hour from current time instead")
+        seconds_in_hour = 60 * 60
+        rate_limit_reset_header = int(time.mktime(time.localtime()) + seconds_in_hour)
+    reset_time = time.asctime(time.localtime(rate_limit_reset_header))
+
+    if resp.status_code == requests.codes.forbidden:
+        # There are several reasons why a 403 status code (FORBIDDEN) could be returned:
+        #   * API rate limit exceeded
+        #   * API secondary rate limit exceeded
+        #   * Failed login limit exceeded
+        #   * Requests with no `User-Agent` header
+        # Reference: https://docs.github.com/rest/overview/resources-in-the-rest-api
+
+        # The most likely reason is that the rate limit has been exceeded so check for that.
+        # The other possible forbidden cases are not common enough to check for here.
+        # Reference: https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting
+        if rate_limit_remaining == "0":
+            msg = textwrap.dedent(
+                f"""\
+                [!] GitHub API rate limit of {rate_limit} requests/hour was exceeded for URL: {api_url}
+                    The current time is:  {current_time}
+                    Rate limit resets at: {reset_time}
+                    Options include waiting to try again after the rate limit resets or to make authenticated
+                    requests by providing a GitHub token in the `GITHUB_TOKEN` environment variable. Reference:
+                    {PAT_REF}
+                """
+            )
+            raise SystemExit(msg)
+
+    # TODO: Make this a debug level log output statement
+    #       https://github.com/phylum-dev/phylum-ci/issues/23
+    print(f" [+] {rate_limit_remaining} GitHub API requests remaining until window resets at: {reset_time}")
+
+    # Wrap all other request failures in a detailed message and exit with that instead of a stack trace
+    try:
+        resp.raise_for_status()
+    except requests.HTTPError as err:
+        msg = textwrap.dedent(
+            f"""\
+            [!] A bad request was made to the GitHub API:
+                {err}
+                Response text: {resp.text.strip()}
+            """
+        )
+        raise SystemExit(msg) from err
+
+    resp_json = resp.json()
+
+    return resp_json

--- a/src/phylum/github.py
+++ b/src/phylum/github.py
@@ -6,8 +6,7 @@ from typing import Optional
 
 import requests
 
-from phylum import __version__
-from phylum.constants import REQ_TIMEOUT
+from phylum.constants import PHYLUM_USER_AGENT, REQ_TIMEOUT
 
 # GitHub API version to use when making requests to the REST API.
 # Reference: https://docs.github.com/rest/overview/api-versions
@@ -17,7 +16,7 @@ GITHUB_API_VERSION = "2022-11-28"
 DEFAULT_HEADERS = {
     "Accept": "application/vnd.github+json",
     "X-GitHub-Api-Version": GITHUB_API_VERSION,
-    "User-Agent": f"phylum-ci/{__version__}",
+    "User-Agent": PHYLUM_USER_AGENT,
 }
 
 # Reference URL for how to create a GitHub Personal Access Token (PAT)

--- a/src/phylum/github.py
+++ b/src/phylum/github.py
@@ -2,7 +2,7 @@
 import os
 import textwrap
 import time
-from typing import Optional
+from typing import Dict, Optional
 
 import requests
 
@@ -23,7 +23,7 @@ DEFAULT_HEADERS = {
 PAT_REF = "https://docs.github.com/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token"
 
 
-def get_headers(github_token: Optional[str] = None) -> dict[str, str]:
+def get_headers(github_token: Optional[str] = None) -> Dict[str, str]:
     """Get the headers to use for a GitHub API request.
 
     Authenticated requests are made by providing a GitHub token. The token can be passed by parameter


### PR DESCRIPTION
* Extract GitHub API methods to a new module
  * Support GET requests
  * Aggregate common values as globals
  * Allow for both authenticated and unauthenticated requests
* Provide option to allow making authenticated GitHub API requests
  * Allow for higher rate limits by accepting `GITHUB_TOKEN` envvar
* Provide more detailed error reporting around GitHub API requests
  * Provide specific guidance for rate limit errors
  * Wrap unhandled errors with contextual output instead of stack traces
* Reduce unauthenticated GitHub API calls to the bare minimum
  * Avoid calls made by simply viewing command help output
  * Use function level caching for static calls
  * Change `--phylum-release` option default to use installed version
    * Fall back to `latest` when no CLI is already installed
    * Add `default_phylum_cli_version` method to support this behavior
    * Update documentation (help message text...which populates docs)
* Provide tool specific `User-Agent` header for all web requests
  * Add User-Agent header to identify as `phylum-ci/<version>`
  * Replace default value when using Python `requests` package
    * `python-requests/<version>`
  * Aid in identifying the specific app/version that made the request
* Update workflows and Dockerfile to make use of `GITHUB_TOKEN`
* Update documentation
* Refactor and format throughout

Closes https://github.com/phylum-dev/phylum-ci/issues/177

BREAKING CHANGE: The `--phylum-release` option (`-r`) default is no
longer `latest`. Default behavior now is to use the installed version
and fall back to `latest` when no Phylum CLI is already installed.

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [ ] ~Have you created sufficient tests?~
  - Manual testing was performed
- [x] Have you updated all affected documentation?
  - The help output changes will propagate through to the documentation upon the next release

## Screenshots

Making unauthenticated requests by calling `phylum-init`, both with and without a specified CLI version:

<img width="1403" alt="image" src="https://user-images.githubusercontent.com/18729796/210021708-12228e67-2c02-4882-abc7-a40112f822a0.png">

---

Making authenticated requests by setting the `GITHUB_TOKEN` environment variable and using it:

<img width="1384" alt="image" src="https://user-images.githubusercontent.com/18729796/210021850-945d0420-79de-4dc4-81af-5b262c40a62c.png">

---

Example of unhandled GitHub request error (no `User-Agent` header provided):

<img width="1568" alt="image" src="https://user-images.githubusercontent.com/18729796/210022046-53810390-93e4-4397-a29c-9b34d13c58be.png">

Note that the certificate error was due to using a proxy in order to remove the header.

---

Example proxy output showing a request and response. Note the `User-Agent` header value:

<img width="1543" alt="image" src="https://user-images.githubusercontent.com/18729796/210022255-a9c7125a-2c8e-4a6a-9d25-fc002dbb01ab.png">

---

Example output of basic `phylum-ci` command showing no GitHub API calls (outside of posting comments) when a Phylum CLI is already installed:

<img width="1565" alt="image" src="https://user-images.githubusercontent.com/18729796/210022429-9b2e669a-63a1-4448-a933-4448d4bfa58b.png">

---

Example output when the GitHub API rate limit is exceeded (and then how it can be "extended" by providing authentication via envvar):

<img width="1399" alt="image" src="https://user-images.githubusercontent.com/18729796/210022690-5a90de21-5463-41d3-97ec-c52454fcb87b.png">
