### PR TITLE
feat: add support for Bitbucket Pipelines

### DIFF
--- a/docs/sync/azure_pipelines.md
+++ b/docs/sync/azure_pipelines.md
@@ -75,7 +75,7 @@ The pre-requisites for using this image are:
   * That usually means a connection to the internet, optionally via a proxy
   * Support for on-premises installs are not available at this time
 * A `.phylum_project` file exists at the root of the repository
-  * See [`phylum project`][phylum_project] and [`phylum project create`][phylum_project_create] command documentation
+  * See [`phylum init`] command documentation
 
 [docker_image]: https://hub.docker.com/r/phylumio/phylum-ci/tags
 [azure_auth]: https://learn.microsoft.com/azure/devops/integrate/get-started/authentication/authentication-guidance
@@ -90,8 +90,6 @@ The pre-requisites for using this image are:
 [phylum_contact]: https://phylum.io/contact-us/
 [app_register]: https://app.phylum.io/register
 [phylum_register]: https://docs.phylum.io/docs/phylum_auth_register
-[phylum_project]: https://docs.phylum.io/docs/phylum_project
-[phylum_project_create]: https://docs.phylum.io/docs/phylum_project_create
 
 ## Configure `azure-pipelines.yml`
 

--- a/docs/sync/bitbucket_pipelines.md
+++ b/docs/sync/bitbucket_pipelines.md
@@ -1,0 +1,316 @@
+---
+title: Bitbucket Pipelines Integration
+category: 62cdf6722c2c1602a4b69643
+hidden: false
+---
+# Bitbucket Pipelines Integration
+
+## Quickstart
+
+Add the following "Phylum Analyze" step to a `bitbucket-pipelines.yml` configuration, in one or more pipeline start
+conditions:
+
+```yaml
+# Ensure these variables are set at the repository or workspace level:
+#  - `PHYLUM_API_KEY`: Phylum authentication token
+#  - `BITBUCKET_TOKEN`: repository, project, or workspace access token with `pullrequest` scope
+
+    - step:
+        name: Phylum Analyze
+        image: phylumio/phylum-ci:latest
+        clone:
+          depth: full
+        script:
+          - phylum-ci
+```
+
+## Overview
+
+Once configured for a repository, the Bitbucket Pipelines integration will provide analysis of project
+dependencies from a lockfile. This can happen in a branch or default pipeline as a result of a commit or in a pull
+request (PR) pipeline. For PR pipelines, analyzed dependencies will include any that are added/modified in the PR.
+For branch pipelines, the analyzed dependencies will be determined by comparing the lockfile in the branch to the
+default branch. **All** dependencies will be analyzed when the branch pipeline is run on the default branch.
+
+The results will be provided in the pipeline logs and provided as a comment on the PR. The CI job will return an
+error (i.e., fail the build) if any of the analyzed dependencies fail to meet the project risk thresholds for any
+of the five Phylum risk domains:
+
+* Vulnerability (aka `vul`)
+* Malicious Code (aka `mal`)
+* Engineering (aka `eng`)
+* License (aka `lic`)
+* Author (aka `aut`)
+
+See [Phylum Risk Domains][risk_domains] documentation for more detail.
+
+**NOTE**: It is not enough to have the total project threshold set. Individual risk domain threshold values must be
+set, either in the UI or with `phylum-ci` options, in order to enable analysis results for CI. Otherwise, the risk
+domain is considered disabled and the threshold value used will be zero (0).
+
+There will be no comment if no dependencies were added or modified for a given PR.
+If one or more dependencies are still processing (no results available), then the comment will make that clear and
+the CI job will only fail if dependencies that have _completed analysis results_ do not meet the specified project
+risk thresholds.
+
+[risk_domains]: https://docs.phylum.io/docs/phylum-package-score#risk-domains
+
+## Prerequisites
+
+Bitbucket Cloud is supported for repositories hosted on <https://bitbucket.org/>. Bitbucket Data Center is not
+currently supported.
+
+The Bitbucket Pipelines environment is primarily supported through the use of a Docker image. The pre-requisites for
+using this image are:
+
+* Access to the [phylumio/phylum-ci Docker image][docker_image]
+* A [Bitbucket access token][bb_tokens] with API access
+  * This is only required when using the integration in pull request pipelines
+  * The token needs the `pullrequest` scope
+* A [Phylum token][phylum_tokens] with API access
+  * [Contact Phylum][phylum_contact] or [register][app_register] to gain access
+    * See also [`phylum auth register`][phylum_register] command documentation
+  * Consider using a bot or group account for this token
+* Access to the Phylum API endpoints
+  * That usually means a connection to the internet, optionally via a proxy
+* A `.phylum_project` file exists at the root of the repository
+  * See [`phylum init`][phylum_init] command documentation
+
+[docker_image]: https://hub.docker.com/r/phylumio/phylum-ci/tags
+[bb_tokens]: https://developer.atlassian.com/cloud/bitbucket/rest/intro/#access-tokens
+[phylum_tokens]: https://docs.phylum.io/docs/api-keys
+[phylum_contact]: https://phylum.io/contact-us/
+[app_register]: https://app.phylum.io/register
+[phylum_register]: https://docs.phylum.io/docs/phylum_auth_register
+[phylum_init]: https://docs.phylum.io/docs/phylum_init
+
+## Configure `bitbucket-pipelines.yml`
+
+Phylum analysis of dependencies can be added to existing CI workflows or on it's own with this minimal configuration:
+
+```yaml
+# Ensure these variables are set at the repository or workspace level:
+#  - `PHYLUM_API_KEY`: Phylum authentication token
+#  - `BITBUCKET_TOKEN`: repository, project, or workspace access token with `pullrequest` scope
+
+pipelines:
+  pull-requests:
+    '**':
+      - step:
+          name: Phylum Analyze PR
+          image: phylumio/phylum-ci:latest
+          clone:
+            depth: full
+          script:
+            - phylum-ci
+  default:
+    - step:
+        name: Phylum Analyze branch
+        image: phylumio/phylum-ci:latest
+        clone:
+          depth: full
+        script:
+          - phylum-ci
+```
+
+This configuration contains pipeline definitions for the `pull-requests` and `default` start conditions. It will
+run for _all_ pull requests and pushes to _any_ branch. It does not override any of the `phylum-ci` arguments, which
+are all either optional or default to secure values. Let's take a deeper dive into each part of the configuration:
+
+### User-defined variables
+
+There are several user-defined variables needed to ensure the `phylum-ci` tool is able to perform it's job. Ensure
+these variables are set at the repository or workspace level. See the [user-defined variables][user_vars] documentation
+for more info.
+
+A [Phylum token][phylum_tokens] with API access is required to perform analysis on project dependencies.
+[Contact Phylum][phylum_contact] or [register][app_register] to gain access.
+See also [`phylum auth register`][phylum_register] command documentation and consider using a bot or group account
+for this token. Provide the token value in a user-defined variable named `PHYLUM_API_KEY`.
+
+A Bitbucket token with API access is required to use the API (e.g., to post comments). This can be a repository,
+project, or workspace access token. The token needs the `pullrequest` scope. The name given to the token will be
+the one that appears to post the comments on the PR. Therefore, it might be worth naming it something like
+`Phylum Analysis`. See the [Bitbucket Access Tokens][bb_tokens] documentation for more info.
+
+Note, the Bitbucket token is only required when this Phylum integration is used in
+[pull request pipelines][pr_pipelines]. It is not required when used in branch based pipelines. Provide the token
+value in a user-defined variable named `BITBUCKET_TOKEN`.
+
+Values for the `BITBUCKET_TOKEN` and `PHYLUM_API_KEY` variables are sensitive and should be set as a
+[secured variable][secured_var]. **Care should be taken to protect them appropriately**.
+
+[user_vars]: https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/#User-defined-variables
+[pr_pipelines]: https://support.atlassian.com/bitbucket-cloud/docs/pipeline-start-conditions/#Pull-Requests
+[secured_var]: https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/#Secured-variables
+
+### Pipeline start conditions
+
+There are a handful of different [pipeline start conditions][start_conditions] available to trigger CI. The Phylum
+analysis step can be included in most of these, or even multiple start conditions. The exceptions _may_ be `tags` and
+`custom` pipelines. The example configuration adds the step to both the `pull-requests` and `default` pipelines:
+
+```yaml
+pipelines:
+  # Pipeline definition for pull requests
+  pull-requests:
+    '**':   # Glob pattern to specify all branches
+      - step:
+          # Add the Phylum Analyze step here
+
+  # Pipeline definition for all branches that don't
+  # match a pipeline definition in other sections
+  default:
+    - step:
+        # Add the Phylum Analyze step here
+```
+
+[start_conditions]: https://support.atlassian.com/bitbucket-cloud/docs/pipeline-start-conditions/
+
+### Step name
+
+The step name is optional, can be named what you like, and have different names depending on the pipeline context.
+See the [`name` step option][step_option_name] documentation for more information.
+
+```yaml
+pipelines:
+  pull-requests:
+    '**':
+      - step:
+          name: Phylum Analyze PR    # Name this what you like
+
+  default:
+    - step:
+        name: Phylum Analyze branch  # Name this what you like
+```
+
+[step_option_name]: https://support.atlassian.com/bitbucket-cloud/docs/step-options/#Name
+
+### Docker image selection
+
+Choose the Docker image tag to match your comfort level with image dependencies. `latest` is a "rolling" tag that
+will point to the image created for the latest released `phylum-ci` Python package. A particular version tag
+(e.g., `0.23.1-CLIv4.4.0`) is created for each release of the `phylum-ci` Python package and _should_ not change
+once published.
+
+However, to be certain that the image does not change...or be warned when it does because it won't be available
+anymore...use the SHA256 digest of the tag. The digest can be found by looking at the `phylumio/phylum-ci`
+[tags on Docker Hub][docker_image] or with the command:
+
+```sh
+# NOTE: The command-line JSON processor `jq` is used here for the sake of a one line example. It is not required.
+❯ docker manifest inspect --verbose phylumio/phylum-ci:0.23.1-CLIv4.4.0 | jq .Descriptor.digest
+"sha256:f2840ad448278e26b69a076a93f2c90cb083803243a614f5efb518f032626578"
+```
+
+For instance, at the time of this writing, all of these tag references pointed to the same image:
+
+```yaml
+  # NOTE: These are examples. Only one image line for `phylum-ci` is expected.
+
+  # Not specifying a tag means a default of `latest`
+  image: phylumio/phylum-ci
+
+  # Be more explicit about wanting the `latest` tag
+  image: phylumio/phylum-ci:latest
+
+  # Use a specific release version of the `phylum-ci` package
+  image: phylumio/phylum-ci:0.23.1-CLIv4.4.0
+
+  # Use a specific image with it's SHA256 digest
+  image: phylumio/phylum-ci@sha256:f2840ad448278e26b69a076a93f2c90cb083803243a614f5efb518f032626578
+```
+
+Only the last tag reference, by SHA256 digest, is guaranteed to not have the underlying image it points to change.
+
+See the Docker [image option][image_option] and [build environment][docker_builds] documentation for more information.
+
+[image_option]: https://support.atlassian.com/bitbucket-cloud/docs/docker-image-options/
+[docker_builds]: https://support.atlassian.com/bitbucket-cloud/docs/use-docker-images-as-build-environments/
+
+### Git clone behavior
+
+The `git` version control system is used within the `phylum-ci` package to do things like determine if there was a
+lockfile change and, when specified, report on new dependencies only. Therefore, a full clone of the repository is
+required to ensure that the local working copy is always pristine and history is available to pull the requested
+information.
+
+```yaml
+    - step:
+        clone:
+          depth: full
+```
+
+See the [git clone behavior][clone_behavior] documentation for more information.
+
+[clone_behavior]: https://support.atlassian.com/bitbucket-cloud/docs/git-clone-behavior/
+
+### Script arguments
+
+The script arguments to the Docker image are the way to exert control over the execution of the Phylum analysis.
+The `phylum-ci` script entry point is expected to be called. It has a number of arguments that are all optional
+and defaulted to secure values. To view the arguments, their description, and default values,
+run the script with `--help` output as specified in the [Usage section of the top-level README.md][usage] or
+view the [script options output][script_options] for the latest release.
+
+[script_options]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/script_options.md
+
+```yaml
+  # NOTE: These are examples. Only one script entry line for `phylum-ci` is expected.
+  script:
+    # Use the defaults for all the arguments.
+    # The default behavior is to only analyze newly added dependencies against
+    # the risk domain threshold levels set at the Phylum project level.
+    - phylum-ci
+
+    # Consider all dependencies in analysis results instead of just the newly added ones.
+    # The default is to only analyze newly added dependencies, which can be useful for
+    # existing code bases that may not meet established project risk thresholds yet,
+    # but don't want to make things worse. Specifying `--all-deps` can be useful for
+    # casting the widest net for strict adherence to Quality Assurance (QA) standards.
+    - phylum-ci --all-deps
+
+    # Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in that
+    # they can be named differently and may or may not contain strict dependencies.
+    # In these cases, it is best to specify an explicit lockfile path.
+    - phylum-ci --lockfile requirements-prod.txt
+
+    # Thresholds for the five risk domains may be set at the Phylum project level.
+    # They can be set differently for CI environments to "fail the build."
+    - |
+      phylum-ci \
+        --vul-threshold 60 \
+        --mal-threshold 60 \
+        --eng-threshold 70 \
+        --lic-threshold 90 \
+        --aut-threshold 80
+
+    # Ensure the latest Phylum CLI is installed.
+    - phylum-ci --force-install
+
+    # Install a specific version of the Phylum CLI.
+    - phylum-ci --phylum-release 4.6.0 --force-install
+
+    # Mix and match for your specific use case.
+    - |
+      phylum-ci \
+        --vul-threshold 60 \
+        --mal-threshold 60 \
+        --eng-threshold 70 \
+        --lic-threshold 90 \
+        --aut-threshold 80 \
+        --lockfile requirements-prod.txt \
+        --all-deps
+```
+
+## Alternatives
+
+It is also possible to make direct use of the [`phylum` Python package][pypi] within CI.
+This may be necessary if the Docker image is unavailable or undesirable for some reason.
+To use the `phylum` package, install it and call the desired entry points from a script under your control.
+See the [Installation][installation] and [Usage][usage] sections of the [README file][readme] for more detail.
+
+[pypi]: https://pypi.org/project/phylum/
+[readme]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md
+[installation]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md#installation
+[usage]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md#usage

