### PR TITLE
chore!: drop Python 3.7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     defaults:
       run:
         shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     rev: 01cee377ba3a5264c7fbe7b6beae7b575f764dc3  # frozen: v3.3.1
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
 
   # NOTE: don't use this config for your own repositories. Instead, see
   #       "Git pre-commit Integration" in `docs/sync/git_precommit.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,9 +103,9 @@ Here's how to set up `phylum-ci` for local development.
 3. Ensure all supported Python versions are installed locally
    1. The strategy is to support all released minor versions of Python that are not end-of-life yet
    2. The current list
-      1. at the time of this writing is 3.7, 3.8, 3.9, 3.10, and 3.11
+      1. at the time of this writing is 3.8, 3.9, 3.10, and 3.11
       2. can be inferred with the Python Developer's Guide, which maintains the
-         [status of active Python releases](https://devguide.python.org/#status-of-python-branches)
+         [status of active Python releases](https://devguide.python.org/versions/)
    3. It is recommended to use [`pyenv`](https://github.com/pyenv/pyenv) to manage multiple Python installations
 
     ```sh
@@ -115,7 +115,6 @@ Here's how to set up `phylum-ci` for local development.
 
     # NOTE: These versions are examples; the latest patch version available from
     #       pyenv should be used in place of `.x`.
-    pyenv install 3.7.x
     pyenv install 3.8.x
     pyenv install 3.9.x
     pyenv install 3.10.x
@@ -123,7 +122,7 @@ Here's how to set up `phylum-ci` for local development.
     pyenv rehash
 
     # Ensure all environments are available globally (helps tox to find them)
-    pyenv global 3.11.x 3.10.x 3.9.x 3.8.x 3.7.x
+    pyenv global 3.11.x 3.10.x 3.9.x 3.8.x
     ```
 
 4. Ensure [poetry v1.3+](https://python-poetry.org/docs/) is installed
@@ -208,7 +207,7 @@ Before you submit a pull request, check that it meets these guidelines:
 * Have you created sufficient tests?
 * Have you updated all affected documentation?
 
-The pull request should work for Python 3.7, 3.8, 3.9, 3.10, and 3.11.
+The pull request should work for Python 3.8, 3.9, 3.10, and 3.11.
 Check <https://github.com/phylum-dev/phylum-ci/actions> and make sure that the tests
 pass for all supported Python versions.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pipx run --spec phylum phylum-init <options>
 pipx run --spec phylum phylum-ci <options>
 ```
 
-These installation methods require Python 3.7+ to run.
+These installation methods require Python 3.8+ to run.
 For a self contained environment, consider using the Docker image as described below.
 
 ### Usage

--- a/poetry.lock
+++ b/poetry.lock
@@ -20,18 +20,6 @@ tests = ["attrs[tests-no-zope]", "zope.interface"]
 tests-no-zope = ["cloudpickle", "cloudpickle", "hypothesis", "hypothesis", "mypy (>=0.971,<0.990)", "mypy (>=0.971,<0.990)", "pympler", "pympler", "pytest (>=4.3.0)", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-mypy-plugins", "pytest-xdist[psutil]", "pytest-xdist[psutil]"]
 
 [[package]]
-name = "backports-cached-property"
-version = "1.0.2"
-description = "cached_property() - computed once per instance, cached as attribute"
-category = "main"
-optional = false
-python-versions = ">=3.6.0"
-files = [
-    {file = "backports.cached-property-1.0.2.tar.gz", hash = "sha256:9306f9eed6ec55fd156ace6bc1094e2c86fae5fb2bf07b6a9c00745c656e75dd"},
-    {file = "backports.cached_property-1.0.2-py3-none-any.whl", hash = "sha256:baeb28e1cd619a3c9ab8941431fe34e8490861fb998c6c4590693d50171db0cc"},
-]
-
-[[package]]
 name = "bleach"
 version = "6.0.0"
 description = "An easy safelist-based HTML-sanitizing tool."
@@ -262,7 +250,6 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "click-log"
@@ -467,7 +454,6 @@ files = [
 ]
 
 [package.dependencies]
-typing-extensions = {version = "*", markers = "python_version <= \"3.7\""}
 urllib3 = ">=1.25"
 
 [package.extras]
@@ -536,7 +522,6 @@ files = [
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
-typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "idna"
@@ -554,7 +539,7 @@ files = [
 name = "importlib-metadata"
 version = "6.1.0"
 description = "Read metadata from Python packages"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -563,7 +548,6 @@ files = [
 ]
 
 [package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
@@ -663,11 +647,9 @@ files = [
 
 [package.dependencies]
 attrs = ">=17.4.0"
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
 pkgutil-resolve-name = {version = ">=1.3.10", markers = "python_version < \"3.9\""}
 pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
@@ -827,7 +809,6 @@ files = [
 
 [package.dependencies]
 mdurl = ">=0.1,<1.0"
-typing_extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
 benchmarking = ["psutil", "pytest", "pytest-benchmark"]
@@ -926,9 +907,6 @@ files = [
     {file = "platformdirs-3.2.0.tar.gz", hash = "sha256:d5b638ca397f25f979350ff789db335903d7ea010ab28903f57b27e1b16c2b08"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=4.5", markers = "python_version < \"3.8\""}
-
 [package.extras]
 docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.2.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
@@ -944,9 +922,6 @@ files = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
-
-[package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
@@ -1052,7 +1027,6 @@ files = [
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
@@ -1417,7 +1391,6 @@ files = [
 
 [package.dependencies]
 click = ">=7"
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 rich = ">=10.7.0"
 
 [package.extras]
@@ -1437,7 +1410,6 @@ files = [
 
 [package.dependencies]
 GitPython = "*"
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 jsonschema = "*"
 levenshtein = ">=0.18.1"
 pyyaml = "*"
@@ -1638,13 +1610,11 @@ cachetools = ">=5.3"
 chardet = ">=5.1"
 colorama = ">=0.4.6"
 filelock = ">=3.10"
-importlib-metadata = {version = ">=6.1", markers = "python_version < \"3.8\""}
 packaging = ">=23"
 platformdirs = ">=3.1.1"
 pluggy = ">=1"
 pyproject-api = ">=1.5.1"
 tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.5", markers = "python_version < \"3.8\""}
 virtualenv = ">=20.21"
 
 [package.extras]
@@ -1785,7 +1755,6 @@ files = [
 [package.dependencies]
 distlib = ">=0.3.6,<1"
 filelock = ">=3.4.1,<4"
-importlib-metadata = {version = ">=4.8.3", markers = "python_version < \"3.8\""}
 platformdirs = ">=2.4,<4"
 
 [package.extras]
@@ -1823,7 +1792,7 @@ test = ["pytest (>=6.0.0)"]
 name = "zipp"
 version = "3.15.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1837,5 +1806,5 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.7,<3.12"
-content-hash = "b867eadd27ef58dafebae80db89d10522df351c77352efc463135ea08f593250"
+python-versions = ">=3.8,<3.12"
+content-hash = "07266d395f60d5aede8b129bdf22f065538367fbb8b617f52523a8a167a7907d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: Software Development :: Quality Assurance",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -46,17 +45,13 @@ phylum-init = "phylum.init.cli:main"
 phylum-ci = "phylum.ci.cli:script_main"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.12"
+python = ">=3.8,<3.12"
 requests = "*"
 cryptography = "*"
 packaging = "*"
 "ruamel.yaml" = "*"
 connect-markdown-renderer = "*"
 pathspec = "*"
-# TODO: Remove these deps when Python 3.7 support is removed: importlib-metadata and backports-cached-property
-#       https://github.com/phylum-dev/phylum-ci/issues/18
-importlib-metadata = {version = "*", python = "<3.8"}
-backports-cached-property = "*"
 
 [tool.poetry.group.test]
 optional = true

--- a/src/phylum/__init__.py
+++ b/src/phylum/__init__.py
@@ -1,15 +1,9 @@
 """Top-level package for phylum."""
-# TODO: Use only the standard library form (importlib.metadata) after Python 3.7 support is dropped
-#       https://github.com/phylum-dev/phylum-ci/issues/18
-try:
-    import importlib.metadata as importlib_metadata
-except ModuleNotFoundError:
-    import importlib_metadata
+from importlib.metadata import metadata, version
 
+PKG_METADATA = metadata(__name__)
 
-PKG_METADATA = importlib_metadata.metadata(__name__)
-
-__version__ = importlib_metadata.version(__name__)
+__version__ = version(__name__)
 __author__ = PKG_METADATA["Author"]
 __email__ = PKG_METADATA["Author-email"]
 

--- a/src/phylum/ci/ci_azure.py
+++ b/src/phylum/ci/ci_azure.py
@@ -22,11 +22,10 @@ import shlex
 import subprocess
 import urllib.parse
 from argparse import Namespace
-from functools import lru_cache
+from functools import cached_property, lru_cache
 from typing import Optional
 
 import requests
-from backports.cached_property import cached_property
 
 from phylum.ci.ci_base import CIBase
 from phylum.ci.ci_github import post_github_comment

--- a/src/phylum/ci/ci_azure.py
+++ b/src/phylum/ci/ci_azure.py
@@ -220,8 +220,7 @@ class CIAzure(CIBase):
                 tgt_branch = f"{new_ref_prefix}{tgt_branch}"
 
         cmd = ["git", "merge-base", src_branch, tgt_branch]
-        shell_escaped_cmd = " ".join(shlex.quote(arg) for arg in cmd)
-        print(f" [*] Finding common ancestor commit with command: {shell_escaped_cmd}")
+        print(f" [*] Finding common ancestor commit with command: {shlex.join(cmd)}")
         try:
             common_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
         except subprocess.CalledProcessError as err:

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -13,11 +13,11 @@ import urllib.parse
 from abc import ABC, abstractmethod
 from argparse import Namespace
 from collections import OrderedDict
+from functools import cached_property
 from pathlib import Path
 from typing import List, Optional
 
 import pathspec
-from backports.cached_property import cached_property
 from connect.utils.terminal.markdown import render
 from packaging.version import Version
 from ruamel.yaml import YAML

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -391,8 +391,7 @@ class CIBase(ABC):
         elif ret.returncode == 14:
             print(f" [-] Project {self.phylum_project} already exists. Continuing with it ...")
         else:
-            shell_escaped_cmd = " ".join(shlex.quote(arg) for arg in cmd)
-            print(f" [!] There was a problem creating the project with command: {shell_escaped_cmd}")
+            print(f" [!] There was a problem creating the project with command: {shlex.join(cmd)}")
             ret.check_returncode()
 
     def post_output(self) -> None:

--- a/src/phylum/ci/ci_bitbucket.py
+++ b/src/phylum/ci/ci_bitbucket.py
@@ -166,8 +166,7 @@ class CIBitbucket(CIBase):
             tgt_branch = f"{new_ref_prefix}{tgt_branch}"
 
         cmd = ["git", "merge-base", src_branch, tgt_branch]
-        shell_escaped_cmd = " ".join(shlex.quote(arg) for arg in cmd)
-        print(f" [*] Finding common ancestor commit with command: {shell_escaped_cmd}")
+        print(f" [*] Finding common ancestor commit with command: {shlex.join(cmd)}")
         try:
             common_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
         except subprocess.CalledProcessError as err:

--- a/src/phylum/ci/ci_bitbucket.py
+++ b/src/phylum/ci/ci_bitbucket.py
@@ -22,11 +22,10 @@ import shlex
 import subprocess
 import urllib.parse
 from argparse import Namespace
-from functools import lru_cache
+from functools import cached_property, lru_cache
 from typing import Optional
 
 import requests
-from backports.cached_property import cached_property
 
 from phylum.ci.ci_base import CIBase
 from phylum.ci.constants import PHYLUM_HEADER

--- a/src/phylum/ci/ci_github.py
+++ b/src/phylum/ci/ci_github.py
@@ -15,10 +15,10 @@ import os
 import re
 import subprocess
 from argparse import Namespace
+from functools import cached_property
 from typing import Optional
 
 import requests
-from backports.cached_property import cached_property
 
 from phylum.ci.ci_base import CIBase
 from phylum.ci.constants import PHYLUM_HEADER

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -12,11 +12,10 @@ import re
 import shlex
 import subprocess
 from argparse import Namespace
-from functools import lru_cache
+from functools import cached_property, lru_cache
 from typing import Optional
 
 import requests
-from backports.cached_property import cached_property
 
 from phylum.ci.ci_base import CIBase
 from phylum.ci.constants import PHYLUM_HEADER

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -127,8 +127,7 @@ class CIGitLab(CIBase):
         # This is a best effort attempt since it is finding the merge base between the current commit
         # and the default branch instead of finding the exact commit from which the branch was created.
         cmd = ["git", "merge-base", src_branch, default_branch]
-        shell_escaped_cmd = " ".join(shlex.quote(arg) for arg in cmd)
-        print(f" [*] Finding common ancestor commit with command: {shell_escaped_cmd}")
+        print(f" [*] Finding common ancestor commit with command: {shlex.join(cmd)}")
         try:
             common_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
         except subprocess.CalledProcessError as err:

--- a/src/phylum/ci/ci_none.py
+++ b/src/phylum/ci/ci_none.py
@@ -7,10 +7,9 @@ This is also the fallback implementation to use when no known CI platform is det
 import argparse
 import re
 import subprocess
+from functools import cached_property
 from pathlib import Path
 from typing import Optional
-
-from backports.cached_property import cached_property
 
 from phylum.ci.ci_base import CIBase
 from phylum.ci.git import git_curent_branch_name, git_remote

--- a/src/phylum/ci/ci_precommit.py
+++ b/src/phylum/ci/ci_precommit.py
@@ -12,10 +12,9 @@ import argparse
 import re
 import subprocess
 import sys
+from functools import cached_property
 from pathlib import Path
 from typing import List, Optional
-
-from backports.cached_property import cached_property
 
 from phylum.ci.ci_base import CIBase
 from phylum.ci.git import git_curent_branch_name

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -79,8 +79,7 @@ def get_phylum_analysis(ci_env: CIBase) -> dict:
     cmd.extend(["--verbose", "--json"])
     cmd.extend(str(lockfile.path) for lockfile in ci_env.lockfiles)
 
-    shell_escaped_cmd = " ".join(shlex.quote(arg) for arg in cmd)
-    print(f" [*] Performing analysis with command: {shell_escaped_cmd}")
+    print(f" [*] Performing analysis with command: {shlex.join(cmd)}")
     try:
         analysis_result = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout
     except subprocess.CalledProcessError as err:

--- a/tests/unit/test_package_metadata.py
+++ b/tests/unit/test_package_metadata.py
@@ -18,7 +18,7 @@ def test_project_version():
 
 def test_python_version():
     """Ensure the python version used to test is a supported version."""
-    supported_minor_versions = (7, 8, 9, 10, 11)
+    supported_minor_versions = (8, 9, 10, 11)
     python_version = sys.version_info
     assert python_version.major == 3, "Only Python 3 is supported"
     assert python_version.minor in supported_minor_versions, "Attempting to run unsupported Python version"

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py37, py38, py39, py310, py311
+envlist = py38, py39, py310, py311
 isolated_build = true
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
This PR is about three months early...at least based on the EOL date in [the Python Developer's Guide](https://devguide.python.org/versions/)...but should not be a big deal. This change was made now to help pave the way for some upcoming QA work (type checking, linting, etc.). Changes made include:

* Upgrade `pyupgrade` pre-commit hook
* Update `pyproject.toml` and regenerate `poetry.lock` 
  * Uses of `backports.cached_property` were replaced with the standard lib `functools.cached_property`
* Use standard lib `importlib.metadata`
  * This replaces the backported `importlib_metadata` package
* Use `shlex.join()` function
  * The `shlex.join()` function was introduced in Python 3.8 and returns a
shell-escaped string from a split command
  * It is used to protect against injection vulnerabilities
  * It is the inverse of `shlex.split()` and simplifies the previous method of manually using `shlex.quote()` for every piece of the command line input
* Update tests
  * Remove Python 3.7 from tox
  * Update the test workflow
  * Update the test for supported Python versions
* Update documentation and remove references to Python 3.7

Closes #18 

BREAKING CHANGE: Support for Python 3.7 was removed due to its imminent end of life

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?
