### PR TITLE
chore: include `GITHUB_TOKEN` in release workflows for docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -84,6 +84,7 @@ jobs:
             --build-arg PKG_NAME=phylum-*.whl \
             --build-arg CLI_VER=${{ github.event.client_payload.CLI_version }} \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --build-arg GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             .
 
       - name: Test docker image with latest phylum wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,9 +153,13 @@ jobs:
 
       - name: Build docker image
         run: |
-          export PKG_SRC=dist/phylum-*.whl
-          export PKG_NAME=phylum-*.whl
-          docker build --tag phylum-ci --build-arg PKG_SRC --build-arg PKG_NAME --build-arg BUILDKIT_INLINE_CACHE=1 .
+          docker build \
+            --tag phylum-ci \
+            --build-arg PKG_SRC=dist/phylum-*.whl \
+            --build-arg PKG_NAME=phylum-*.whl \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --build-arg GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            .
 
       - name: Test docker image with pre-built distributions
         run: |


### PR DESCRIPTION
In adding the feature to increase the rate limits for GitHub API calls (#179), a few of the `phylum-ci` repository workflows were updated to take advantage of the fact that the `GITHUB_TOKEN` is already available in those workflows. However, two updates were missed: the release and docker workflows. This change includes them.
