### PR TITLE
ci: pin workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,9 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
+  # All GitHub actions should be pinned to an explicit SHA instead of a tag name.
+  # Each pin should include a comment about the version of the action to which it corresponds.
+  # Dependabot will update these comments at the same time that it updates the pin.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/auto_updates.yml
+++ b/.github/workflows/auto_updates.yml
@@ -64,7 +64,7 @@ jobs:
         # NOTE: The git user name and email used for commits is already configured,
         #       by the crazy-max/ghaction-import-gpg action.
         run: |
-          git commit -a -m "build: Bump poetry.lock dependencies and pre-commit hooks"
+          git commit -a -m "build: Bump `poetry.lock` dependencies and `pre-commit` hooks"
           git push --force origin HEAD:workflow-auto-updates
 
       - name: Create Pull Request
@@ -74,11 +74,12 @@ jobs:
           # This PAT is for the `phylum-bot` account and only has the `public_repo` scope to limit privileges.
           github-token: ${{ secrets.GH_RELEASE_PAT }}
           script: |
-            github.rest.pulls.create({
+            const response = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               head: "workflow-auto-updates",
               base: context.ref,
-              title: "build: bump poetry.lock dependencies and pre-commit hooks",
+              title: "build: bump `poetry.lock` dependencies and `pre-commit` hooks",
               body: "Bump dependencies in `poetry.lock` and hooks in `.pre-commit-config.yaml`.",
             });
+            console.log(response);

--- a/.github/workflows/auto_updates.yml
+++ b/.github/workflows/auto_updates.yml
@@ -23,11 +23,11 @@ jobs:
         shell: bash
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       # This GPG key is for the `phylum-bot` account and used in order to ensure commits are signed/verified
       - name: Import GPG key for bot account
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549 # v5.2.0
         with:
           gpg_private_key: ${{ secrets.PHYLUM_BOT_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PHYLUM_BOT_GPG_PASSPHRASE }}
