### PR TITLE
feat!: allow `.phylum_project` file to be optional

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,8 +3,8 @@
 # See https://pre-commit.com for more information
 ---
 - id: phylum
-  name: analyze lockfile with phylum
-  description: Run `phylum` on a dependency lockfile
+  name: analyze lockfiles with phylum
+  description: Run `phylum` on dependency lockfiles
   entry: phylum-ci
   language: python
   stages: [commit]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,8 @@ However, some entries may be manually edited, where it helps for clarity and und
 * Support RSA SHA256 signature verification in `phylum-init` ([#165](https://github.com/phylum-dev/phylum-ci/issues/165)) ([`4fad7dd`](https://github.com/phylum-dev/phylum-ci/commit/4fad7ddac071de506e0ec684d31b10e4e658ccca))
 
 ### Breaking
-* CLI installs prior to v3.12.0 are no longer supported. BREAKING CHANGE: CLI installs and upgrades can no longer be confirmed with `.minisig` minisign signatures and must instead use `.signature` RSA SHA256 based signatures. ([`4fad7dd`](https://github.com/phylum-dev/phylum-ci/commit/4fad7ddac071de506e0ec684d31b10e4e658ccca))
+* CLI installs prior to v3.12.0 are no longer supported.
+* CLI installs and upgrades can no longer be confirmed with `.minisig` minisign signatures and must instead use `.signature` RSA SHA256 based signatures. ([`4fad7dd`](https://github.com/phylum-dev/phylum-ci/commit/4fad7ddac071de506e0ec684d31b10e4e658ccca))
 
 ## v0.19.0 (2022-11-15)
 ### Feature

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,7 +208,7 @@ Before you submit a pull request, check that it meets these guidelines:
 * Have you created sufficient tests?
 * Have you updated all affected documentation?
 
-The pull request should work for Python 3.6, 3.7, 3.8, 3.9, 3.10, and 3.11.
+The pull request should work for Python 3.7, 3.8, 3.9, 3.10, and 3.11.
 Check <https://github.com/phylum-dev/phylum-ci/actions> and make sure that the tests
 pass for all supported Python versions.
 
@@ -219,23 +219,30 @@ squash merging) or any included commit (when rebase merging) must adhere to the 
 important because the conventional commits made to the default branch are used to automatically bump release versions,
 populate the changelog, and create releases.
 
+## Release Process
+
+See the [release process][release] for more info about how to cut a release and the automation workflows involved.
+
+[release]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/release_process.md
+
 ## Tips
 
 To run a subset of tests from the tox test environments, call `tox` from `poetry` and
 interact with `pytest` by passing additional positional arguments:
 
 ```sh
+# passing additional options to pytest requires using the double dash
+# escape twice, once for escaping `poetry` and again for escaping `tox`
+poetry run -- tox -e py310 -- --help
+
 # run a specific test module across all test environments
-poetry run tox tests/unit/test_package_metadata.py
+poetry run -- tox -- tests/unit/test_package_metadata.py
 
 # run a specific test module across a specific test environment
-poetry run tox -e py39 tests/unit/test_package_metadata.py
+poetry run -- tox -e py39 -- tests/unit/test_package_metadata.py
 
 # run a specific test function within a test module, in a specific test environment
-poetry run tox -e py310 tests/unit/test_package_metadata.py::test_python_version
-
-# passing additional options to pytest requires using the double dash escape
-poetry run tox -e py310 -- --help
+poetry run -- tox -e py310 -- tests/unit/test_package_metadata.py::test_python_version
 ```
 
 To run a script entry point with the local checkout of the code (in develop mode), use `poetry`:
@@ -248,8 +255,9 @@ poetry install --sync
 poetry run phylum-init -h
 ```
 
-To iterate during development of the `phylum-ci` integrations, it can be helpful to force the analysis of the lockfile,
-even when it has not changed. It can also be useful to ensure all dependencies are considered. To do so, use the flags:
+To iterate during development of the `phylum-ci` integrations, it can be helpful to force the analysis of the
+lockfile(s), even when it has not changed. It can also be useful to ensure all dependencies are considered.
+To do so, use the flags:
 
 ```sh
 # long form options

--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ Utilities for integrating Phylum into CI pipelines (and beyond)
 [workflow_test]: https://github.com/phylum-dev/phylum-ci/actions/workflows/test.yml
 [CoC]: https://github.com/phylum-dev/phylum-ci/blob/main/CODE_OF_CONDUCT.md
 [pre-commit]: https://github.com/pre-commit/pre-commit
-[contributing]: https://github.com/phylum-dev/phylum-ci/blob/main/CONTRIBUTING.md
-[changelog]: https://github.com/phylum-dev/phylum-ci/blob/main/CHANGELOG.md
-[security]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/security.md
 [downloads]: https://pepy.tech/project/phylum
 
 ## Installation and usage
@@ -76,7 +73,7 @@ docker run --rm phylumio/phylum-ci phylum-ci --help
 # Export a Phylum token (e.g., from `phylum auth token`)
 export PHYLUM_API_KEY=$(phylum auth token)
 
-# Run it from a git repo directory containing a `.phylum_project` and a lockfile
+# Run it from a git repo directory containing at least one lockfile
 docker run -it --rm -e PHYLUM_API_KEY --mount type=bind,src=$(pwd),dst=/phylum -w /phylum phylumio/phylum-ci
 ```
 
@@ -93,8 +90,8 @@ version of the Phylum CLI, in the form of `<phylum-ci version>-CLIv<Phylum CLI v
 # Get the most current release of *both* `phylum-ci` and the Phylum CLI
 docker pull phylumio/phylum-ci:latest
 
-# Get the image with `phylum-ci` version 0.13.0 and Phylum CLI version 3.8.0
-docker pull phylumio/phylum-ci:0.13.0-CLIv3.8.0
+# Get the image with `phylum-ci` version 0.24.1 and Phylum CLI version 4.7.0
+docker pull phylumio/phylum-ci:0.24.1-CLIv4.7.0
 ```
 
 #### `phylum-init` Script Entry Point
@@ -120,23 +117,18 @@ The script can be used locally or from within a Continuous Integration (CI) envi
 It will attempt to detect the CI platform based on the environment from which it is run and act accordingly.
 The current CI platforms/environments supported are:
 
-* GitLab CI
-  * See the [GitLab CI Integration documentation][gitlab_docs] for more info
+|Platform/Environment|Information Link|
+|--------------------|---------------------|
+|GitHub Actions|[Documentation][github_docs]|
+|GitLab CI|[Documentation][gitlab_docs]|
+|Azure Pipelines|[Documentation][azure_docs]|
+|Bitbucket Pipelines|[Documentation][bb_pipelines_docs]|
+|Git `pre-commit` Hooks|[Documentation][precommit_docs]|
 
-* GitHub Actions
-  * See the [GitHub Actions Integration documentation][github_docs] for more info
-
-* Azure Pipelines
-  * See the [Azure Pipelines Integration documentation][azure_docs] for more info
-
-* Git `pre-commit` Hooks
-  * See the [Git `pre-commit` Integration documentation][precommit_docs] for more info
-
-* None (local use)
-  * This is the "fall-through" case used when no other environment is detected
-  * Can be useful to analyze lockfiles locally, prior to or after submitting a pull/merge request (PR/MR) to a CI system
-    * Establishing a successful submission prior to submitting a PR/MR to a CI system
-    * Troubleshooting after submitting a PR/MR to a CI system and getting unexpected results
+There is also support for local use. This is the "fall-through" case used when no other environment is detected.
+This can be useful to analyze lockfiles locally, prior to or after submitting a pull/merge request (PR/MR) to a CI
+system. It can also help in establishing a successful submission prior to submitting a PR/MR to a CI system.
+Additionally, local use can aid troubleshooting after submitting a PR/MR to a CI system and getting unexpected results.
 
 The options for `phylum-ci`, automatically updated to be current for the latest release:
 
@@ -144,9 +136,10 @@ The options for `phylum-ci`, automatically updated to be current for the latest 
 
 ![phylum-ci options](https://raw.githubusercontent.com/phylum-dev/phylum-ci/main/docs/img/phylum-ci_options.svg)
 
-[gitlab_docs]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/sync/gitlab_ci.md
 [github_docs]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/sync/github_actions.md
+[gitlab_docs]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/sync/gitlab_ci.md
 [azure_docs]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/sync/azure_pipelines.md
+[bb_pipelines_docs]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/sync/bitbucket_pipelines.md
 [precommit_docs]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/sync/git_precommit.md
 
 ## License
@@ -167,6 +160,8 @@ If not, see <https://www.gnu.org/licenses/gpl.html> or write to `phylum@phylum.i
 Suggestions and help are welcome. Feel free to open an issue or otherwise contribute.
 More information is available on the [contributing documentation][contributing] page.
 
+[contributing]: https://github.com/phylum-dev/phylum-ci/blob/main/CONTRIBUTING.md
+
 ## Code of Conduct
 
 Everyone participating in the `phylum-ci` project, and in particular in the issue tracker and pull requests, is
@@ -178,6 +173,8 @@ expected to treat other people with respect and more generally to follow the gui
 Found a security issue in this repository? See the [security policy][security]
 for details on coordinated disclosure.
 
+[security]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/security.md
+
 ## Change log
 
 All notable changes to this project are documented in the [CHANGELOG][changelog].
@@ -188,3 +185,5 @@ The entries in the changelog are primarily automatically generated through the u
 [conventional commits](https://www.conventionalcommits.org) and the
 [Python Semantic Release](https://python-semantic-release.readthedocs.io/en/latest/index.html) tool.
 However, some entries may be manually edited, where it helps for clarity and understanding.
+
+[changelog]: https://github.com/phylum-dev/phylum-ci/blob/main/CHANGELOG.md

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -40,7 +40,7 @@ approach, an option is exposed to optionally publish the built package to the
 environment. For example using `pipx` to run a specific developmental release version:
 
 ```sh
-pipx run -i https://test.pypi.org/simple/ --spec "phylum==0.2.0.dev19" --pip-args="--extra-index-url=https://pypi.org/simple/" phylum-init -h
+pipx run -i https://test.pypi.org/simple/ --spec "phylum==0.24.2.dev183" --pip-args="--extra-index-url=https://pypi.org/simple/" phylum-init -h
 ```
 
 ### Release workflow

--- a/docs/sync/azure_pipelines.md
+++ b/docs/sync/azure_pipelines.md
@@ -11,9 +11,9 @@ Azure Pipelines [supports several different source repositories][supported_repos
 hosted on [Azure Repos Git][azure_repos_git] and [GitHub][github_repos].
 
 Once configured for a repository, the Azure Pipelines integration will provide analysis of project dependencies from
-a lockfile. This can happen in a branch pipeline run from a CI trigger or in a Pull Request (PR) pipeline run from a
+lockfiles. This can happen in a branch pipeline run from a CI trigger or in a Pull Request (PR) pipeline run from a
 PR trigger. For PR triggered pipelines, analyzed dependencies will include any that are added/modified in the PR.
-For CI triggered pipelines, the analyzed dependencies will be determined by comparing the lockfile in the branch to
+For CI triggered pipelines, the analyzed dependencies will be determined by comparing lockfiles in the branch to
 the default branch. **All** dependencies will be analyzed when the CI triggered pipeline is run on the default branch.
 
 The results will be provided in the pipeline logs and provided as a comment in a thread on the PR. The CI job will
@@ -74,8 +74,6 @@ The pre-requisites for using this image are:
 * Access to the Phylum API endpoints
   * That usually means a connection to the internet, optionally via a proxy
   * Support for on-premises installs are not available at this time
-* A `.phylum_project` file exists at the root of the repository
-  * See [`phylum init`] command documentation
 
 [docker_image]: https://hub.docker.com/r/phylumio/phylum-ci/tags
 [azure_auth]: https://learn.microsoft.com/azure/devops/integrate/get-started/authentication/authentication-guidance
@@ -286,6 +284,9 @@ view the [script options output][script_options] for the latest release.
       # they can be named differently and may or may not contain strict dependencies.
       # In these cases, it is best to specify an explicit lockfile path.
       - script: phylum-ci --lockfile requirements-prod.txt
+
+      # Specify multiple explicit lockfile paths
+      - script: phylum-ci --lockfile requirements-prod.txt path/to/lock.file
 
       # Thresholds for the five risk domains may be set at the Phylum project level.
       # They can be set differently for CI environments to "fail the build."

--- a/docs/sync/bitbucket_pipelines.md
+++ b/docs/sync/bitbucket_pipelines.md
@@ -27,9 +27,9 @@ conditions:
 ## Overview
 
 Once configured for a repository, the Bitbucket Pipelines integration will provide analysis of project
-dependencies from a lockfile. This can happen in a branch or default pipeline as a result of a commit or in a pull
+dependencies from lockfiles. This can happen in a branch or default pipeline as a result of a commit or in a pull
 request (PR) pipeline. For PR pipelines, analyzed dependencies will include any that are added/modified in the PR.
-For branch pipelines, the analyzed dependencies will be determined by comparing the lockfile in the branch to the
+For branch pipelines, the analyzed dependencies will be determined by comparing lockfiles in the branch to the
 default branch. **All** dependencies will be analyzed when the branch pipeline is run on the default branch.
 
 The results will be provided in the pipeline logs and provided as a comment on the PR. The CI job will return an
@@ -73,8 +73,6 @@ using this image are:
   * Consider using a bot or group account for this token
 * Access to the Phylum API endpoints
   * That usually means a connection to the internet, optionally via a proxy
-* A `.phylum_project` file exists at the root of the repository
-  * See [`phylum init`][phylum_init] command documentation
 
 [docker_image]: https://hub.docker.com/r/phylumio/phylum-ci/tags
 [bb_tokens]: https://developer.atlassian.com/cloud/bitbucket/rest/intro/#access-tokens
@@ -82,7 +80,6 @@ using this image are:
 [phylum_contact]: https://phylum.io/contact-us/
 [app_register]: https://app.phylum.io/register
 [phylum_register]: https://docs.phylum.io/docs/phylum_auth_register
-[phylum_init]: https://docs.phylum.io/docs/phylum_init
 
 ## Configure `bitbucket-pipelines.yml`
 
@@ -274,6 +271,9 @@ view the [script options output][script_options] for the latest release.
     # they can be named differently and may or may not contain strict dependencies.
     # In these cases, it is best to specify an explicit lockfile path.
     - phylum-ci --lockfile requirements-prod.txt
+
+    # Specify multiple explicit lockfile paths
+    - phylum-ci --lockfile requirements-prod.txt path/to/lock.file
 
     # Thresholds for the five risk domains may be set at the Phylum project level.
     # They can be set differently for CI environments to "fail the build."

--- a/docs/sync/git_precommit.md
+++ b/docs/sync/git_precommit.md
@@ -46,14 +46,11 @@ The pre-requisites for using the git `pre-commit` hook are:
 * Access to the Phylum API endpoints
   * That usually means a connection to the internet, optionally via a proxy
   * Support for on-premises installs are not available at this time
-* A `.phylum_project` file exists at the root of the repository
-  * See [`phylum init`][phylum_init] command documentation
 
 [phylum_tokens]: https://docs.phylum.io/docs/api-keys
 [phylum_contact]: https://phylum.io/contact-us/
 [app_register]: https://app.phylum.io/register
 [phylum_register]: https://docs.phylum.io/docs/phylum_auth_register
-[phylum_init]: https://docs.phylum.io/docs/phylum_init
 
 **NOTE: If the `phylum` CLI binary is installed locally, it will be used. Otherwise, the hook will install it.**
 
@@ -93,10 +90,10 @@ Two common customization keys for the `phylum` hook are `files` and `args`:
 
 ### File Control
 
-The `files` key in the hook configuration file is the way to ensure the hook only runs when the specified
-lockfile has changed, saving execution time.
+The `files` key in the hook configuration file is the way to ensure the hook only runs when specified
+lockfiles have changed, saving execution time.
 
-The value for the `files` key is a [Python regular expression][re] and are matched with `re.search`.
+The value for the `files` key is a [Python regular expression][re] and is matched with `re.search`.
 
 [re]: https://docs.python.org/3/library/re.html#regular-expression-syntax
 
@@ -110,8 +107,20 @@ The value for the `files` key is a [Python regular expression][re] and are match
         files: ^poetry\.lock$
 
         # Specify `requirements-*.txt` files
-        # NOTE: An explicit lockfile should still be specified in the `args` key
+        # NOTE: Explicit lockfiles should still be specified in the `args` key
         files: ^requirements-.*\.txt$
+
+        # Specify both `package-lock.json` and `poetry.lock` on one line
+        files: ^(package-lock\.json|poetry\.lock)$
+
+        # Specify multiple files using the inline `re.VERBOSE` flag `(?x)`
+        files: |
+            (?x)^(
+                package-lock\.json|
+                poetry\.lock|
+                requirements-.*\.txt|
+                path/to/lock\.file
+            )$
 ```
 
 ### Argument Control
@@ -145,6 +154,13 @@ with `--help` output as specified in the [Usage section of the top-level README.
         # they can be named differently and may or may not contain strict dependencies.
         # In these cases, it is best to specify an explicit lockfile path.
         args: [--lockfile=requirements-prod.txt]
+
+        # Specify multiple explicit lockfile paths
+        args:
+          - --lockfile=requirements-prod.txt
+          - --lockfile=package-lock.json
+          - --lockfile=poetry.lock
+          - --lockfile=path/to/lock.file
 
         # Thresholds for the five risk domains may be set at the Phylum project level.
         # They can be set differently for the hook.

--- a/docs/sync/github_actions.md
+++ b/docs/sync/github_actions.md
@@ -14,7 +14,7 @@ Full documentation can be found there or by viewing the [Phylum Analyze PR actio
 
 The Phylum Analyze PR action is a [Docker container action][container_action].
 This has the advantage of ensuring everything needed to work with Phylum for analyzing a PR
-for dependencies in a lockfile is self contained and known to function as a single unit.
+for dependencies in lockfiles is self contained and known to function as a single unit.
 There are some disadvantages and some users may prefer a different solution.
 
 [marketplace]: https://github.com/marketplace/actions/phylum-analyze-pr

--- a/docs/sync/gitlab_ci.md
+++ b/docs/sync/gitlab_ci.md
@@ -7,10 +7,10 @@ hidden: false
 
 ## Overview
 
-Once configured for a repository, the GitLab CI integration will provide analysis of project dependencies from a
-lockfile. This can happen in a branch pipeline as a result of a commit or in a Merge Request (MR) pipeline. For
+Once configured for a repository, the GitLab CI integration will provide analysis of project dependencies from
+lockfiles. This can happen in a branch pipeline as a result of a commit or in a Merge Request (MR) pipeline. For
 MR pipelines, analyzed dependencies will include any that are added/modified in the MR. For branch pipelines, the
-analyzed dependencies will be determined by comparing the lockfile in the branch to the default branch. **All**
+analyzed dependencies will be determined by comparing lockfiles in the branch to the default branch. **All**
 dependencies will be analyzed when the branch pipeline is run on the default branch.
 
 The results will be provided in the pipeline logs and provided as a note (comment) on the MR. The CI job will
@@ -56,8 +56,6 @@ The pre-requisites for using this image are:
   * Consider using a bot or group account for this token
 * Access to the Phylum API endpoints
   * That usually means a connection to the internet, optionally via a proxy
-* A `.phylum_project` file exists at the root of the repository
-  * See [`phylum init`][phylum_init] command documentation
 
 [gl_saas]: https://docs.gitlab.com/ee/subscriptions/gitlab_com/
 [self_managed]: https://docs.gitlab.com/ee/subscriptions/self_managed/
@@ -67,7 +65,6 @@ The pre-requisites for using this image are:
 [phylum_contact]: https://phylum.io/contact-us/
 [app_register]: https://app.phylum.io/register
 [phylum_register]: https://docs.phylum.io/docs/phylum_auth_register
-[phylum_init]: https://docs.phylum.io/docs/phylum_init
 
 ## Configure `.gitlab-ci.yml`
 
@@ -265,6 +262,9 @@ view the [script options output][script_options] for the latest release.
     # they can be named differently and may or may not contain strict dependencies.
     # In these cases, it is best to specify an explicit lockfile path.
     - phylum-ci --lockfile requirements-prod.txt
+
+    # Specify multiple explicit lockfile paths
+    - phylum-ci --lockfile requirements-prod.txt path/to/lock.file
 
     # Thresholds for the five risk domains may be set at the Phylum project level.
     # They can be set differently for CI environments to "fail the build."

--- a/poetry.lock
+++ b/poetry.lock
@@ -405,6 +405,82 @@ files = [
 ]
 
 [[package]]
+name = "dulwich"
+version = "0.21.3"
+description = "Python Git Library"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "dulwich-0.21.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:25376efc6ea2ee9daa868a120d4f9c905dcb7774f68931be921fba41a657f58a"},
+    {file = "dulwich-0.21.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9213a114dd19cfca19715088f12f143e918c5e1b4e26f7acf1a823d7da9e1413"},
+    {file = "dulwich-0.21.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:baf5b3b901272837bee2311ecbd28fdbe960d288a070dc72bdfdf48cfcbb8090"},
+    {file = "dulwich-0.21.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7b8cb38a93de87b980f882f0dcd19f2e3ad43216f34e06916315cb3a03e6964"},
+    {file = "dulwich-0.21.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f4f8ff776ca38ce272d9c164a7f77db8a54a8cad6d9468124317adf8732be07d"},
+    {file = "dulwich-0.21.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:03ed9448f2944166e28aa8d3f4c8feeceb5c6880e9ffe5ab274869d45abd9589"},
+    {file = "dulwich-0.21.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6618e35268d116bffddd6dbec360a40c54b3164f8af0513d95d8698f36e2eacc"},
+    {file = "dulwich-0.21.3-cp310-cp310-win32.whl", hash = "sha256:d7ad871d044a96f794170f2434e832c6b42804d0b53721377d03f865245cd273"},
+    {file = "dulwich-0.21.3-cp310-cp310-win_amd64.whl", hash = "sha256:ba3d42cd83d7f89b9c1b2f76df971e8ab58815f8060da4dc67b9ae9dba1b34cc"},
+    {file = "dulwich-0.21.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:092829f27a2c87cdf6b6523216822859ecf01d281ddfae0e58cad1f44adafff6"},
+    {file = "dulwich-0.21.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bb54fe45deb55e4caae4ea2c1dba93ee79fb5c377287b14056d4c30fb156920e"},
+    {file = "dulwich-0.21.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d0ac29adf468a838884e1507d81e872096238c76fe7da7f3325507e4390b6867"},
+    {file = "dulwich-0.21.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8d1837c3d2d8e56aacc13a91ec7540b3baadc1b254fbdf225a2d15b72b654c3"},
+    {file = "dulwich-0.21.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1cf246530b8d574b33a9614da76881b96c190c0fe78f76ab016c88082c0da051"},
+    {file = "dulwich-0.21.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:be0801ae3f9017c6437bcd23a4bf2b2aa88e465f7efeed4b079944d07e3df994"},
+    {file = "dulwich-0.21.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5a1137177b62eec949c0f1564eef73920f842af5ebfc260c20d9cd47e8ecd519"},
+    {file = "dulwich-0.21.3-cp311-cp311-win32.whl", hash = "sha256:b09b6166876d2cba8f331a548932b09e11c9386db0525c9ca15c399b666746fc"},
+    {file = "dulwich-0.21.3-cp311-cp311-win_amd64.whl", hash = "sha256:250ec581682af846cb85844f8032b7642dd278006b1c3abd5e8e718eba0b1b00"},
+    {file = "dulwich-0.21.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ad7de37c9ff817bc5d26f89100f87b7f1a5cc25e5eaaa54f11dc66cca9652e4"},
+    {file = "dulwich-0.21.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b541bd58426a30753ab12cc024ba29b6699d197d9d0d9f130b9768ab20e0e6a"},
+    {file = "dulwich-0.21.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f8d45f5fcdb52c60c902a951f549faad9979314e7e069f4fa3d14eb409b16a0"},
+    {file = "dulwich-0.21.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:a98989ff1ed20825728495ffb859cd700a120850074184d2e1ec08a0b1ab8ab3"},
+    {file = "dulwich-0.21.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:33f73e8f902c6397cc73a727db1f6e75add8ce894bfbb1a15daa2f7a4138a744"},
+    {file = "dulwich-0.21.3-cp37-cp37m-win32.whl", hash = "sha256:a2e6270923bf5ec0e9f720d689579a904f401c62193222d000d8cb8e880684e9"},
+    {file = "dulwich-0.21.3-cp37-cp37m-win_amd64.whl", hash = "sha256:1799c04bd53ec404ebd2c82c1d66197a31e5f0549c95348bb7d3f57a28c94241"},
+    {file = "dulwich-0.21.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:c80ade5cdb0ea447e7f43b32abc2f4a628dcdfa64dc8ee5ab4262987e5e0814f"},
+    {file = "dulwich-0.21.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:40f8f461eba87ef2e8ce0005ca2c12f1b4fdbbafd3a717b8570060d7cd35ee0c"},
+    {file = "dulwich-0.21.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:af7a417e19068b1abeb9addd3c045a2d6e40d15365af6aa3cbe2d47305b5bb11"},
+    {file = "dulwich-0.21.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:026427b5ef0f1fe138ed22078e49b00175b58b11e5c18e2be00f06ee0782603b"},
+    {file = "dulwich-0.21.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae38c6d24d7aff003a241c8f1dd268eb1c6f7625d91e3435836ff5a5eed05ce5"},
+    {file = "dulwich-0.21.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:512bb4b04e403a38860f7eb22abeeaefba3c4a9c08bc7beec8885494c5828034"},
+    {file = "dulwich-0.21.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:3b048f84c94c3284f29bf228f1094ccc48763d76ede5c35632153bd7f697b846"},
+    {file = "dulwich-0.21.3-cp38-cp38-win32.whl", hash = "sha256:a275b3a579dfd923d6330f6e5c2886dbdb5da4e004c5abecb107eb347d301412"},
+    {file = "dulwich-0.21.3-cp38-cp38-win_amd64.whl", hash = "sha256:208d01a9cda1bae16c92e8c54e806701a16969346aba44b8d6921c6c227277a9"},
+    {file = "dulwich-0.21.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:73f9feba3da1ae66f0b521d7c2727db7f5025a83facdc73f4f39abe2b6d4f00d"},
+    {file = "dulwich-0.21.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:cf7af6458cf6343a2a0632ae2fc5f04821b2ffefc7b8a27f4eacb726ef89c682"},
+    {file = "dulwich-0.21.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7aaf5c4528e83e3176e7dbb01dcec34fb41c93279a8f8527cf33e5df88bfb910"},
+    {file = "dulwich-0.21.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:075c8e9d2694ff16fc6e8a5ec0c771b7c33be12e4ebecc346fd74315d3d84605"},
+    {file = "dulwich-0.21.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3b686b49adeb7fc45791dfae96ffcffeba1038e8b7603f369d6661f59e479fc"},
+    {file = "dulwich-0.21.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:21ee962211839bb6e52d41f363ce9dbb0638d341a1c02263e163d69012f58b25"},
+    {file = "dulwich-0.21.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2bf2be68fddfc0adfe43be99ab31f6b0f16b9ef1e40464679ba831ff615ad4a3"},
+    {file = "dulwich-0.21.3-cp39-cp39-win32.whl", hash = "sha256:ddb790f2fdc22984fba643866b21d04733c5cf7c3ace2a1e99e0c1c1d2336aab"},
+    {file = "dulwich-0.21.3-cp39-cp39-win_amd64.whl", hash = "sha256:c97561c22fc05d0f6ba370d9bd67f86c313c38f31a1793e0ee9acb78ee28e4b8"},
+    {file = "dulwich-0.21.3-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:b9fc609a3d4009ee31212f435f5a75720ef24280f6d23edfd53f77b562a79c5b"},
+    {file = "dulwich-0.21.3-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f2cb11fe789b72feeae7cdf6e27375c33ed6915f8ca5ea7ce81b5e234c75a9e"},
+    {file = "dulwich-0.21.3-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c349431f5c8aa99b8744550d0bb4615f63e73450584202ac5db0e5d7da4d82ff"},
+    {file = "dulwich-0.21.3-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:9f08e5cc10143d3da2a2cf735d8b932ef4e4e1d74b0c74ce66c52eab02068be8"},
+    {file = "dulwich-0.21.3-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:67dbf4dd7586b2d437f539d5dc930ebceaf74a4150720644d6ea7e5ffc1cb2ff"},
+    {file = "dulwich-0.21.3-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89af4ee347f361338bad5c27b023f9d19e7aed17aa75cb519f28e6cf1658a0ba"},
+    {file = "dulwich-0.21.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0cd83f84e58aa59fb9d85cf15e74be83a5be876ac5876d5030f60fcce7ab36f1"},
+    {file = "dulwich-0.21.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:8ba1fe3fb415fd34cae5ca090fb82030b6e8423d6eb2c4c9c4fbf50b15c7664c"},
+    {file = "dulwich-0.21.3-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:058aaba18aefe18fcd84b216fd34d032ad453967dcf3dee263278951cd43e2d4"},
+    {file = "dulwich-0.21.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08ee426b609dab552839b5c7394ae9af2112c164bb727b7f85a69980eced9251"},
+    {file = "dulwich-0.21.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf1f6edc968619a4355481c29d5571726723bc12924e2b25bd3348919f9bc992"},
+    {file = "dulwich-0.21.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7c69c95d5242171d07396761f759a8a4d566e9a01bf99612f9b9e309e70a80fc"},
+    {file = "dulwich-0.21.3.tar.gz", hash = "sha256:7ca3b453d767eb83b3ec58f0cfcdc934875a341cdfdb0dc55c1431c96608cf83"},
+]
+
+[package.dependencies]
+typing-extensions = {version = "*", markers = "python_version <= \"3.7\""}
+urllib3 = ">=1.25"
+
+[package.extras]
+fastimport = ["fastimport"]
+https = ["urllib3 (>=1.24.1)"]
+paramiko = ["paramiko"]
+pgp = ["gpg"]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.1.1"
 description = "Backport of PEP 654 (exception groups)"
@@ -801,6 +877,18 @@ python-versions = ">=3.7"
 files = [
     {file = "packaging-23.0-py3-none-any.whl", hash = "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"},
     {file = "packaging-23.0.tar.gz", hash = "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"},
+]
+
+[[package]]
+name = "pathspec"
+version = "0.11.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pathspec-0.11.1-py3-none-any.whl", hash = "sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"},
+    {file = "pathspec-0.11.1.tar.gz", hash = "sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687"},
 ]
 
 [[package]]
@@ -1754,4 +1842,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<3.12"
-content-hash = "f1f76066fb140cba28faf383ab10a9462eb5b1b46a392e656f67b899d307e6a9"
+content-hash = "b867eadd27ef58dafebae80db89d10522df351c77352efc463135ea08f593250"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = ["dependency", "security", "CI", "integration"]
 # Classifiers can be found here: https://pypi.org/classifiers/
 # TODO: Update the "Development Status" as the project/package matures
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Natural Language :: English",
@@ -52,6 +52,7 @@ cryptography = "*"
 packaging = "*"
 "ruamel.yaml" = "*"
 connect-markdown-renderer = "*"
+pathspec = "*"
 # TODO: Remove these deps when Python 3.7 support is removed: importlib-metadata and backports-cached-property
 #       https://github.com/phylum-dev/phylum-ci/issues/18
 importlib-metadata = {version = "*", python = "<3.8"}
@@ -64,6 +65,7 @@ optional = true
 pytest = "*"
 tomli = "*"
 tox = "*"
+dulwich = "*"
 
 [tool.poetry.group.ci]
 optional = true

--- a/src/phylum/ci/ci_azure.py
+++ b/src/phylum/ci/ci_azure.py
@@ -143,7 +143,10 @@ class CIAzure(CIBase):
     def phylum_label(self) -> str:
         """Get a custom label for use when submitting jobs with `phylum analyze`."""
         if is_in_pr():
-            pr_number = os.getenv("SYSTEM_PULLREQUEST_PULLREQUESTID", "unknown-number")
+            # This variable is only populated for PRs from GitHub which have a different PR ID and PR number
+            pr_number = os.getenv("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER")
+            if pr_number is None:
+                pr_number = os.getenv("SYSTEM_PULLREQUEST_PULLREQUESTID", "unknown-number")
             pr_src_branch = os.getenv("SYSTEM_PULLREQUEST_SOURCEBRANCH", "unknown-ref")
             ref_prefix = "refs/heads/"
             # Starting with Python 3.9, the str.removeprefix() method was introduced to do this same thing

--- a/src/phylum/ci/ci_azure.py
+++ b/src/phylum/ci/ci_azure.py
@@ -17,12 +17,12 @@ Azure References:
 """
 import base64
 import os
+import re
 import shlex
 import subprocess
 import urllib.parse
 from argparse import Namespace
 from functools import lru_cache
-from pathlib import Path
 from typing import Optional
 
 import requests
@@ -31,7 +31,7 @@ from backports.cached_property import cached_property
 from phylum.ci.ci_base import CIBase
 from phylum.ci.ci_github import post_github_comment
 from phylum.ci.constants import PHYLUM_HEADER
-from phylum.ci.git import git_default_branch_name, git_hash_object, git_remote
+from phylum.ci.git import git_default_branch_name, git_remote
 from phylum.constants import PHYLUM_USER_AGENT, REQ_TIMEOUT
 
 AZURE_PAT_ERR_MSG = """
@@ -64,8 +64,8 @@ def is_in_pr() -> bool:
     """Indicate if the integration is operating in the context of a pull request pipeline.
 
     Azure Pipelines allows for triggering pipelines to run in different contexts:
-        * On every push, for the last commit in the push (e.g., CI triggers)
-        * For pull requests (e.g., PR triggers)
+      * On every push, for the last commit in the push (e.g., CI triggers)
+      * For pull requests (e.g., PR triggers)
 
     There are other types of triggers but the one we really care about is PR triggers.
     Those will mean running in a context that allows for full output in the form of
@@ -152,15 +152,14 @@ class CIAzure(CIBase):
             label = f"{self.ci_platform_name}_PR#{pr_number}_{pr_src_branch}"
         else:
             current_branch = os.getenv("BUILD_SOURCEBRANCHNAME", "unknown-branch")
-            lockfile_hash_object = git_hash_object(self.lockfile)
-            label = f"{self.ci_platform_name}_{current_branch}_{lockfile_hash_object[:7]}"
+            label = f"{self.ci_platform_name}_{current_branch}_{self.lockfile_hash_object}"
 
-        label = label.replace(" ", "-")
+        label = re.sub(r"\s+", "-", label)
         return label
 
     @cached_property
-    def common_lockfile_ancestor_commit(self) -> Optional[str]:
-        """Find the common lockfile ancestor commit."""
+    def common_ancestor_commit(self) -> Optional[str]:
+        """Find the common ancestor commit."""
         remote = git_remote()
 
         if is_in_pr():
@@ -188,9 +187,9 @@ class CIAzure(CIBase):
             tgt_branch = f"refs/remotes/{remote}/HEAD"
 
             # If the current commit is on the default branch, then the merge base will be the same
-            # as the current commit and it won't be possible to provide a useful common lockfile
-            # ancestor commit. In this case, it is better to force analysis of the lockfile and
-            # consider *all* dependencies in analysis results instead of just the newly added ones.
+            # as the current commit and it won't be possible to provide a useful common ancestor
+            # commit. In this case, it is better to force analysis of the lockfile(s) and consider
+            # *all* dependencies in analysis results instead of just the newly added ones.
             if src_branch == git_default_branch_name(remote):
                 print(" [+] Source branch is same as default branch. Proceeding with analysis of all dependencies ...")
                 self._force_analysis = True
@@ -220,40 +219,35 @@ class CIAzure(CIBase):
 
         cmd = ["git", "merge-base", src_branch, tgt_branch]
         shell_escaped_cmd = " ".join(shlex.quote(arg) for arg in cmd)
-        print(f" [*] Finding common lockfile ancestor commit with command: {shell_escaped_cmd}")
+        print(f" [*] Finding common ancestor commit with command: {shell_escaped_cmd}")
         try:
-            common_ancestor_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
+            common_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
         except subprocess.CalledProcessError as err:
             ref_url = "https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/steps-checkout#shallow-fetch"
-            print(f" [!] The common lockfile ancestor commit could not be found: {err}")
+            print(f" [!] The common ancestor commit could not be found: {err}")
             print(f" [!] stdout:\n{err.stdout}")
             print(f" [!] stderr:\n{err.stderr}")
             print(f" [!] Ensure shallow fetch is disabled for repo checkouts: {ref_url}")
-            common_ancestor_commit = None
+            common_commit = None
 
-        return common_ancestor_commit
+        return common_commit
 
-    def _is_lockfile_changed(self, lockfile: Path) -> bool:
-        """Predicate for detecting if the given lockfile has changed."""
-        diff_base_sha = self.common_lockfile_ancestor_commit
-        print(f" [+] The common lockfile ancestor commit: {diff_base_sha}")
+    @property
+    def is_any_lockfile_changed(self) -> bool:
+        """Predicate for detecting if any lockfile has changed."""
+        diff_base_sha = self.common_ancestor_commit
+        print(f" [+] The common ancestor commit: {diff_base_sha}")
 
         # Assume no change when there isn't enough information to tell
         if diff_base_sha is None:
             return False
 
-        # `--exit-code` will make git exit with 1 if there were differences while 0 means no differences.
-        # Any other exit code is an error and a reason to re-raise.
-        cmd = ["git", "diff", "--exit-code", "--quiet", diff_base_sha, "--", str(lockfile.resolve())]
-        ret = subprocess.run(cmd, check=False)
-        if ret.returncode == 0:
-            return False
-        if ret.returncode == 1:
-            return True
-        # Reference: https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/steps-checkout
-        print(" [!] Consider changing the `fetchDepth` property in CI settings to clone/fetch more branch history")
-        ret.check_returncode()
-        return False  # unreachable code but this makes mypy happy
+        err_msg = """\
+            [!] Consider changing the `fetchDepth` property in CI settings to clone/fetch more branch history.
+                Reference: https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/steps-checkout"""
+        self.update_lockfiles_change_status(diff_base_sha, err_msg)
+
+        return any(lockfile.is_lockfile_changed for lockfile in self.lockfiles)
 
     def post_output(self) -> None:
         """Post the output of the analysis.

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -336,16 +336,16 @@ class CIBase(ABC):
         branch history...which can happen with shallow clones.
         """
         for lockfile in self.lockfiles:
-            print(f" [*] Checking {lockfile} for changes ...")
+            print(f" [*] Checking `{lockfile!r}` for changes ...")
             # `--exit-code` will make git exit with 1 if there were differences while 0 means no differences.
             # Any other exit code is an error and a reason to re-raise.
             cmd = ["git", "diff", "--exit-code", "--quiet", commit, "--", str(lockfile.path)]
             ret = subprocess.run(cmd, check=False)
             if ret.returncode == 0:
-                print(f" [-] The lockfile `{lockfile}` has not changed")
+                print(f" [-] The lockfile `{lockfile!r}` has not changed")
                 lockfile.is_lockfile_changed = False
             elif ret.returncode == 1:
-                print(f" [-] The lockfile `{lockfile}` has changed")
+                print(f" [-] The lockfile `{lockfile!r}` has changed")
                 lockfile.is_lockfile_changed = True
             else:
                 if err_msg:

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -424,6 +424,11 @@ class CIBase(ABC):
             risk_data = self.parse_risk_data(analysis, packages)
         else:
             print(" [+] Only considering newly added dependencies ...")
+            # When the `--force-analysis` flag is specified without the `--all-deps` flag, it is necessary
+            # to ensure the `is_lockfile_changed` property is set for each lockfile. Simply referencing
+            # the `is_any_lockfile_changed` property will ensure this happens.
+            if self.force_analysis and self.is_any_lockfile_changed:
+                print(" [-] Updated each lockfile's change status")
             packages = sorted({pkg for lockfile in self.lockfiles for pkg in lockfile.new_deps})
             print(f" [+] {len(packages)} unique newly added dependencies")
             risk_data = self.parse_risk_data(analysis, packages)

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -133,8 +133,7 @@ class CIBase(ABC):
         lockfiles = []
         for provided_lockfile in provided_lockfiles:
             if not provided_lockfile.exists():
-                print(f" [!] Provided lockfile does not exist: {provided_lockfile}")
-                continue
+                raise SystemExit(f" [!] Provided lockfile does not exist: {provided_lockfile}")
             if not provided_lockfile.stat().st_size:
                 print(f" [!] Provided lockfile is an empty file: {provided_lockfile}")
                 continue

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -4,18 +4,19 @@ The "base" environment is one that makes use of the CLI directly and is not nece
 integration (CI) environment. Common functionality is provided where possible and CI specific features are
 designated as abstract methods to be defined in specific CI environments.
 """
-import json
 import os
+import shlex
 import shutil
 import subprocess
-import tempfile
 import textwrap
 import urllib.parse
 from abc import ABC, abstractmethod
 from argparse import Namespace
+from collections import OrderedDict
 from pathlib import Path
 from typing import List, Optional
 
+import pathspec
 from backports.cached_property import cached_property
 from connect.utils.terminal.markdown import render
 from packaging.version import Version
@@ -29,29 +30,11 @@ from phylum.ci.constants import (
     PROJECT_THRESHOLD_OPTIONS,
     SUCCESS_COMMENT,
 )
+from phylum.ci.git import git_hash_object, git_repo_name
+from phylum.ci.lockfile import Lockfile, Lockfiles
 from phylum.constants import MIN_CLI_VER_INSTALLED, SUPPORTED_LOCKFILES, TOKEN_ENVVAR_NAME
 from phylum.init.cli import get_phylum_bin_path
 from phylum.init.cli import main as phylum_init
-
-
-def detect_lockfile() -> Optional[Path]:
-    """Detect the lockfile in use and return it.
-
-    This method has some assumptions:
-      * It is called from the root of a repository
-      * There is only one lockfile allowed
-    """
-    cwd = Path.cwd()
-    lockfiles_in_cwd = [path.resolve() for lockfile_glob in SUPPORTED_LOCKFILES for path in cwd.glob(lockfile_glob)]
-    lockfiles_in_cwd = [path for path in lockfiles_in_cwd if path.stat().st_size]
-    if not lockfiles_in_cwd:
-        return None
-    if len(lockfiles_in_cwd) > 1:
-        lockfiles = ", ".join(str(lockfile) for lockfile in lockfiles_in_cwd)
-        print(f" [!] Multiple lockfiles detected: {lockfiles}")
-        raise SystemExit(" [!] Only one lockfile is supported at this time. Consider specifying it with `--lockfile`.")
-    lockfile = lockfiles_in_cwd[0]
-    return lockfile
 
 
 class CIBase(ABC):
@@ -65,35 +48,24 @@ class CIBase(ABC):
           * call `super().__init__(args)`
           * define `self.ci_platform_name`
         """
-        self.args = args
-        self._phylum_project_file = Path.cwd().joinpath(".phylum_project").resolve()
-
-        # The lockfile specified as a script argument will be used, if provided.
-        # Otherwise, an attempt will be made to automatically detect the lockfile.
-        provided_lockfile: Path = args.lockfile
-        if provided_lockfile and provided_lockfile.exists() and provided_lockfile.stat().st_size:
-            self._lockfile = provided_lockfile.resolve()
-            print(f" [-] Provided lockfile: {self._lockfile}")
-        else:
-            detected_lockfile = detect_lockfile()
-            if detected_lockfile:
-                self._lockfile = detected_lockfile
-                print(f" [-] Detected lockfile: {self._lockfile}")
-            else:
-                raise SystemExit(
-                    " [!] A lockfile is required and was not detected. Consider specifying one with `--lockfile`."
-                )
-
+        self._args = args
         self._all_deps = args.all_deps
         self._force_analysis = args.force_analysis
-        self._phylum_project = args.project
-        self._phylum_group = args.group
+
+        # Create a copy of the original `.phylum_project` file values, when the file exists.
+        # This is necessary because it is possible that user-provided values for the project and
+        # group are given, which causes the file to be overwritten when creating that project.
+        self._phylum_project_file = Path.cwd().joinpath(".phylum_project").resolve()
+        self._project_file_already_existed = self._phylum_project_file.exists()
+        self._project_settings = {}
+        if self._project_file_already_existed:
+            yaml = YAML()
+            self._project_settings = yaml.load(self._phylum_project_file.read_text(encoding="utf-8"))
 
         # Ensure all pre-requisites are met and bail at the earliest opportunity when they aren't
         self._check_prerequisites()
         print(" [+] All pre-requisites met")
 
-        self._cli_path: Optional[Path] = None
         self.gbl_failed = False
         self.gbl_incomplete = False
         self.incomplete_pkgs: Packages = []
@@ -106,19 +78,74 @@ class CIBase(ABC):
         if args.token is not None:
             token = args.token
             os.environ[TOKEN_ENVVAR_NAME] = args.token
-        self.args.token = token
+        self._args.token = token
 
-        self._lockfile_changed = self._is_lockfile_changed(self.lockfile)
-
-    @property
-    def lockfile(self) -> Path:
-        """Get the package lockfile."""
-        return self._lockfile
+        self.ensure_project_exists()
 
     @property
-    def is_lockfile_changed(self) -> bool:
-        """Get the lockfile's modification status."""
-        return self._lockfile_changed
+    def args(self) -> Namespace:
+        """Get the namespace arguments provided on the command line."""
+        return self._args
+
+    @cached_property
+    def lockfiles(self) -> Lockfiles:
+        """Get the package lockfile(s) in lexicographic order.
+
+        The package lockfile(s) can be specified as an option or contained in the `.phylum_project` file.
+        Lockfiles provided as an input option will be preferred over any entries in the `.phylum_project` file.
+
+        When no valid lockfiles are provided otherwise, an attempt will be made to automatically detect them.
+        """
+        arg_lockfiles: Optional[List[List[Path]]] = self.args.lockfile
+        if arg_lockfiles:
+            # flatten the list of lists
+            provided_arg_lockfiles = [path for sub_list in arg_lockfiles for path in sub_list]
+            print(f" [+] Lockfile(s) provided as arguments: {provided_arg_lockfiles}")
+            valid_lockfiles = self.filter_lockfiles(provided_arg_lockfiles)
+            if valid_lockfiles:
+                print(f" [-] Valid provided lockfiles: {valid_lockfiles}")
+                return valid_lockfiles
+
+        print(" [+] No valid lockfiles were provided as arguments. Checking the `.phylum_project` file ...")
+        lockfile_entries: List[OrderedDict] = self._project_settings.get("lockfiles", [])
+        lockfile_paths = [lockfile_entry.get("path") for lockfile_entry in lockfile_entries]
+        provided_project_lockfiles = [Path(lockfile) for lockfile in lockfile_paths if lockfile]
+        if provided_project_lockfiles:
+            print(f" [+] Lockfile(s) provided in `.phylum_project` file: {provided_project_lockfiles}")
+            valid_lockfiles = self.filter_lockfiles(provided_project_lockfiles)
+            if valid_lockfiles:
+                print(f" [-] Valid provided lockfiles: {valid_lockfiles}")
+                return valid_lockfiles
+
+        print(" [+] No valid lockfiles in the `.phylum_project` file. An attempt will be made to detect lockfiles.")
+        detected_lockfiles = detect_lockfiles()
+        if detected_lockfiles:
+            print(f" [+] Detected lockfile(s): {detected_lockfiles}")
+            valid_lockfiles = self.filter_lockfiles(detected_lockfiles)
+            if valid_lockfiles:
+                print(f" [-] Valid detected lockfiles: {valid_lockfiles}")
+                return valid_lockfiles
+
+        raise SystemExit(" [!] No valid lockfiles were detected. Consider specifying at least one with `--lockfile`.")
+
+    def filter_lockfiles(self, provided_lockfiles: List[Path]) -> Lockfiles:
+        """Filter potential lockfiles and return the valid ones in sorted order."""
+        lockfiles = []
+        for provided_lockfile in provided_lockfiles:
+            if not provided_lockfile.exists():
+                print(f" [!] Provided lockfile does not exist: {provided_lockfile}")
+                continue
+            if not provided_lockfile.stat().st_size:
+                print(f" [!] Provided lockfile is an empty file: {provided_lockfile}")
+                continue
+            cmd = [str(self.cli_path), "parse", str(provided_lockfile)]
+            # stdout and stderr are piped to DEVNULL because we only care about the return code.
+            # pylint: disable-next=subprocess-run-check ; we want return code here and don't want to raise when non-zero
+            if bool(subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode):
+                print(f" [!] Provided lockfile failed to parse as a known lockfile type: {provided_lockfile}")
+                continue
+            lockfiles.append(Lockfile(provided_lockfile, self.cli_path, self.common_ancestor_commit))
+        return sorted(lockfiles)
 
     @property
     def all_deps(self) -> bool:
@@ -130,23 +157,32 @@ class CIBase(ABC):
         """Get the status of forcing an analysis."""
         return self._force_analysis
 
-    @property
+    @cached_property
     def phylum_project(self) -> str:
         """Get the effective Phylum project name in use.
 
         The Phylum project name can be specified as an option or contained in the `.phylum_project` file.
         A project name provided as an input option will be preferred over an entry in the `.phylum_project` file.
 
-        Return `None` when the project name is not available.
+        When no project name is provided through options or project file, a project name will be provided by detecting
+        the git repository name. The goal is a unique and deterministic project name for each git repository submitted
+        by the same Phylum user account.
         """
-        # Project supplied as an option
-        if self._phylum_project:
-            return self._phylum_project
+        project_name = self.args.project
+        if project_name:
+            print(f" [+] Project name provided as argument: {project_name}")
+            return project_name
 
-        # Project supplied in `.phylum_project`
-        yaml = YAML()
-        settings_dict = yaml.load(self.phylum_project_file.read_text(encoding="utf-8"))
-        return settings_dict.get("name")
+        print(" [+] Project name not provided as argument. Checking the `.phylum_project` file ...")
+        project_name = self._project_settings.get("name")
+        if project_name:
+            print(f" [+] Project name provided in `.phylum_project` file: {project_name}")
+            return project_name
+
+        print(" [+] Project name not found in the `.phylum_project` file or file does not exist. Detecting instead ...")
+        project_name = git_repo_name()
+        print(f" [+] Project name detected from git repository name: {project_name}")
+        return project_name
 
     @property
     def phylum_group(self) -> Optional[str]:
@@ -158,218 +194,23 @@ class CIBase(ABC):
         Return `None` when the group name is not available.
         """
         # Group supplied on command-line
-        if self._phylum_project:
-            return self._phylum_group
+        # A group can not be specified without a project
+        if self.args.group and self.args.project:
+            return self.args.group
 
         # Group supplied in `.phylum_project`
-        yaml = YAML()
-        settings_dict = yaml.load(self.phylum_project_file.read_text(encoding="utf-8"))
-        return settings_dict.get("group_name")
+        # Don't "mix" a project supplied as an option with a group that wasn't
+        if not self.args.project:
+            return self._project_settings.get("group_name")
 
-    @property
-    def phylum_project_file(self) -> Path:
-        """Get the path to the Phylum project file `.phylum_project`."""
-        return self._phylum_project_file
-
-    @property
-    def cli_path(self) -> Optional[Path]:
-        """Get the path to the Phylum CLI binary."""
-        return self._cli_path
-
-    @property
-    def project_id(self) -> str:
-        """Get the GUID for the project."""
-        return self._project_id
+        return None
 
     @cached_property
-    def project_url(self) -> str:
-        """Construct a project URL and return it.
+    def cli_path(self) -> Path:
+        """Get the path to the Phylum CLI binary.
 
-        The project URL is used to access a particular project in the web UI, by label, and optionally with a group.
+        Check for an existing Phylum CLI and install it if needed.
         """
-        query = {"label": self.phylum_label}
-        if self.phylum_group is not None:
-            query["group"] = self.phylum_group
-        query_params = urllib.parse.urlencode(query, safe="/", quote_via=urllib.parse.quote)
-        project_url = f"https://app.phylum.io/projects/{self.project_id}?{query_params}"
-        return project_url
-
-    @property
-    def project_url_md(self) -> str:
-        """Construct a markdown link for viewing the project in the Phylum UI."""
-        return f"\n[View this project in the Phylum UI]({self.project_url})"
-
-    @property
-    def analysis_output(self) -> str:
-        """Get the output from the overall analysis, in markdown format."""
-        return self._analysis_output
-
-    @property
-    @abstractmethod
-    def phylum_label(self) -> str:
-        """Get a custom label for use when submitting jobs with `phylum analyze`.
-
-        Each CI platform/environment has unique ways of referencing events, PRs, branches, etc.
-        """
-        raise NotImplementedError()
-
-    @cached_property
-    @abstractmethod
-    def common_lockfile_ancestor_commit(self) -> Optional[str]:
-        """Find the common lockfile ancestor commit.
-
-        When found, it should be returned as a string of the SHA1 sum representing the commit.
-        When it can't be found (or there is an error), `None` should be returned.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def _is_lockfile_changed(self, lockfile: Path) -> bool:
-        """Predicate for detecting if the given lockfile has changed."""
-        raise NotImplementedError()
-
-    @abstractmethod
-    def _check_prerequisites(self) -> None:
-        """Ensure the necessary pre-requisites are met and bail when they aren't.
-
-        The current pre-requisites for *all* CI environments/platforms are:
-          * A `.phylum_project` file exists at the working directory or project name is specified as an option
-          * A Phylum CLI version with the `parse` command
-          * Have `git` installed and available for use on the PATH
-        """
-        print(" [+] Confirming pre-requisites ...")
-
-        if self.phylum_project_file.exists():
-            print(f" [+] Existing `.phylum_project` file found at: {self.phylum_project_file}")
-        else:
-            print(f" [+] No existing `.phylum_project` file found at: {self.phylum_project_file}")
-            if self.phylum_project:
-                print(f" [+] A Phylum project will be used (or created) with the provided name: {self.phylum_project}")
-            else:
-                msg = """\
-                    [!] No Phylum project could be determined!
-                    [!] Consider specifying one with `--project` and optionally with the `--group` option."""
-                raise SystemExit(textwrap.dedent(msg))
-
-        if Version(self.args.version) < Version(MIN_CLI_VER_INSTALLED):
-            raise SystemExit(f" [!] The CLI version must be at least {MIN_CLI_VER_INSTALLED}")
-
-        if shutil.which("git"):
-            print(" [+] `git` binary found on the PATH")
-        else:
-            raise SystemExit(" [!] `git` is required to be installed and available on the PATH")
-
-    def post_output(self) -> None:
-        """Post the output of the analysis as markdown rendered for output to the terminal/logs.
-
-        Each implementation that offers analysis output in the form of comments on a pull/merge request should
-        ensure those comments are unique and not added multiple times as the review changes but the lockfile doesn't.
-        """
-        # Pull out the project URL link, which doesn't render well
-        output = self.analysis_output.replace(self.project_url_md, "")
-
-        # Post the markdown output, rendered for terminal/log output
-        print(f" [+] Analysis output:\n{render(output)}")
-
-        # Post the project URL link separately
-        print(f"View this project in the Phylum UI: {self.project_url}\n")
-
-    @cached_property
-    def current_lockfile_packages(self) -> Packages:
-        """Get the current lockfile packages.
-
-        This property expects the Phylum CLI path to be known and will raise `SystemExit` when that path is unknown.
-        """
-        if not self.cli_path:
-            raise SystemExit(" [!] Phylum CLI path is unknown. Try using the `init_cli` method first.")
-        try:
-            cmd = [str(self.cli_path), "parse", str(self.lockfile)]
-            parse_result = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
-        except subprocess.CalledProcessError as err:
-            print(f" [!] There was an error running the command: {' '.join(err.cmd)}")
-            print(f" [!] stdout:\n{err.stdout}")
-            print(f" [!] stderr:\n{err.stderr}")
-            raise SystemExit(f" [!] Is {self.lockfile} valid? If so, please report this as a bug.") from err
-        parsed_pkgs = json.loads(parse_result)
-        curr_lockfile_packages = [PackageDescriptor(**pkg) for pkg in parsed_pkgs]
-        return curr_lockfile_packages
-
-    @property
-    def previous_lockfile_object(self) -> Optional[str]:
-        """Get the previous git object for the lockfile."""
-        if not self.common_lockfile_ancestor_commit:
-            return None
-        try:
-            cmd = [
-                "git",
-                "rev-parse",
-                "--verify",
-                f"{self.common_lockfile_ancestor_commit}:{self.lockfile.name}",
-            ]
-            prev_lockfile_object = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
-        except subprocess.CalledProcessError as err:
-            # There could be a true error, but the working assumption when here is a previous version does not exist
-            print(f" [?] There *may* be an issue with the attempt to get the previous lockfile object: {err}")
-            print(f" [?] stdout:\n{err.stdout}")
-            print(f" [?] stderr:\n{err.stderr}")
-            print(" [+] Assuming a previous lockfile version does not exist ...")
-            prev_lockfile_object = None
-        return prev_lockfile_object
-
-    def get_previous_lockfile_packages(self, prev_lockfile_object: str) -> Packages:
-        """Get the previous lockfile packages from the corresponding git object and return them.
-
-        Expects the Phylum CLI path to be known and will raise `SystemExit` when that path is unknown.
-        """
-        if not self.cli_path:
-            raise SystemExit(" [!] Phylum CLI path is unknown. Try using the `init_cli` method first.")
-
-        with tempfile.NamedTemporaryFile(mode="w+") as prev_lockfile_fd:
-            try:
-                cmd = ["git", "cat-file", "blob", prev_lockfile_object]
-                prev_lockfile_contents = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout
-                prev_lockfile_fd.write(prev_lockfile_contents)
-                prev_lockfile_fd.flush()
-            except subprocess.CalledProcessError as err:
-                print(f" [!] There was an error running the command: {' '.join(err.cmd)}")
-                print(f" [!] stdout:\n{err.stdout}")
-                print(f" [!] stderr:\n{err.stderr}")
-                print(" [!] Due to error, assuming no previous lockfile packages. Please report this as a bug.")
-                return []
-            try:
-                cmd = [str(self.cli_path), "parse", prev_lockfile_fd.name]
-                parse_result = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
-            except subprocess.CalledProcessError as err:
-                print(f" [!] There was an error running the command: {' '.join(err.cmd)}")
-                print(f" [!] stdout:\n{err.stdout}")
-                print(f" [!] stderr:\n{err.stderr}")
-                print(" [!] Due to error, assuming no previous lockfile packages. Please report this as a bug.")
-                return []
-
-        parsed_pkgs = json.loads(parse_result)
-        prev_lockfile_packages = [PackageDescriptor(**pkg) for pkg in parsed_pkgs]
-        return prev_lockfile_packages
-
-    def get_new_deps(self) -> Packages:
-        """Get the new dependencies added to the lockfile and return them in sorted order."""
-        curr_lockfile_packages = self.current_lockfile_packages
-
-        prev_lockfile_object = self.previous_lockfile_object
-        if not prev_lockfile_object:
-            print(" [+] No previous lockfile object found. Assuming all packages in the current lockfile are new.")
-            return curr_lockfile_packages
-
-        prev_lockfile_packages = self.get_previous_lockfile_packages(prev_lockfile_object)
-
-        prev_pkg_set = set(prev_lockfile_packages)
-        curr_pkg_set = set(curr_lockfile_packages)
-        new_deps = sorted(curr_pkg_set.difference(prev_pkg_set))
-        print(f" [+] New dependencies: {new_deps}")
-
-        return new_deps
-
-    def init_cli(self) -> None:
-        """Check for an existing Phylum CLI install, install it if needed, and set the path class instance variable."""
         specified_version = self.args.version
         # fmt: off
         install_args = [
@@ -396,9 +237,8 @@ class CIBase(ABC):
                     print(" [+] Version checks succeeded. Using existing version.")
 
         cli_path, cli_version = get_phylum_bin_path()
-        print(f" [+] Using Phylum CLI instance: {cli_version} at {str(cli_path)}")
-
-        self._cli_path = cli_path
+        if cli_path is None:
+            raise SystemExit(" [!] Failed to initialize the Phylum CLI")
 
         # Exit condition: a Phylum API key should be in place or available at this point.
         # Ensure stdout is piped to DEVNULL, to keep the token from being printed in (CI log) output.
@@ -407,8 +247,172 @@ class CIBase(ABC):
         if bool(subprocess.run(cmd, stdout=subprocess.DEVNULL).returncode):
             raise SystemExit(" [!] A Phylum API key is required to continue.")
 
+        print(f" [+] Using Phylum CLI instance: {cli_version} at {str(cli_path)}")
+        return cli_path
+
+    @property
+    def project_id(self) -> str:
+        """Get the GUID for the project."""
+        return self._project_id
+
+    @cached_property
+    def project_url(self) -> str:
+        """Construct a project URL and return it.
+
+        The project URL is used to access a particular project in the web UI, by label, and optionally with a group.
+        """
+        query = {"label": self.phylum_label}
+        if self.phylum_group:
+            query["group"] = self.phylum_group
+        query_params = urllib.parse.urlencode(query, safe="/", quote_via=urllib.parse.quote)
+        project_url = f"https://app.phylum.io/projects/{self.project_id}?{query_params}"
+        return project_url
+
+    @property
+    def project_url_md(self) -> str:
+        """Construct a markdown link for viewing the project in the Phylum UI."""
+        return f"\n[View this project in the Phylum UI]({self.project_url})"
+
+    @property
+    def analysis_output(self) -> str:
+        """Get the output from the overall analysis, in markdown format."""
+        return self._analysis_output
+
+    @property
+    @abstractmethod
+    def phylum_label(self) -> str:
+        """Get a custom label for use when submitting jobs with `phylum analyze`.
+
+        Each CI platform/environment has unique ways of referencing events, PRs, branches, etc.
+        However, each implementation is expected to at least:
+          * Start the label with the `self.ci_platform_name`
+          * Replace all runs of whitespace characters with a single `-` character
+        """
+        raise NotImplementedError()
+
+    @property
+    def lockfile_hash_object(self) -> str:
+        """Get the lockfile hash object of the first changed lockfile and return it.
+
+        Since there can be many changed lockfiles, find and use only the hash object of the first changed lockfile.
+        Since it is possible that no lockfile has changed (e.g., when forcing analysis), default to first lockfile.
+        When found, only the first seven characters of the hash object will be returned, which is a git "short SHA-1".
+        Reference: https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection
+        """
+        if not self.lockfiles:
+            return "unknown"
+        first_changed_lockfile = self.lockfiles[0]
+        for lockfile in self.lockfiles:
+            if lockfile.is_lockfile_changed:
+                first_changed_lockfile = lockfile
+                break
+        lockfile_hash_object = git_hash_object(first_changed_lockfile.path)
+        return lockfile_hash_object[:7]
+
+    @cached_property
+    @abstractmethod
+    def common_ancestor_commit(self) -> Optional[str]:
+        """Find the common ancestor commit.
+
+        When found, it should be returned as a string of the SHA1 sum representing the commit.
+        When it can't be found (or there is an error), `None` should be returned.
+        """
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def is_any_lockfile_changed(self) -> bool:
+        """Get the lockfiles' collective modification status.
+
+        Implementations should return `True` if any lockfile has changed and `False` otherwise.
+        """
+        raise NotImplementedError()
+
+    def update_lockfiles_change_status(self, commit: str, err_msg: Optional[str] = None) -> None:
+        """Update each lockfile's change status.
+
+        The input `commit` is the one to use in a `git diff` command to view the changes relative to the working tree.
+        The input `err_msg` is what will be printed when `git diff` fails. This is usually due to not having enough
+        branch history...which can happen with shallow clones.
+        """
+        for lockfile in self.lockfiles:
+            print(f" [*] Checking {lockfile} for changes ...")
+            # `--exit-code` will make git exit with 1 if there were differences while 0 means no differences.
+            # Any other exit code is an error and a reason to re-raise.
+            cmd = ["git", "diff", "--exit-code", "--quiet", commit, "--", str(lockfile.path)]
+            ret = subprocess.run(cmd, check=False)
+            if ret.returncode == 0:
+                print(f" [-] The lockfile `{lockfile}` has not changed")
+                lockfile.is_lockfile_changed = False
+            elif ret.returncode == 1:
+                print(f" [-] The lockfile `{lockfile}` has changed")
+                lockfile.is_lockfile_changed = True
+            else:
+                if err_msg:
+                    print(textwrap.dedent(err_msg))
+                ret.check_returncode()
+
+    @abstractmethod
+    def _check_prerequisites(self) -> None:
+        """Ensure the necessary pre-requisites are met and bail when they aren't.
+
+        The current pre-requisites for *all* CI environments/platforms are:
+          * A Phylum CLI version with ability to specify multiple lockfiles
+          * Have `git` installed and available for use on the PATH
+        """
+        print(" [+] Confirming pre-requisites ...")
+
+        if Version(self.args.version) < Version(MIN_CLI_VER_INSTALLED):
+            raise SystemExit(f" [!] The CLI version must be at least {MIN_CLI_VER_INSTALLED}")
+
+        if shutil.which("git"):
+            print(" [+] `git` binary found on the PATH")
+        else:
+            raise SystemExit(" [!] `git` is required to be installed and available on the PATH")
+
+    def ensure_project_exists(self) -> None:
+        """Ensure a Phylum project is created and in place.
+
+        A project may or may not already exist. Attempt to create the project, possibly overwriting a `.phylum_project`
+        file that already exists. Continue on without error when the specified project already exists.
+        """
+        print(f" [*] Attempting to create a Phylum project with the name: {self.phylum_project} ...")
+        cmd = [str(self.cli_path), "project", "create", self.phylum_project]
+        if self.phylum_group:
+            print(f" [-] Using Phylum group: {self.phylum_group}")
+            cmd = [str(self.cli_path), "project", "create", "--group", self.phylum_group, self.phylum_project]
+        ret = subprocess.run(cmd, check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        # The Phylum CLI will return a unique error code of 14 when a project that already
+        # exists is attempted to be created. This situation is recognized and allowed to happen
+        # since it means the project exists as expected. Any other exit code is an error.
+        if ret.returncode == 0:
+            print(f" [-] Project {self.phylum_project} created successfully.")
+            if self._project_file_already_existed:
+                print(f" [!] Overwrote previous `.phylum_project` file found at: {self._phylum_project_file}")
+        elif ret.returncode == 14:
+            print(f" [-] Project {self.phylum_project} already exists. Continuing with it ...")
+        else:
+            shell_escaped_cmd = " ".join(shlex.quote(arg) for arg in cmd)
+            print(f" [!] There was a problem creating the project with command: {shell_escaped_cmd}")
+            ret.check_returncode()
+
+    def post_output(self) -> None:
+        """Post the output of the analysis as markdown rendered for output to the terminal/logs.
+
+        Each implementation that offers analysis output in the form of comments on a pull/merge request should
+        ensure those comments are unique and not added multiple times as the review changes but no lockfile does.
+        """
+        # Pull out the project URL link, which doesn't render well
+        output = self.analysis_output.replace(self.project_url_md, "")
+
+        # Post the markdown output, rendered for terminal/log output
+        print(f" [+] Analysis output:\n{render(output)}")
+
+        # Post the project URL link separately
+        print(f"View this project in the Phylum UI: {self.project_url}\n")
+
     def analyze(self, analysis: dict) -> ReturnCode:
-        """Analyze the results gathered from passing a lockfile to `phylum analyze`."""
+        """Analyze the results gathered from passing the lockfile(s) to `phylum analyze`."""
         self._project_id = analysis.get("project", "00000000-0000-0000-0000-000000000000")
         print(f" [+] Project ID: {self.project_id}")
 
@@ -416,12 +420,12 @@ class CIBase(ABC):
             print(" [+] Considering all current dependencies ...")
             pkgs = analysis.get("packages", [])
             packages = sorted([PackageDescriptor(pkg.get("name"), pkg.get("version"), pkg.get("type")) for pkg in pkgs])
-            print(f" [+] {len(packages)} current dependencies")
+            print(f" [+] {len(packages)} unique current dependencies")
             risk_data = self.parse_risk_data(analysis, packages)
         else:
             print(" [+] Only considering newly added dependencies ...")
-            packages = self.get_new_deps()
-            print(f" [+] {len(packages)} newly added dependencies")
+            packages = sorted({pkg for lockfile in self.lockfiles for pkg in lockfile.new_deps})
+            print(f" [+] {len(packages)} unique newly added dependencies")
             risk_data = self.parse_risk_data(analysis, packages)
 
         returncode = ReturnCode.SUCCESS
@@ -574,3 +578,33 @@ def build_issues_list(package_result: dict, issue_flags: List[str]) -> List[Issu
                 title = pkg_issue.get("title")
                 issues.append(IssueEntry(severity, domain, title))
     return sorted(issues)
+
+
+def detect_lockfiles() -> List[Path]:
+    """Detect the lockfile(s) in use and return them.
+
+    Lockfiles that match entries in supported ignore files will be excluded.
+
+    This function makes the following assumptions:
+      * It is called from the root of a repository
+      * Ignore files only exist at the root of a repository
+      * Recursing fully into the repository is acceptable
+    """
+    cwd = Path.cwd()
+    spec = None
+    potential_ignore_files = (Path(".gitignore"), Path(".ignore"))
+
+    ignore_files = [f.resolve() for f in potential_ignore_files if f.exists()]
+    if ignore_files:
+        try:
+            lines = [line for ignore_file in ignore_files for line in ignore_file.read_text("utf-8").splitlines()]
+            spec = pathspec.PathSpec.from_lines("gitwildmatch", lines)
+        except (UnicodeDecodeError, pathspec.patterns.gitwildmatch.GitWildMatchPatternError) as err:
+            # Ignore the failure and proceed without ignore-file filtering (how ironic)
+            print(f" [!] Could not parse an ignore file: {err}")
+            print(" [-] Continuing anyway ...")
+
+    lockfiles = [path.resolve() for lockfile_glob in SUPPORTED_LOCKFILES for path in cwd.glob(f"**/{lockfile_glob}")]
+    if spec:
+        lockfiles = [path for path in lockfiles if not spec.match_file(str(path))]
+    return lockfiles

--- a/src/phylum/ci/ci_bitbucket.py
+++ b/src/phylum/ci/ci_bitbucket.py
@@ -105,8 +105,8 @@ class CIBitbucket(CIBase):
         """Get a custom label for use when submitting jobs with `phylum analyze`."""
         if is_in_pr():
             pr_id = os.getenv("BITBUCKET_PR_ID", "unknown-ID")
-            pr_title = os.getenv("BITBUCKET_BRANCH", "unknown-branch")
-            label = f"{self.ci_platform_name}_PR#{pr_id}_{pr_title}"
+            pr_src_branch = os.getenv("BITBUCKET_BRANCH", "unknown-branch")
+            label = f"{self.ci_platform_name}_PR#{pr_id}_{pr_src_branch}"
         else:
             current_branch = os.getenv("BITBUCKET_BRANCH", "unknown-branch")
             label = f"{self.ci_platform_name}_{current_branch}_{self.lockfile_hash_object}"

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -87,8 +87,8 @@ class CIGitLab(CIBase):
         """Get a custom label for use when submitting jobs with `phylum analyze`."""
         if is_in_mr():
             mr_iid = os.getenv("CI_MERGE_REQUEST_IID", "unknown-IID")
-            mr_title = os.getenv("CI_MERGE_REQUEST_TITLE", "unknown-title")
-            label = f"{self.ci_platform_name}_MR#{mr_iid}_{mr_title}"
+            mr_src_branch = os.getenv("CI_MERGE_REQUEST_SOURCE_BRANCH_NAME", "unknown-branch")
+            label = f"{self.ci_platform_name}_MR#{mr_iid}_{mr_src_branch}"
         else:
             current_branch = os.getenv("CI_COMMIT_BRANCH", "unknown-branch")
             label = f"{self.ci_platform_name}_{current_branch}_{self.lockfile_hash_object}"

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -8,11 +8,11 @@ GitLab References:
   * https://docs.gitlab.com/ee/api/notes.html#merge-requests
 """
 import os
+import re
 import shlex
 import subprocess
 from argparse import Namespace
 from functools import lru_cache
-from pathlib import Path
 from typing import Optional
 
 import requests
@@ -20,7 +20,7 @@ from backports.cached_property import cached_property
 
 from phylum.ci.ci_base import CIBase
 from phylum.ci.constants import PHYLUM_HEADER
-from phylum.ci.git import git_default_branch_name, git_hash_object, git_remote
+from phylum.ci.git import git_default_branch_name, git_remote
 from phylum.constants import PHYLUM_USER_AGENT, REQ_TIMEOUT
 
 
@@ -29,8 +29,8 @@ def is_in_mr() -> bool:
     """Indicate if the integration is operating in the context of a merge request pipeline.
 
     GitLab CI allows for the possibility of running pipelines in different contexts:
-        * On every push, for the last commit in the push (e.g., branch pipelines)
-        * For merge requests (e.g., merge request pipelines)
+      * On every push, for the last commit in the push (e.g., branch pipelines)
+      * For merge requests (e.g., merge request pipelines)
 
     Knowing when the context is within a merge request helps to ensure the logic used
     to determine the lockfile changes is correct. It also helps to ensure output is not
@@ -91,23 +91,22 @@ class CIGitLab(CIBase):
             label = f"{self.ci_platform_name}_MR#{mr_iid}_{mr_title}"
         else:
             current_branch = os.getenv("CI_COMMIT_BRANCH", "unknown-branch")
-            lockfile_hash_object = git_hash_object(self.lockfile)
-            label = f"{self.ci_platform_name}_{current_branch}_{lockfile_hash_object[:7]}"
+            label = f"{self.ci_platform_name}_{current_branch}_{self.lockfile_hash_object}"
 
-        label = label.replace(" ", "-")
+        label = re.sub(r"\s+", "-", label)
         return label
 
     @cached_property
-    def common_lockfile_ancestor_commit(self) -> Optional[str]:
-        """Find the common lockfile ancestor commit.
+    def common_ancestor_commit(self) -> Optional[str]:
+        """Find the common ancestor commit.
 
         Some pre-defined variables are used: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
         """
         remote = git_remote()
 
         if is_in_mr():
-            common_ancestor_commit = os.getenv("CI_MERGE_REQUEST_DIFF_BASE_SHA")
-            return common_ancestor_commit
+            common_commit = os.getenv("CI_MERGE_REQUEST_DIFF_BASE_SHA")
+            return common_commit
 
         src_branch_name = os.getenv("CI_COMMIT_BRANCH")
         if not src_branch_name:
@@ -130,40 +129,35 @@ class CIGitLab(CIBase):
         # and the default branch instead of finding the exact commit from which the branch was created.
         cmd = ["git", "merge-base", src_branch, default_branch]
         shell_escaped_cmd = " ".join(shlex.quote(arg) for arg in cmd)
-        print(f" [*] Finding common lockfile ancestor commit with command: {shell_escaped_cmd}")
+        print(f" [*] Finding common ancestor commit with command: {shell_escaped_cmd}")
         try:
-            common_ancestor_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
+            common_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
         except subprocess.CalledProcessError as err:
             ref_url = "https://docs.gitlab.com/ee/ci/runners/configure_runners.html#git-strategy"
-            print(f" [!] The common lockfile ancestor commit could not be found: {err}")
+            print(f" [!] The common ancestor commit could not be found: {err}")
             print(f" [!] stdout:\n{err.stdout}")
             print(f" [!] stderr:\n{err.stderr}")
             print(f" [!] Ensure the git strategy is set to `clone` for repo checkouts: {ref_url}")
-            common_ancestor_commit = None
+            common_commit = None
 
-        return common_ancestor_commit
+        return common_commit
 
-    def _is_lockfile_changed(self, lockfile: Path) -> bool:
-        """Predicate for detecting if the given lockfile has changed."""
-        diff_base_sha = self.common_lockfile_ancestor_commit
-        print(f" [+] The common lockfile ancestor commit: {diff_base_sha}")
+    @property
+    def is_any_lockfile_changed(self) -> bool:
+        """Predicate for detecting if any lockfile has changed."""
+        diff_base_sha = self.common_ancestor_commit
+        print(f" [+] The common ancestor commit: {diff_base_sha}")
 
         # Assume no change when there isn't enough information to tell
         if diff_base_sha is None:
             return False
 
-        # `--exit-code` will make git exit with 1 if there were differences while 0 means no differences.
-        # Any other exit code is an error and a reason to re-raise.
-        cmd = ["git", "diff", "--exit-code", "--quiet", diff_base_sha, "--", str(lockfile.resolve())]
-        ret = subprocess.run(cmd, check=False)
-        if ret.returncode == 0:
-            return False
-        if ret.returncode == 1:
-            return True
-        # Reference: https://docs.gitlab.com/ee/ci/large_repositories/index.html#shallow-cloning
-        print(" [!] Consider changing the `GIT_DEPTH` variable in CI settings to clone/fetch more branch history")
-        ret.check_returncode()
-        return False  # unreachable code but this makes mypy happy
+        err_msg = """\
+            [!] Consider changing the `GIT_DEPTH` variable in CI settings to clone/fetch more branch history.
+                Reference: https://docs.gitlab.com/ee/ci/large_repositories/index.html#shallow-cloning"""
+        self.update_lockfiles_change_status(diff_base_sha, err_msg)
+
+        return any(lockfile.is_lockfile_changed for lockfile in self.lockfiles)
 
     def post_output(self) -> None:
         """Post the output of the analysis.

--- a/src/phylum/ci/ci_precommit.py
+++ b/src/phylum/ci/ci_precommit.py
@@ -106,9 +106,9 @@ class CIPreCommit(CIBase):
         staged_files = [Path(staged_file).resolve() for staged_file in self.extra_args]
         for lockfile in self.lockfiles:
             if lockfile.path in staged_files:
-                print(f" [-] The lockfile `{lockfile}` has changed")
+                print(f" [-] The lockfile `{lockfile!r}` has changed")
                 lockfile.is_lockfile_changed = True
             else:
-                print(f" [-] The lockfile `{lockfile}` has not changed")
+                print(f" [-] The lockfile `{lockfile!r}` has not changed")
                 lockfile.is_lockfile_changed = False
         return any(lockfile.is_lockfile_changed for lockfile in self.lockfiles)

--- a/src/phylum/ci/common.py
+++ b/src/phylum/ci/common.py
@@ -21,8 +21,8 @@ Packages = List[PackageDescriptor]
 class ProjectThresholdInfo:
     """Class for keeping track of project risk threshold information.
 
-    `threshold`: The risk domain threshold value in use.
-    `req_src`: The source of the threshold requirement. For example, `phylum-ci option` for command line options
+    * `threshold`: The risk domain threshold value in use.
+    * `req_src`: The source of the threshold requirement. For example, `phylum-ci option` for command line options
     """
 
     threshold: float

--- a/src/phylum/ci/constants.py
+++ b/src/phylum/ci/constants.py
@@ -16,7 +16,7 @@ SUCCESS_DETAILS = "The Phylum risk analysis is complete and did not identify any
 FAILURE_DETAILS = """
         This repository analyzes risk of new dependencies with Phylum. An administrator
         of this repository has set score requirements for Phylum's five risk domains.
-        One or more dependencies added to the lockfile failed the risk analysis.
+        One or more dependencies added to a lockfile failed the risk analysis.
         """.strip()
 
 # String template providing information about an incomplete analysis.

--- a/src/phylum/ci/git.py
+++ b/src/phylum/ci/git.py
@@ -1,16 +1,32 @@
 """Provide common git functions."""
 
+import os
 import subprocess
 from pathlib import Path
+from typing import List, Optional
 
 
-def git_remote() -> str:
+def git_base_cmd(git_c_path: Optional[Path] = None) -> List[str]:
+    """Provide a normalized base command list for use in constructing git commands.
+
+    The optional `git_c_path` is used to tell `git` to run as if it were started in that
+    path instead of the current working directory, which is the default when not provided.
+    """
+    if git_c_path is None or not git_c_path.exists():
+        return ["git"]
+    return ["git", "-C", str(git_c_path.resolve())]
+
+
+def git_remote(git_c_path: Optional[Path] = None) -> str:
     """Get the git remote and return it.
+
+    The optional `git_c_path` is used to tell `git` to run as if it were started in that
+    path instead of the current working directory, which is the default when not provided.
 
     This function is limited in that it will only work when there is a single remote defined.
     A RuntimeError exception will be raised when there is not exactly one remote.
     """
-    cmd = ["git", "remote"]
+    cmd = git_base_cmd(git_c_path) + ["remote"]
     remotes = subprocess.run(cmd, check=True, text=True, capture_output=True).stdout.splitlines()
     if not remotes:
         raise RuntimeError("No git remotes configured")
@@ -20,14 +36,18 @@ def git_remote() -> str:
     return remote
 
 
-def git_set_remote_head(remote: str) -> None:
+def git_set_remote_head(remote: str, git_c_path: Optional[Path] = None) -> None:
     """Set the remote HEAD ref for a given remote.
+
+    The optional `git_c_path` is used to tell `git` to run as if it were started in that
+    path instead of the current working directory, which is the default when not provided.
 
     Some CI environments do not set the remote HEAD. Use this function to do so.
     It assumes git credentials are available to run the command.
     """
+    base_cmd = git_base_cmd(git_c_path=git_c_path)
     print(" [*] Automatically setting the remote HEAD ref ...")
-    cmd = ["git", "remote", "set-head", remote, "--auto"]
+    cmd = base_cmd + ["remote", "set-head", remote, "--auto"]
     try:
         subprocess.run(cmd, check=True, capture_output=True)
     except subprocess.CalledProcessError as err:
@@ -37,14 +57,18 @@ def git_set_remote_head(remote: str) -> None:
         raise SystemExit(" [!] Ensure credentials are available to run git commands") from err
 
 
-def git_default_branch_name(remote: str) -> str:
+def git_default_branch_name(remote: str, git_c_path: Optional[Path] = None) -> str:
     """Get the default branch name and return it.
+
+    The optional `git_c_path` is used to tell `git` to run as if it were started in that
+    path instead of the current working directory, which is the default when not provided.
 
     This function assumes that the symbolic ref `refs/remotes/<remote>/HEAD`
     exists and contains an entry/mapping to the current default branch.
     """
+    base_cmd = git_base_cmd(git_c_path=git_c_path)
     prefix = f"refs/remotes/{remote}/"
-    cmd = ["git", "symbolic-ref", f"{prefix}HEAD"]
+    cmd = base_cmd + ["symbolic-ref", f"{prefix}HEAD"]
     try:
         default_branch_name = subprocess.run(cmd, check=True, text=True, capture_output=True).stdout.strip()
     except subprocess.CalledProcessError:
@@ -63,16 +87,62 @@ def git_default_branch_name(remote: str) -> str:
     return default_branch_name
 
 
-def git_curent_branch_name() -> str:
-    """Get the current branch name and return it."""
-    cmd = ["git", "branch", "--show-current"]
+def git_curent_branch_name(git_c_path: Optional[Path] = None) -> str:
+    """Get the current branch name and return it.
+
+    The optional `git_c_path` is used to tell `git` to run as if it were started in that
+    path instead of the current working directory, which is the default when not provided.
+    """
+    base_cmd = git_base_cmd(git_c_path=git_c_path)
+    cmd = base_cmd + ["branch", "--show-current"]
     current_branch = subprocess.run(cmd, check=True, text=True, capture_output=True).stdout.strip()
     return current_branch
 
 
-def git_hash_object(object_path: Path) -> str:
-    """Get the unique key that git uses to refer to the blob type data object for the provided path and return it."""
+def git_hash_object(object_path: Path, git_c_path: Optional[Path] = None) -> str:
+    """Get the unique key that git uses to refer to the blob type data object for the provided path and return it.
+
+    The optional `git_c_path` is used to tell `git` to run as if it were started in that
+    path instead of the current working directory, which is the default when not provided.
+    """
+    base_cmd = git_base_cmd(git_c_path=git_c_path)
     # Reference: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
-    cmd = ["git", "hash-object", str(object_path)]
+    cmd = base_cmd + ["hash-object", str(object_path)]
     hash_object = subprocess.run(cmd, check=True, text=True, capture_output=True).stdout.strip()
     return hash_object
+
+
+def git_repo_name(git_c_path: Optional[Path] = None) -> str:
+    """Get the git repository name and return it.
+
+    The optional `git_c_path` is used to tell `git` to run as if it were started in that
+    path instead of the current working directory, which is the default when not provided.
+
+    The repo name will be extracted from the remote's url, when a single remote exists (e.g., repo was cloned).
+    Otherwise, the repo name will be derived from the top-level directory name of the git repository. This can happen
+    for local use cases where the repository was created with `git init` and no remote set. It may also happen if there
+    are multiple remotes set or the link to the original remote was removed.
+
+    Assumptions:
+      * Only a single remote is in use if remotes are used
+      * When a remote exists, it points to a URL and not another local repo
+      * Cloned local repos without a remote defined will have a name that does not end in `.git`
+    """
+    base_cmd = git_base_cmd(git_c_path=git_c_path)
+
+    try:
+        remote = git_remote(git_c_path=git_c_path)
+        is_remote_defined = True
+        cmd = base_cmd + ["remote", "get-url", remote]
+    except RuntimeError as err:
+        print(f" [!] {err}. Will get the repo name from the local repository instead.")
+        is_remote_defined = False
+        cmd = base_cmd + ["rev-parse", "--show-toplevel"]
+
+    full_repo_name = subprocess.run(cmd, check=True, text=True, capture_output=True).stdout.strip()
+
+    repo_name = os.path.basename(full_repo_name)
+    if is_remote_defined and repo_name.endswith(".git"):
+        repo_name, _ = os.path.splitext(repo_name)
+
+    return repo_name

--- a/src/phylum/ci/lockfile.py
+++ b/src/phylum/ci/lockfile.py
@@ -35,14 +35,14 @@ class Lockfile:
         """Return a debug printable string representation of the `Lockfile` object."""
         # NOTE: Any change from this format should be made carefully as caller's
         #       may be relying on `repr(lockfile)` to provide the relative path.
-        #       Example: print(f"Relative path to lockfile: {lockfile!r}")
+        #       Example: print(f"Relative path to lockfile: `{lockfile!r}`")
         return str(self.path.relative_to(Path.cwd()))
 
     def __str__(self) -> str:
         """Return the nicely printable string representation of the `Lockfile` object."""
         # NOTE: Any change from this format should be made carefully as caller's
         #       may be relying on `str(lockfile)` to provide the path.
-        #       Example: print(f"Path to lockfile: {lockfile}")
+        #       Example: print(f"Path to lockfile: `{lockfile}`")
         return str(self.path)
 
     def __lt__(self: Self, other: Self) -> bool:
@@ -86,7 +86,7 @@ class Lockfile:
 
         prev_lockfile_object = self.previous_lockfile_object()
         if not prev_lockfile_object:
-            print(f" [+] No previous lockfile object found for {self.path}. Assuming all current packages are new.")
+            print(f" [+] No previous lockfile object found for `{self!r}`. Assuming all current packages are new.")
             return curr_lockfile_packages
 
         prev_lockfile_packages = self.get_previous_lockfile_packages(prev_lockfile_object)
@@ -98,7 +98,7 @@ class Lockfile:
         #       https://github.com/phylum-dev/roadmap/issues/263
         new_deps_set = curr_pkg_set.difference(prev_pkg_set)
         new_deps_list = sorted(new_deps_set)
-        print(f" [+] New dependencies in {self.path}: {new_deps_list}")
+        print(f" [+] New dependencies in `{self!r}`: {new_deps_list}")
         return new_deps_list
 
     def current_lockfile_packages(self) -> Packages:
@@ -110,7 +110,7 @@ class Lockfile:
             print(f" [!] There was an error running the command: {' '.join(err.cmd)}")
             print(f" [!] stdout:\n{err.stdout}")
             print(f" [!] stderr:\n{err.stderr}")
-            raise SystemExit(f" [!] Is {self.path} valid? If so, please report this as a bug.") from err
+            raise SystemExit(f" [!] Is `{self!r}` a valid lockfile? If so, please report this as a bug.") from err
         parsed_pkgs = json.loads(parse_result)
         curr_lockfile_packages = [PackageDescriptor(**pkg) for pkg in parsed_pkgs]
         return curr_lockfile_packages
@@ -158,8 +158,9 @@ class Lockfile:
                 print(f" [!] stderr:\n{err.stderr}")
                 msg = textwrap.dedent(
                     f"""\
-                    [!] Due to error, assuming no previous lockfile packages for {self!r}@{self.common_ancestor_commit}.
-                        Please report this as a bug if you believe there is a valid lockfile at that revision.
+                    [!] Due to error, assuming no previous lockfile packages.
+                        Please report this as a bug if you believe `{self!r}`
+                        is a valid lockfile at revision `{self.common_ancestor_commit}`.
                     """
                 )
                 print(msg)

--- a/src/phylum/ci/lockfile.py
+++ b/src/phylum/ci/lockfile.py
@@ -1,0 +1,163 @@
+"""Define a lockfile implementation.
+
+A Phylum project can consist of multiple lockfiles.
+This class represents a single lockfile.
+"""
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import List, Optional, TypeVar
+
+from phylum.ci.common import PackageDescriptor, Packages
+
+# Starting with Python 3.11, the `typing.Self` type was introduced to do this same thing.
+# Reference: https://peps.python.org/pep-0673/
+Self = TypeVar("Self", bound="Lockfile")
+
+
+class Lockfile:
+    """Provide methods for an instance of a lockfile."""
+
+    def __init__(self, provided_lockfile: Path, cli_path: Path, common_ancestor_commit: Optional[str]) -> None:
+        """Initialize a lockfile object."""
+        self._path = provided_lockfile.resolve()
+        self.cli_path = cli_path
+        self._common_ancestor_commit = common_ancestor_commit
+        self._is_lockfile_changed: Optional[bool] = None
+
+        if not shutil.which("git"):
+            raise SystemExit(" [!] `git` is required to be installed and available on the PATH")
+
+    def __repr__(self) -> str:
+        """Return a debug printable string representation of the `Lockfile` object."""
+        return str(self.path.relative_to(Path.cwd()))
+
+    def __str__(self) -> str:
+        """Return the nicely printable string representation of the `Lockfile` object."""
+        # NOTE: Any change from this format should be made carefully as caller's
+        #       may be relying on `str(lockfile)` to provide the path.
+        #       Example: print(f"Path to lockfile: {lockfile}")
+        return str(self.path)
+
+    def __lt__(self: Self, other: Self) -> bool:
+        """Provide a less than "rich comparison" method to enable sorting class objects."""
+        return self.path < other.path
+
+    @property
+    def path(self) -> Path:
+        """Get the lockfile path."""
+        return self._path
+
+    @property
+    def is_lockfile_changed(self) -> Optional[bool]:
+        """Predicate for detecting if the lockfile has changed."""
+        return self._is_lockfile_changed
+
+    @is_lockfile_changed.setter
+    def is_lockfile_changed(self, value: bool) -> None:
+        """Set the value for whether the lockfile has changed."""
+        self._is_lockfile_changed = value
+
+    @property
+    def common_ancestor_commit(self) -> Optional[str]:
+        """Get the common ancestor commit.
+
+        It will be returned as a string of the SHA1 sum representing the commit.
+        When it isn't provided, `None` will be returned.
+        """
+        return self._common_ancestor_commit
+
+    @property
+    def new_deps(self) -> Packages:
+        """Get the new dependencies added to the lockfile and return them in sorted order."""
+        # Only consider newly added dependencies
+        if self.is_lockfile_changed is None:
+            print(" [!] The `is_lockfile_changed` property has not been set yet")
+        if not self.is_lockfile_changed:
+            return []
+
+        curr_lockfile_packages = self.current_lockfile_packages()
+
+        prev_lockfile_object = self.previous_lockfile_object()
+        if not prev_lockfile_object:
+            print(f" [+] No previous lockfile object found for {self.path}. Assuming all current packages are new.")
+            return curr_lockfile_packages
+
+        prev_lockfile_packages = self.get_previous_lockfile_packages(prev_lockfile_object)
+
+        prev_pkg_set = set(prev_lockfile_packages)
+        curr_pkg_set = set(curr_lockfile_packages)
+
+        # TODO: Consider using these new dependencies to track the output findings...as mapped to a lockfile.
+        #       https://github.com/phylum-dev/roadmap/issues/263
+        new_deps_set = curr_pkg_set.difference(prev_pkg_set)
+        new_deps_list = sorted(new_deps_set)
+        print(f" [+] New dependencies in {self.path}: {new_deps_list}")
+        return new_deps_list
+
+    def current_lockfile_packages(self) -> Packages:
+        """Get the current lockfile packages."""
+        try:
+            cmd = [str(self.cli_path), "parse", str(self.path)]
+            parse_result = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
+        except subprocess.CalledProcessError as err:
+            print(f" [!] There was an error running the command: {' '.join(err.cmd)}")
+            print(f" [!] stdout:\n{err.stdout}")
+            print(f" [!] stderr:\n{err.stderr}")
+            raise SystemExit(f" [!] Is {self.path} valid? If so, please report this as a bug.") from err
+        parsed_pkgs = json.loads(parse_result)
+        curr_lockfile_packages = [PackageDescriptor(**pkg) for pkg in parsed_pkgs]
+        return curr_lockfile_packages
+
+    def previous_lockfile_object(self) -> Optional[str]:
+        """Get the previous git object for the lockfile.
+
+        Return None when no previous lockfile object can be found.
+        """
+        if not self.common_ancestor_commit:
+            return None
+        try:
+            cmd = ["git", "rev-parse", "--verify", f"{self.common_ancestor_commit}:{self.path.name}"]
+            prev_lockfile_object = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
+        except subprocess.CalledProcessError as err:
+            # There could be a true error, but the working assumption when here is a previous version does not exist
+            print(f" [?] There *may* be an issue with the attempt to get the previous lockfile object: {err}")
+            print(f" [?] stdout:\n{err.stdout}")
+            print(f" [?] stderr:\n{err.stderr}")
+            print(" [+] Assuming a previous lockfile version does not exist ...")
+            prev_lockfile_object = None
+        return prev_lockfile_object
+
+    def get_previous_lockfile_packages(self, prev_lockfile_object: str) -> Packages:
+        """Get the previous lockfile packages from the corresponding git object and return them."""
+        with tempfile.NamedTemporaryFile(mode="w+") as prev_lockfile_fd:
+            try:
+                cmd = ["git", "cat-file", "blob", prev_lockfile_object]
+                prev_lockfile_contents = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout
+                prev_lockfile_fd.write(prev_lockfile_contents)
+                prev_lockfile_fd.flush()
+            except subprocess.CalledProcessError as err:
+                print(f" [!] There was an error running the command: {' '.join(err.cmd)}")
+                print(f" [!] stdout:\n{err.stdout}")
+                print(f" [!] stderr:\n{err.stderr}")
+                print(" [!] Due to error, assuming no previous lockfile packages. Please report this as a bug.")
+                return []
+            try:
+                cmd = [str(self.cli_path), "parse", prev_lockfile_fd.name]
+                parse_result = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
+            except subprocess.CalledProcessError as err:
+                print(f" [!] There was an error running the command: {' '.join(err.cmd)}")
+                print(f" [!] stdout:\n{err.stdout}")
+                print(f" [!] stderr:\n{err.stderr}")
+                print(" [!] Due to error, assuming no previous lockfile packages. Please report this as a bug.")
+                return []
+
+        parsed_pkgs = json.loads(parse_result)
+        prev_lockfile_packages = [PackageDescriptor(**pkg) for pkg in parsed_pkgs]
+        return prev_lockfile_packages
+
+
+# Type alias
+Lockfiles = List[Lockfile]

--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -2,12 +2,12 @@
 from phylum import __version__
 
 # This is the minimum CLI version supported for new installs.
-# `--label` was added as a long form option to the analyze command starting with v3.12.0
-MIN_CLI_VER_FOR_INSTALL = "v3.12.0"
+# Ability to specify multiple lockfiles was added in v4.5.0
+MIN_CLI_VER_FOR_INSTALL = "v4.5.0"
 
 # This is the minimum CLI version supported for existing installs.
-# `--label` was added as a long form option to the analyze command starting with v3.12.0
-MIN_CLI_VER_INSTALLED = "v3.12.0"
+# Ability to specify multiple lockfiles was added in v4.5.0
+MIN_CLI_VER_INSTALLED = "v4.5.0"
 
 # Keys are lowercase machine hardware names as returned from `uname -m`.
 # Values are the mapped rustc architecture.
@@ -42,7 +42,6 @@ SUPPORTED_LOCKFILES = {
     # Python
     "requirements.txt": "pip",
     "Pipfile.lock": "pipenv",
-    "Pipfile": "pipenv",
     "poetry.lock": "poetry",
     # C#
     "*.csproj": "nuget",

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -1,0 +1,46 @@
+"""Test the git helper functions."""
+
+from pathlib import Path
+
+import pytest
+from dulwich import porcelain
+
+from phylum.ci.git import git_repo_name
+
+# Names of a git repository that will be initialized locally
+LOCAL_REPO_NAMES = [
+    "local_repo_name",
+    "local_repo.name",
+    "local_repo.git",
+    "local.repo.name",
+]
+
+
+@pytest.mark.parametrize("repo_name", LOCAL_REPO_NAMES)
+def test_initialized_local_repo_name(tmp_path, repo_name):
+    """Ensure a local repo, with no remotes, has it's name correctly identified."""
+    repo_path: Path = tmp_path / repo_name
+    porcelain.init(str(repo_path))
+    local_repo_name = git_repo_name(git_c_path=repo_path)
+    assert local_repo_name == repo_name, "The local repo name should be found"
+
+
+@pytest.mark.parametrize("repo_name", LOCAL_REPO_NAMES)
+def test_cloned_local_repo_name(tmp_path, repo_name: str):
+    """Ensure a cloned local repo has it's name correctly identified."""
+    if repo_name.endswith(".git"):
+        pytest.skip("Cloned local repos with a name ending in `.git` are not supported")
+    init_repo_path: Path = tmp_path / repo_name
+    cloned_repo_path: Path = tmp_path / "cloned_local_repo_name"
+    porcelain.init(str(init_repo_path))
+    porcelain.clone(source=str(init_repo_path), target=str(cloned_repo_path))
+    remote_repo_name = git_repo_name(git_c_path=cloned_repo_path)
+    assert remote_repo_name == repo_name, "The cloned local repo name should be found"
+
+
+def test_cloned_remote_repo_name(tmp_path):
+    """Ensure a cloned remote repo has it's name correctly identified."""
+    repo_path: Path = tmp_path / "cloned_remote_repo_name"
+    porcelain.clone(source="https://github.com/phylum-dev/phylum-ci.git", target=str(repo_path), depth=1)
+    remote_repo_name = git_repo_name(git_c_path=repo_path)
+    assert remote_repo_name == "phylum-ci", "The cloned remote repo name should be found"

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -7,16 +7,19 @@ from dulwich import porcelain
 
 from phylum.ci.git import git_repo_name
 
-# Names of a git repository that will be initialized locally
-LOCAL_REPO_NAMES = [
+# Names of a git repository that will be cloned locally
+CLONED_LOCAL_REPO_NAMES = [
     "local_repo_name",
     "local_repo.name",
-    "local_repo.git",
     "local.repo.name",
 ]
 
+# Names of a git repository that will be initialized locally
+# Separate lists are used because cloned local repos with a name ending in `.git` are not supported
+INITIALIZED_LOCAL_REPO_NAMES = CLONED_LOCAL_REPO_NAMES + ["local_repo.git"]
 
-@pytest.mark.parametrize("repo_name", LOCAL_REPO_NAMES)
+
+@pytest.mark.parametrize("repo_name", INITIALIZED_LOCAL_REPO_NAMES)
 def test_initialized_local_repo_name(tmp_path, repo_name):
     """Ensure a local repo, with no remotes, has it's name correctly identified."""
     repo_path: Path = tmp_path / repo_name
@@ -25,11 +28,9 @@ def test_initialized_local_repo_name(tmp_path, repo_name):
     assert local_repo_name == repo_name, "The local repo name should be found"
 
 
-@pytest.mark.parametrize("repo_name", LOCAL_REPO_NAMES)
+@pytest.mark.parametrize("repo_name", CLONED_LOCAL_REPO_NAMES)
 def test_cloned_local_repo_name(tmp_path, repo_name: str):
     """Ensure a cloned local repo has it's name correctly identified."""
-    if repo_name.endswith(".git"):
-        pytest.skip("Cloned local repos with a name ending in `.git` are not supported")
     init_repo_path: Path = tmp_path / repo_name
     cloned_repo_path: Path = tmp_path / "cloned_local_repo_name"
     porcelain.init(str(init_repo_path))


### PR DESCRIPTION
Actions taken include:

* Add support for multiple lockfiles
  * Bump the minimum required Phylum CLI version to v4.5.0
    * Ability to specify multiple lockfiles was added then
  * Create a `Lockfile` class to represent a single lockfile
    * Move properties of a lockfile from `CIBase` to `Lockfile` class
  * Update each CI environment to update every lockfile's change status
* Consolidate initialization/instantiation logic in class properties
  * The Phylum project name
    * Generate a deterministic project name when not otherwise provided
  * The Phylum group name
  * The lockfile(s) in use
    * Detect the lockfile(s) when not otherwise provided
  * The Phylum CLI path
  * Lockfile hash object
* Move "ensure a project" function from cli to a `CIBase` class method
* Remove pre-requisite check for `.phylum_project` file
* Add restrictions to the Phylum label generation
  * Start the label with the `self.ci_platform_name`
  * Replace all runs of whitespace characters with single `-` character
  * Update each CI implementation to adhere to the restrictions
* Add  `git_repo_name` function to get a git repository's name
  * Refactor git helper functions to allow for easier testing
  * Add tests for the new function
* Add `pathspec` to main dependencies
  * Used to respect ignore files when detecting lockfiles
* Add `dulwich` to test dependencies
  * Used to test `git` functionality programmatically w/o `subprocess`
* Bump the PyPI package development status from `Alpha` to `Beta`
* Update documentation
  * Allow for the possibility of multiple lockfiles
  * Add examples for how to specify multiple lockfiles
  * Remove wording specifing the `.phylum_project` file as required
  * Add a reference to the release process in `CONTRIBUTING.md`
  * Update method for passing additional options through `poetry`/`tox`
  * Clean up formatting in `CHANGELOG.md`
* Format and refactor throughout
  * Check for 100 return code when getting `phylum analyze` results
  * Use source branch consistently in PR/MR labels
  * Use correct PR number in ADO labels for GitHub repos

Closes #147

BREAKING CHANGE: CLI installs prior to v4.5.0 are no longer supported.
A Phylum CLI version with ability to specify multiple lockfiles is
required.

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
  - A handful of new unit tests were added to cover the new `git` helper function
  - Manual testing has been completed on the local (CINone) and pre-commit environments
  - Manual testing has been completed on the CI environments for: GitHub, Bitbucket, GitLab, and Azure Pipelines
  - The changes in this PR are available for testing as a Docker image: `docker pull maxrake/phylum-ci:project_shun`
- [x] Have you updated all affected documentation?
  - [x] Documentation in the `phylum-ci` repo has been updated
  - [x] Documentation in the `phylum-analyze-pr-action` repo has been updated
    - This should happen _after_ the changes here have been released
    - See https://github.com/phylum-dev/phylum-analyze-pr-action/pull/24

## Screenshots

---

The `pre-commit` environment was exercised by updating the lockfile with a known bad dep. In this case, a `.phylum_project` file was present to obtain the project name, group, and lockfile(s) in use.

<img width="1115" alt="image" src="https://user-images.githubusercontent.com/18729796/228053232-b866e9b3-32b7-4c16-99b8-c898b43ee0da.png">

---

The `CINone` environment was exercised by updating the lockfile with a known bad dep. In this case, a `.phylum_project` file was present to obtain the project name, group, and lockfile(s) in use.

<img width="1115" alt="image" src="https://user-images.githubusercontent.com/18729796/228054335-c13008ad-c6cc-4796-b891-3c2e7183a470.png">

---

Multiple lockfiles specified as options. One of them is an empty file and get correctly filtered out.

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/18729796/228055175-a1541295-43fb-439b-8a37-d0dd29c45527.png">

---

Multiple lockfiles specified in the `.phylum_project` file. One is an empty file, another is non-existent, and a third is not actually a lockfile. These were all correctly filtered out.

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/18729796/228056327-a44bc2cd-d3f0-4644-9164-750103b9d14b.png">

---

Multiple lockfiles, at different directory levels, and no `.phylum_project` file. The `.ignore` file is not a real ignore file (it is a binary that was renamed).

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/18729796/228057771-61ceb1ba-fdf3-4482-943c-7e1bba253d9f.png">

---

Multiple lockfiles, at different directory levels, and no `.phylum_project` file. The `--force-analysis` flag is specified without the `--all-deps` flag.

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/18729796/228068532-1b34d521-3ea7-434e-b845-9f80f52e5b86.png">

---

Logs from GitHub Action run during a PR. In this case, a `requirements.txt` file that already existed in the root of the repo was updated to add a known bad dep. Additionally, a new lockfile, also named `requirements.txt`, was added with some known bad deps...but 7 levels deep in the directory tree. The findings were as expected and the PR was correctly commented.

<img width="1146" alt="image" src="https://user-images.githubusercontent.com/18729796/228050760-9bfb1b34-28c9-4c83-b110-e89a5c04e7f4.png">


---

Logs from Bitbucket run in a branch pipeline.

<img width="2492" alt="image" src="https://user-images.githubusercontent.com/18729796/228073106-d06dee14-ad11-43a3-9329-a8f78667e34c.png">

---

Logs from GitLab run in a branch pipeline. The lockfile was specified on the command line since it has a non-standard name. The `.phylum_project` file was removed and the dependencies were updated to be current.

<img width="1296" alt="image" src="https://user-images.githubusercontent.com/18729796/228304266-aee88526-91f0-4f0d-9301-44e0052e433a.png">

---

Logs from GitLab run in a merge request pipeline. The lockfile was updated to add a few known bad deps. The comment was applied to the MR correctly.

<img width="1296" alt="image" src="https://user-images.githubusercontent.com/18729796/228308224-366aebce-d318-4b34-819d-d477b92a24a1.png">

---

Logs from Azure Pipelines run in a CI trigger pipeline context. The `.phylum_project` file was removed and the dependencies were updated to be current.

<img width="1794" alt="image" src="https://user-images.githubusercontent.com/18729796/228320892-517b39bd-2fb2-4020-b5ea-2522fe0ab38c.png">

---

Logs from Azure Pipelines run in XYZ pipeline context. The lockfile was updated to add a few known bad deps. The comment was applied to the PR correctly.

<img width="1794" alt="image" src="https://user-images.githubusercontent.com/18729796/228328175-7bd09c3b-3abf-4de3-b883-8c40cdd288db.png">

---