--- a/docs/sync/git_precommit.md
+++ b/docs/sync/git_precommit.md
@@ -47,13 +47,13 @@ The pre-requisites for using the git `pre-commit` hook are:
   * That usually means a connection to the internet, optionally via a proxy
   * Support for on-premises installs are not available at this time
 * A `.phylum_project` file exists at the root of the repository
-  * See [`phylum project`](https://docs.phylum.io/docs/phylum_project) and
-    [`phylum project create`](https://docs.phylum.io/docs/phylum_project_create) command documentation
+  * See [`phylum init`][phylum_init] command documentation
 
 [phylum_tokens]: https://docs.phylum.io/docs/api-keys
 [phylum_contact]: https://phylum.io/contact-us/
 [app_register]: https://app.phylum.io/register
 [phylum_register]: https://docs.phylum.io/docs/phylum_auth_register
+[phylum_init]: https://docs.phylum.io/docs/phylum_init
 
 **NOTE: If the `phylum` CLI binary is installed locally, it will be used. Otherwise, the hook will install it.**
 

--- a/docs/sync/gitlab_ci.md
+++ b/docs/sync/gitlab_ci.md
@@ -57,7 +57,7 @@ The pre-requisites for using this image are:
 * Access to the Phylum API endpoints
   * That usually means a connection to the internet, optionally via a proxy
 * A `.phylum_project` file exists at the root of the repository
-  * See [`phylum project`][phylum_project] and [`phylum project create`][phylum_project_create] command documentation
+  * See [`phylum init`][phylum_init] command documentation
 
 [gl_saas]: https://docs.gitlab.com/ee/subscriptions/gitlab_com/
 [self_managed]: https://docs.gitlab.com/ee/subscriptions/self_managed/
@@ -67,8 +67,7 @@ The pre-requisites for using this image are:
 [phylum_contact]: https://phylum.io/contact-us/
 [app_register]: https://app.phylum.io/register
 [phylum_register]: https://docs.phylum.io/docs/phylum_auth_register
-[phylum_project]: https://docs.phylum.io/docs/phylum_project
-[phylum_project_create]: https://docs.phylum.io/docs/phylum_project_create
+[phylum_init]: https://docs.phylum.io/docs/phylum_init
 
 ## Configure `.gitlab-ci.yml`
 

--- a/docs/sync/integrations_overview.md
+++ b/docs/sync/integrations_overview.md
@@ -5,41 +5,37 @@ hidden: false
 ---
 # Integrations
 
-Phylum is the future of software supply chain security and is eager to provide integrations across the diverse
-set of environments and ecosystems used by developers.
+Phylum is the future of software supply chain security and is eager to provide
+integrations across the diverse set of environments and ecosystems used by developers.
 
 ## Current Integrations
 
 The current Continuous Integration (CI) platforms/environments supported are:
 
-### GitHub Actions
+|Platform/Environment|Information Link|
+|--------------------|---------------------|
+|GitHub App|[GitHub Marketplace][github_app_docs]|
+|GitHub Actions|[Documentation][github_action_docs]|
+|GitLab CI|[Documentation][gitlab_docs]|
+|Azure Pipelines|[Documentation][azure_docs]|
+|Bitbucket Pipelines|[Documentation][bb_pipelines_docs]|
+|Git `pre-commit` Hooks|[Documentation][precommit_docs]|
 
-See the [GitHub Actions Integration documentation][github_docs] for more info.
-
-[github_docs]: https://docs.phylum.io/docs/github_actions
-
-### GitLab CI
-
-See the [GitLab CI Integration documentation][gitlab_docs] for more info.
-
+[github_app_docs]: https://github.com/marketplace/phylum-io
+[github_action_docs]: https://docs.phylum.io/docs/github_actions
 [gitlab_docs]: https://docs.phylum.io/docs/gitlab_ci
-
-### Azure Pipelines
-
-See the [Azure Pipelines Integration documentation][azure_docs] for more info.
-
 [azure_docs]: https://docs.phylum.io/docs/azure_pipelines
-
-### Git `pre-commit` Hooks
-
-See the [Git `pre-commit` documentation][precommit_docs] for more info.
-
+[bb_pipelines_docs]: https://docs.phylum.io/docs/bitbucket_pipelines
 [precommit_docs]: https://docs.phylum.io/docs/git_precommit
 
 ## Future Integrations
 
-If there is an unsupported use case for managing the security of your dependencies, we want to know about it.
-If there is a way Phylum can be used to make your life as a developer easier, we want to be there for you and do it!
+If there is an unsupported use case for managing the security of your dependencies,
+we want to know about it. If there is a way Phylum can be used to make your life
+as a developer easier, we want to be there for you and do it!
 
-Please let us know what you need by either creating a [GitHub issue](https://github.com/phylum-dev/phylum-ci/issues)
-or sending a note through the general [Contact Us](https://docs.phylum.io/docs/support) options.
+Please let us know what you need by either creating a [GitHub issue][github_issue]
+or sending a note through the general [Contact Us][support] options.
+
+[github_issue]: https://github.com/phylum-dev/phylum-ci/issues
+[support]: https://docs.phylum.io/docs/support

--- a/src/phylum/ci/ci_bitbucket.py
+++ b/src/phylum/ci/ci_bitbucket.py
@@ -1,0 +1,283 @@
+"""Define an implementation for the Bitbucket Pipelines platform.
+
+Bitbucket References:
+  * https://support.atlassian.com/bitbucket-cloud/
+  * https://support.atlassian.com/bitbucket-cloud/resources/
+  * https://support.atlassian.com/bitbucket-cloud/docs/using-access-tokens/
+  * https://support.atlassian.com/bitbucket-cloud/docs/bitbucket-pipelines-configuration-reference/
+  * https://support.atlassian.com/bitbucket-cloud/docs/pipeline-start-conditions/
+  * https://support.atlassian.com/bitbucket-cloud/docs/use-docker-images-as-build-environments/
+  * https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
+  * https://support.atlassian.com/bitbucket-cloud/docs/git-clone-behavior/
+  * https://developer.atlassian.com/cloud/bitbucket/rest/intro/
+  * https://developer.atlassian.com/cloud/bitbucket/rest/intro/#access-tokens
+  * https://developer.atlassian.com/cloud/bitbucket/rest/intro/#repository-object-and-uuid
+  * https://developer.atlassian.com/cloud/bitbucket/rest/intro/#filtering
+  * https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/
+  * https://developer.atlassian.com/cloud/bitbucket/rest/intro/#pullrequest
+"""
+import os
+import shlex
+import subprocess
+import urllib.parse
+from argparse import Namespace
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+import requests
+from backports.cached_property import cached_property
+
+from phylum.ci.ci_base import CIBase
+from phylum.ci.constants import PHYLUM_HEADER
+from phylum.ci.git import git_default_branch_name, git_hash_object, git_remote
+from phylum.constants import PHYLUM_USER_AGENT, REQ_TIMEOUT
+
+BITBUCKET_TOK_ERR_MSG = """
+A Bitbucket access token with API access is required to use the API (e.g., to post comments).
+This can be a repository, project, or workspace token with at least the `pullrequest` scope.
+See the Bitbucket documentation for using access tokens:
+  * https://developer.atlassian.com/cloud/bitbucket/rest/intro/#access-tokens
+"""
+
+
+@lru_cache(maxsize=1)
+def is_in_pr() -> bool:
+    """Indicate if the integration is operating in the context of a pull request pipeline.
+
+    Bitbucket allows for the possibility of running pipelines in different contexts:
+        * On every push, for the last commit in the push (e.g., branch and default pipelines)
+        * For pull requests (e.g., pull request pipelines)
+
+    Knowing when the context is within a pull request helps to ensure the logic used
+    to determine the lockfile changes is correct. It also helps to ensure output is not
+    attempted to be posted when NOT in the context of a review.
+    """
+    # References:
+    # https://github.com/watson/ci-info/blob/master/vendors.json
+    # https://support.atlassian.com/bitbucket-cloud/docs/pipeline-start-conditions/
+    # https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
+    return bool(os.getenv("BITBUCKET_PR_ID"))
+
+
+class CIBitbucket(CIBase):
+    """Provide methods for a Bitbucket Pipelines environment."""
+
+    def __init__(self, args: Namespace) -> None:
+        super().__init__(args)
+        self.ci_platform_name = "Bitbucket Pipelines"
+        if is_in_pr():
+            print(" [-] Pipeline context: pull request pipeline")
+        else:
+            print(" [-] Pipeline context: branch pipeline")
+
+    def _check_prerequisites(self) -> None:
+        """Ensure the necessary pre-requisites are met and bail when they aren't.
+
+        These are the current pre-requisites for operating within a Bitbucket Pipelines Environment:
+          * The environment must actually be within Bitbucket Pipelines
+          * A Bitbucket token providing API access is available when operating in an PR pipeline
+        """
+        super()._check_prerequisites()
+
+        # References:
+        # https://github.com/watson/ci-info/blob/master/vendors.json
+        # https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
+        if os.getenv("BITBUCKET_COMMIT") is None:
+            raise SystemExit(" [!] Must be working within the Bitbucket Pipelines environment")
+
+        # A Bitbucket token with API access is required to use the API (e.g., to post comments).
+        # This can be a repository, project, or workspace access token.
+        # See the Bitbucket Token Overview Documentation for info:
+        # https://developer.atlassian.com/cloud/bitbucket/rest/intro/#access-tokens
+        bitbucket_token = os.getenv("BITBUCKET_TOKEN", "")
+        if not bitbucket_token and is_in_pr():
+            raise SystemExit(f" [!] A Bitbucket access token must be set at `BITBUCKET_TOKEN`: {BITBUCKET_TOK_ERR_MSG}")
+        self._bitbucket_token = bitbucket_token
+
+    @property
+    def bitbucket_token(self) -> str:
+        """Get the Bitbucket token (e.g., repository, project, or workspace access token)."""
+        return self._bitbucket_token
+
+    @property
+    def phylum_label(self) -> str:
+        """Get a custom label for use when submitting jobs with `phylum analyze`."""
+        if is_in_pr():
+            pr_id = os.getenv("BITBUCKET_PR_ID", "unknown-ID")
+            pr_title = os.getenv("BITBUCKET_BRANCH", "unknown-branch")
+            label = f"{self.ci_platform_name}_PR#{pr_id}_{pr_title}"
+        else:
+            current_branch = os.getenv("BITBUCKET_BRANCH", "unknown-branch")
+            lockfile_hash_object = git_hash_object(self.lockfile)
+            label = f"{self.ci_platform_name}_{current_branch}_{lockfile_hash_object[:7]}"
+
+        label = label.replace(" ", "-")
+        return label
+
+    @cached_property
+    def common_lockfile_ancestor_commit(self) -> Optional[str]:
+        """Find the common lockfile ancestor commit.
+
+        Some pre-defined variables are used: https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
+        """
+        remote = git_remote()
+
+        if is_in_pr():
+            # There is no single predefined variable available to provide the PR base SHA.
+            # Instead, it can be determined with a `git merge-base` command, like is done for the CINone implementation.
+            # Reference: https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
+            src_branch = os.getenv("BITBUCKET_BRANCH", "")
+            tgt_branch = os.getenv("BITBUCKET_PR_DESTINATION_BRANCH", "")
+            if not src_branch:
+                raise SystemExit(" [!] The BITBUCKET_BRANCH environment variable must exist and be set")
+            if not tgt_branch:
+                raise SystemExit(" [!] The BITBUCKET_PR_DESTINATION_BRANCH environment variable must exist and be set")
+            print(f" [+] BITBUCKET_BRANCH: {src_branch}")
+            print(f" [+] BITBUCKET_PR_DESTINATION_BRANCH: {tgt_branch}")
+        else:
+            # Assume the working context is within a branch-based CI triggered
+            # build environment when not in a PR (no tag or custom pipelines).
+            src_branch = os.getenv("BITBUCKET_BRANCH", "")
+            if not src_branch:
+                raise SystemExit(" [!] The BITBUCKET_BRANCH environment variable must exist and be set")
+            print(f" [+] BITBUCKET_BRANCH: {src_branch}")
+
+            # This is a best effort attempt since it is finding the merge base between the current commit
+            # and the default branch instead of finding the exact commit from which the branch was created.
+            tgt_branch = f"refs/remotes/{remote}/HEAD"
+
+            # If the current commit is on the default branch, then the merge base will be the same
+            # as the current commit and it won't be possible to provide a useful common lockfile
+            # ancestor commit. In this case, it is better to force analysis of the lockfile and
+            # consider *all* dependencies in analysis results instead of just the newly added ones.
+            if src_branch == git_default_branch_name(remote):
+                print(" [+] Source branch is same as default branch. Proceeding with analysis of all dependencies ...")
+                self._force_analysis = True
+                self._all_deps = True
+
+        # Because the checkout step only fetches the bare minimum needed for the pipeline, and
+        # because the PR merge commit is checked out in a "detached HEAD" state, it is necessary
+        # to be explicit about the refs so that they can be found in this limited git repository.
+        new_ref_prefix = f"refs/remotes/{remote}/"
+        # The source branch is simply the branch name, without any prefix
+        # (e.g., `mybranch` instead of `refs/remotes/origin/mybranch`).
+        src_branch = f"{new_ref_prefix}{src_branch}"
+        if is_in_pr():
+            # The target branch is also simply the branch name, without any prefix, but only when in a PR context.
+            tgt_branch = f"{new_ref_prefix}{tgt_branch}"
+
+        cmd = ["git", "merge-base", src_branch, tgt_branch]
+        shell_escaped_cmd = " ".join(shlex.quote(arg) for arg in cmd)
+        print(f" [*] Finding common lockfile ancestor commit with command: {shell_escaped_cmd}")
+        try:
+            common_ancestor_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
+        except subprocess.CalledProcessError as err:
+            ref_url = "https://support.atlassian.com/bitbucket-cloud/docs/git-clone-behavior/"
+            print(f" [!] The common lockfile ancestor commit could not be found: {err}")
+            print(f" [!] stdout:\n{err.stdout}")
+            print(f" [!] stderr:\n{err.stderr}")
+            print(f" [!] Ensure the git strategy is set to `full clone depth` for repo checkouts: {ref_url}")
+            common_ancestor_commit = None
+
+        return common_ancestor_commit
+
+    def _is_lockfile_changed(self, lockfile: Path) -> bool:
+        """Predicate for detecting if the given lockfile has changed."""
+        diff_base_sha = self.common_lockfile_ancestor_commit
+        print(f" [+] The common lockfile ancestor commit: {diff_base_sha}")
+
+        # Assume no change when there isn't enough information to tell
+        if diff_base_sha is None:
+            return False
+
+        # `--exit-code` will make git exit with 1 if there were differences while 0 means no differences.
+        # Any other exit code is an error and a reason to re-raise.
+        cmd = ["git", "diff", "--exit-code", "--quiet", diff_base_sha, "--", str(lockfile.resolve())]
+        ret = subprocess.run(cmd, check=False)
+        if ret.returncode == 0:
+            return False
+        if ret.returncode == 1:
+            return True
+        # Reference: https://support.atlassian.com/bitbucket-cloud/docs/git-clone-behavior/
+        print(" [!] Consider changing the `clone depth` variable in CI settings to clone/fetch more branch history")
+        ret.check_returncode()
+        return False  # unreachable code but this makes mypy happy
+
+    def post_output(self) -> None:
+        """Post the output of the analysis.
+
+        Post output directly in the logs regardless of the pipeline context.
+        Post output as a comment on the Bitbucket Pipelines Pull Request (PR)
+        when operating in a pull request pipeline.
+        """
+        super().post_output()
+
+        if not is_in_pr():
+            # Can't post the output to the PR when there is no PR
+            return
+
+        # API Reference: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/
+        bitbucket_api_root_url = "https://api.bitbucket.org"
+
+        # BITBUCKET_REPO_FULL_NAME provides the workspace and repository name that corresponds to BITBUCKET_REPO_UUID.
+        # BITBUCKET_REPO_UUID is used in the API calls since it should never change.
+        repo_uuid = os.getenv("BITBUCKET_REPO_UUID")
+        repo_full_name = os.getenv("BITBUCKET_REPO_FULL_NAME")
+
+        pr_id = os.getenv("BITBUCKET_PR_ID")
+
+        # This is the same endpoint for listing all PR comments (GET) and creating new ones (POST)
+        # NOTE: It is possible to make calls with the repository UUID and an empty workspace:
+        #       https://api.bitbucket.org/2.0/repositories/{}/{repo_uuid}/pullrequests/{pull_request_id}/comments
+        #       The braces (even the empty braces) are required in the construction of the endpoint request.
+        #       Reference: https://developer.atlassian.com/cloud/bitbucket/rest/intro/#repository-object-and-uuid
+        pr_comments_api_endpoint = f"/2.0/repositories/{{}}/{repo_uuid}/pullrequests/{pr_id}/comments"
+        url = f"{bitbucket_api_root_url}{pr_comments_api_endpoint}"
+
+        headers = {
+            "User-Agent": PHYLUM_USER_AGENT,
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.bitbucket_token}",
+        }
+
+        # Comments are returned in chronological order. It is possible to use query parameters to our advantage.
+        # Reference: https://developer.atlassian.com/cloud/bitbucket/rest/intro/#filtering
+        query_params = {
+            # Reverse the order
+            "sort": "-updated_on",
+            # Filter out any comments that are not produced by this integration
+            "q": f'content.raw~"{PHYLUM_HEADER}"',
+            # Only return the field containing the raw comment text
+            "fields": "values.content.raw",
+            # Only return the most recently posted Phylum-generated comment
+            "pagelen": "1",
+        }
+
+        query_params_encoded = urllib.parse.urlencode(query_params, safe="/", quote_via=urllib.parse.quote)
+        print(f" [*] Getting all current pull request comments with GET URL: {url}?{query_params_encoded} ...")
+        print(f" [-] The repository UUID {repo_uuid} maps to workspace and repository name: {repo_full_name}")
+        req = requests.get(url, params=query_params, headers=headers, timeout=REQ_TIMEOUT)
+        req.raise_for_status()
+        pr_comments = req.json()
+
+        print(" [*] Checking existing pull request comments for existing content to avoid duplication ...")
+        if pr_comments.get("values"):
+            # NOTE: The API call normally returns all the comments in chronological order. Query parameters are used to
+            #       only return the most recent Phylum comment, if one exists, since this is the only one we care about.
+            print(" [+] The most recently posted Phylum pull request comment was found.")
+            pr_comment = pr_comments.get("values")[0]
+            if pr_comment.get("content", {}).get("raw", "") == self.analysis_output:
+                print(" [+] It contains the same content as the current analysis. Nothing to do.")
+                return
+            print(" [+] It does not contain the same content as the current analysis.")
+        else:
+            print(" [+] No existing Phylum pull request comments found.")
+
+        # If we got here, then the most recent Phylum PR comment does not match the current analysis output or
+        # there were no Phylum PR comments. Either way, create a new PR comment.
+        data = {"content": {"raw": self.analysis_output}}
+        headers["Content-Type"] = "application/json"
+        print(f" [*] Creating new pull request comment with POST URL: {url} ...")
+        response = requests.post(url, json=data, headers=headers, timeout=REQ_TIMEOUT)
+        response.raise_for_status()

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -12,6 +12,7 @@ from phylum import __version__
 from phylum.ci import SCRIPT_NAME
 from phylum.ci.ci_azure import CIAzure
 from phylum.ci.ci_base import CIBase, CIEnvs
+from phylum.ci.ci_bitbucket import CIBitbucket
 from phylum.ci.ci_github import CIGitHub
 from phylum.ci.ci_gitlab import CIGitLab
 from phylum.ci.ci_none import CINone
@@ -42,6 +43,11 @@ def detect_ci_platform(args: argparse.Namespace, remainder: List[str]) -> CIBase
     if os.getenv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI"):
         print(" [+] CI environment detected: Azure Pipelines")
         ci_envs.append(CIAzure(args))
+
+    # Detect Bitbucket Pipelines
+    if os.getenv("BITBUCKET_COMMIT"):
+        print(" [+] CI environment detected: Bitbucket Pipelines")
+        ci_envs.append(CIBitbucket(args))
 
     # Detect Python pre-commit environment
     # This might be a naive strategy for detecting the `pre-commit` case, but there is at least an attempt,

--- a/src/phylum/ci/constants.py
+++ b/src/phylum/ci/constants.py
@@ -14,15 +14,9 @@ SUCCESS_DETAILS = "The Phylum risk analysis is complete and did not identify any
 
 # Expandable HTML providing information on why there was a failure
 FAILURE_DETAILS = """
-        <details>
-        <summary>Background</summary>
-        <br />
-        This repository analyzes the risk of new dependencies. An administrator of
-        this repository has set score requirements for Phylum's five risk domains.
-        <br /><br />
-        If you see this comment, one or more dependencies added to the
-        package manager lockfile have failed Phylum's risk analysis.
-        </details>
+        This repository analyzes risk of new dependencies with Phylum. An administrator
+        of this repository has set score requirements for Phylum's five risk domains.
+        One or more dependencies added to the lockfile failed the risk analysis.
         """.strip()
 
 # String template providing information about an incomplete analysis.


### PR DESCRIPTION
This change adds an integration for the Bitbucket pipelines CI
environment. Specifically, it adds support for the Bitbucket Cloud
ecosystem, which is their CI/CD as a service offering for repositories
hosted at <https://bitbucket.org/>.

This integration detects and handles both branch pipelines and pull
request (PR) pipelines. When in the PR pipeline context, the results
will be written to logs and also as a comment on the PR. PR comments
in Bitbucket do not allow for HTML tags from markdown input and will
display the tags as text instead of a rendered blend of HTML and
Markdown.

It was discovered that not only was Bitbucket affected by the inline
HTML tags, but also the integrations and code paths that do not rely on
posting a PR comment. That included: `pre-commit`, the local use case
`CI-None`, `Azure` and `GitLab` for their branch pipeline output, and
_all_ the log output for integrations with pull request pipeline output
(GitHub, GitLab, Azure, Bitbucket).

It was decided to remove the HTML tags entirely from all Phylum
comments. That means the text will be displayed normally instead of in a
collapsible element. The text was also modified to be more succinct.
This means that for some integrations there will be more text shown by
default (vs. in a collapsible element). It also means that all
integrations will have the same output "look and feel" for failures.

Other actions taken:

* Update the integrations overview documentation
  * Add new entries
    * Bitbucket pipelines
    * GitLab App
  * Format the page to present the information more succinctly
* Update docs to prefer `phylum init` over `phylum project create`

Closes #189

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] ~Have you created sufficient tests?~
  - Still no automated tests
  - Manual testing was performed (see screenshots)
- [x] Have you updated all affected documentation?

## Screenshots

The new "Integrations Overview" page layout can be previewed by [viewing it within this branch](https://github.com/phylum-dev/phylum-ci/blob/bb_integr8/docs/sync/integrations_overview.md)

<img width="1154" alt="image" src="https://user-images.githubusercontent.com/18729796/217993435-baf0c4ea-f052-468a-b611-79deb3788175.png">

---

Using both repository and workspace variables:

<img width="1196" alt="image" src="https://user-images.githubusercontent.com/18729796/217994458-19b8a675-5f11-4890-b2d1-6001f4f9021f.png">

<img width="1196" alt="image" src="https://user-images.githubusercontent.com/18729796/217994521-b90b3e3a-9027-494d-be03-49ab22f58d91.png">

---

Logs from a branch pipeline run after adding a new dependency:

<img width="2062" alt="image" src="https://user-images.githubusercontent.com/18729796/217994979-174f306c-6d1a-4b95-9fc0-928b189dca76.png">

---

Logs from the same branch after updating the dependency to a good version:

<img width="2062" alt="image" src="https://user-images.githubusercontent.com/18729796/217995392-44a5c6dc-2433-4bef-aaa1-4969581899ba.png">

---

PR output after creating a PR with some known bad dependencies:

<img width="1458" alt="image" src="https://user-images.githubusercontent.com/18729796/217996181-547912ec-cf7c-4587-9059-f50cc3328521.png">

---

Log output from that same PR pipeline run:

<img width="2094" alt="image" src="https://user-images.githubusercontent.com/18729796/217996366-30e9b7ad-82fc-47eb-93c0-bcb1d549572e.png">

<img width="1977" alt="image" src="https://user-images.githubusercontent.com/18729796/217996537-a91649e3-84e3-4635-bca1-eaf63b45aae5.png">

---

PR output after reverting to known good deps:

<img width="1530" alt="image" src="https://user-images.githubusercontent.com/18729796/217996939-041c540f-3fa4-42ac-b767-e8b017d9b84f.png">

---

Log output from that same PR pipeline run:

<img width="2550" alt="image" src="https://user-images.githubusercontent.com/18729796/217997094-681a52ae-95ab-4052-b5d9-ab27a6d465e2.png">

---

Adding one more known good dep does not result in a repeat comment:

<img width="1464" alt="image" src="https://user-images.githubusercontent.com/18729796/217997519-db48b04a-8238-46df-83d2-5124652c7cf4.png">

<img width="2550" alt="image" src="https://user-images.githubusercontent.com/18729796/217997464-03b2074c-48fa-4e60-adc6-447a4122c824.png">

---

History of the pipeline runs for the `test_bb` branch that was used to create these screenshots. Notice that the first run took the longest, at 22s, while the rest were much shorter...likely due to Docker image caching.

<img width="1318" alt="image" src="https://user-images.githubusercontent.com/18729796/217997861-4ebc5aa7-703a-4c37-be57-233b624a929d.png">

---

Branch pipeline logs from merging the PR back to `main` (notice that _all_ dependencies are analyzed):

<img width="2045" alt="image" src="https://user-images.githubusercontent.com/18729796/217998952-7b38acde-5c8d-4b60-9735-f4cce0ecf0e7.png">