@@ -43,7 +43,7 @@ jobs:
         run: poetry config virtualenvs.in-project true
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'poetry'
@@ -69,7 +69,7 @@ jobs:
 
       - name: Create Pull Request
         if: ${{ steps.commit.outcome == 'success' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6.4.0
         with:
           # This PAT is for the `phylum-bot` account and only has the `public_repo` scope to limit privileges.
           github-token: ${{ secrets.GH_RELEASE_PAT }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,7 +66,7 @@ jobs:
           echo "REL_VER_WITHOUT_v=$REL_VER_WITHOUT_v" >> $GITHUB_ENV
 
       - name: Checkout the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           # This will ensure the checkout matches the tag for the latest release
           ref: ${{ env.REL_VER_WITH_v }}

--- a/.github/workflows/phylum_analyze_pr.yml
+++ b/.github/workflows/phylum_analyze_pr.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           fetch-depth: 0
       - name: Analyze poetry.lock file
-        uses: phylum-dev/phylum-analyze-pr-action@v2
+        uses: phylum-dev/phylum-analyze-pr-action@53d203dd18c41350a673bcc236aa05337eb6edf3 # v2.1.1
         with:
           phylum_token: ${{ secrets.PHYLUM_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -31,7 +31,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           # `python-semantic-release` needs full history to properly determine the next release version
           fetch-depth: 0
@@ -45,7 +45,7 @@ jobs:
           poetry config repositories.testpypi https://test.pypi.org/legacy/
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'poetry'
@@ -70,7 +70,7 @@ jobs:
         run: poetry build -vvv
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: dist
           path: ./dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       DOCKER_BUILDKIT: 1
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           # `python-semantic-release` needs full history to properly determine the next release version
           fetch-depth: 0
@@ -56,7 +56,7 @@ jobs:
 
       # This GPG key is for the `phylum-bot` account and used in order to ensure commits and tags are signed/verified
       - name: Import GPG key for bot account
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549 # v5.2.0
         with:
           gpg_private_key: ${{ secrets.PHYLUM_BOT_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PHYLUM_BOT_GPG_PASSPHRASE }}
@@ -73,7 +73,7 @@ jobs:
           poetry config repositories.testpypi https://test.pypi.org/legacy/
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'poetry'
@@ -208,9 +208,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       - name: Update v2-latest using rdme
-        uses: readmeio/rdme@v8
+        uses: readmeio/rdme@8015101d7a10d3810d65583d947d6a17a57ff693 # v8.5.0
         with:
           rdme: docs ./docs/sync --key=${{ secrets.README_API }} --version=2-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       - name: Install poetry
         run: pipx install poetry
@@ -32,7 +32,7 @@ jobs:
         run: poetry config virtualenvs.in-project true
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'poetry'
@@ -62,7 +62,7 @@ jobs:
       DOCKER_BUILDKIT: 1
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       - name: Install poetry
         run: pipx install poetry
@@ -71,7 +71,7 @@ jobs:
         run: poetry config virtualenvs.in-project true
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'poetry'

--- a/.phylum_project
+++ b/.phylum_project
@@ -1,6 +1,7 @@
 id: 56f7f1b0-7f63-47a4-9f5e-8194772b2e13
 name: phylum-ci
-created_at: 2022-12-30T10:24:24.678837-06:00
+created_at: 2023-02-17T09:53:00.474315-06:00
 group_name: phylum_bot
-lockfile_type: poetry
-lockfile_path: poetry.lock
+lockfiles:
+- path: poetry.lock
+  type: poetry

--- a/docs/sync/bitbucket_pipelines.md
+++ b/docs/sync/bitbucket_pipelines.md
@@ -13,7 +13,7 @@ conditions:
 ```yaml
 # Ensure these variables are set at the repository or workspace level:
 #  - `PHYLUM_API_KEY`: Phylum authentication token
-#  - `BITBUCKET_TOKEN`: repository, project, or workspace access token with `pullrequest` scope
+#  - `BITBUCKET_TOKEN`: repository, project, or workspace access token with `pullrequest` (read) scope
 
     - step:
         name: Phylum Analyze
@@ -66,7 +66,7 @@ using this image are:
 * Access to the [phylumio/phylum-ci Docker image][docker_image]
 * A [Bitbucket access token][bb_tokens] with API access
   * This is only required when using the integration in pull request pipelines
-  * The token needs the `pullrequest` scope
+  * The token needs the `pullrequest` (read) scope
 * A [Phylum token][phylum_tokens] with API access
   * [Contact Phylum][phylum_contact] or [register][app_register] to gain access
     * See also [`phylum auth register`][phylum_register] command documentation
@@ -91,7 +91,7 @@ Phylum analysis of dependencies can be added to existing CI workflows or on it's
 ```yaml
 # Ensure these variables are set at the repository or workspace level:
 #  - `PHYLUM_API_KEY`: Phylum authentication token
-#  - `BITBUCKET_TOKEN`: repository, project, or workspace access token with `pullrequest` scope
+#  - `BITBUCKET_TOKEN`: repository, project, or workspace access token with `pullrequest` (read) scope
 
 pipelines:
   pull-requests:
@@ -129,8 +129,8 @@ See also [`phylum auth register`][phylum_register] command documentation and con
 for this token. Provide the token value in a user-defined variable named `PHYLUM_API_KEY`.
 
 A Bitbucket token with API access is required to use the API (e.g., to post comments). This can be a repository,
-project, or workspace access token. The token needs the `pullrequest` scope. The name given to the token will be
-the one that appears to post the comments on the PR. Therefore, it might be worth naming it something like
+project, or workspace access token. The token needs the `pullrequest` (read) scope. The name given to the token will
+be the one that appears to post the comments on the PR. Therefore, it might be worth naming it something like
 `Phylum Analysis`. See the [Bitbucket Access Tokens][bb_tokens] documentation for more info.
 
 Note, the Bitbucket token is only required when this Phylum integration is used in


### PR DESCRIPTION
All GitHub actions were pinned to an explicit SHA instead of a tag name/version. Each pin includes a comment about the version it represents, which will be updated automatically by Dependabot at the same time as the pin.

Other changes made in this PR:
* Update Phylum project file to current format
* Format and refactor the auto_updates workflow
* Be more explicit about the Bitbucket token scope access
  * This was based on feedback from @furi0us333 after going through the documentation in an actual Bitbucket Pipepines configuration

Closes #202

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] ~Have you created sufficient tests?~
- [x] Have you updated all affected documentation?
