### PR TITLE
feat: detect SPDX formatted SBOM files

### DIFF
--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -52,6 +52,11 @@ SUPPORTED_LOCKFILES = {
     "go.sum": "go",
     # Rust
     "Cargo.lock": "cargo",
+    # SBOM
+    "*.spdx.json": "spdx",
+    "*.spdx.yaml": "spdx",
+    "*.spdx.yml": "spdx",
+    "*.spdx": "spdx",
 }
 
 # Timeout value, in seconds, to tell the Python Requests package to stop waiting for a response.


### PR DESCRIPTION
Add support for SPDX file types in the supported lockfiles in `phylum-ci`.

## Screenshots

```console
../phylum-ci  8  21 on  detect_spdx [✘!?] is 📦 v0.25.0 via 🐍 v3.11.2
❯ cp ../localdev/cli/tests/fixtures/spdx-2.* delme/

../phylum-ci  8  21 on  detect_spdx [✘!?] is 📦 v0.25.0 via 🐍 v3.11.2
❯ l delme
total 12824
drwxr-xr-x   8 maxrake  staff   256B Apr  4 15:41 .
drwxr-xr-x  32 maxrake  staff   1.0K Apr  4 15:40 ..
-rw-r--r--   1 maxrake  staff     0B Mar 13 11:59 empty.txt
-rw-r--r--   1 maxrake  staff   192B Mar 22 17:22 requirements.txt
-rw-r--r--   1 maxrake  staff   2.5M Apr  4 15:41 spdx-2.2.spdx
-rw-r--r--   1 maxrake  staff    10K Apr  4 15:41 spdx-2.2.spdx.json
-rw-r--r--   1 maxrake  staff   3.7M Apr  4 15:41 spdx-2.3.spdx.json
-rw-r--r--   1 maxrake  staff    16K Apr  4 15:41 spdx-2.3.spdx.yaml

../phylum-ci  8  21 on  detect_spdx [✘!?] is 📦 v0.25.0 via 🐍 v3.11.2
❯ phylum-ci --version
phylum-ci 0.25.0

../phylum-ci  8  21 on  detect_spdx [✘!?] is 📦 v0.25.0 via 🐍 v3.11.2
❯ phylum-ci
 [+] Phylum CLI version not specified
 [+] Found installed Phylum CLI version: v4.8.0
 [*] Using Phylum CLI version: v4.8.0
 [+] No CI environment detected
 [+] Confirming pre-requisites ...
 [+] `git` binary found on the PATH
 [+] Existing `.git` directory was found at the current working directory
 [+] All pre-requisites met
 [+] Project name not provided as argument. Checking the `.phylum_project` file ...
 [+] Project name not found in the `.phylum_project` file or file does not exist. Detecting instead ...
 [+] Project name detected from git repository name: phylum-ci
 [*] Attempting to create a Phylum project with the name: phylum-ci ...
 [+] Existing Phylum CLI instance found: v4.8.0 at /Users/maxrake/.local/bin/phylum
 [+] Using Phylum CLI instance: v4.8.0 at /Users/maxrake/.local/bin/phylum
 [-] Project phylum-ci created successfully.
 [+] No valid lockfiles were provided as arguments. Checking the `.phylum_project` file ...
 [+] No valid lockfiles in the `.phylum_project` file. An attempt will be made to detect lockfiles.
 [+] Detected lockfile(s): [PosixPath('/Users/maxrake/dev/phylum/phylum-ci/delme/requirements.txt'), PosixPath('/Users/maxrake/dev/phylum/phylum-ci/poetry.lock')]
 [-] Valid detected lockfiles: [delme/requirements.txt, poetry.lock]
 [+] lockfile(s) in use: [delme/requirements.txt, poetry.lock]
 [*] Checking `delme/requirements.txt` for changes ...
 [-] The lockfile `delme/requirements.txt` has not changed
 [*] Checking `poetry.lock` for changes ...
 [-] The lockfile `poetry.lock` has not changed
 [+] No lockfile has changed. Nothing to do.

../phylum-ci  8  22 on  detect_spdx [!?] is 📦 v0.25.0 via 🐍 v3.11.2 took 4s
❯ poetry run phylum-ci
 [+] Phylum CLI version not specified
 [+] Found installed Phylum CLI version: v4.8.0
 [*] Using Phylum CLI version: v4.8.0
 [+] No CI environment detected
 [+] Confirming pre-requisites ...
 [+] `git` binary found on the PATH
 [+] Existing `.git` directory was found at the current working directory
 [+] All pre-requisites met
 [+] Project name not provided as argument. Checking the `.phylum_project` file ...
 [+] Project name provided in `.phylum_project` file: phylum-ci
 [*] Attempting to create a Phylum project with the name: phylum-ci ...
 [+] Existing Phylum CLI instance found: v4.8.0 at /Users/maxrake/.local/bin/phylum
 [+] Using Phylum CLI instance: v4.8.0 at /Users/maxrake/.local/bin/phylum
 [-] Project phylum-ci already exists. Continuing with it ...
 [+] No valid lockfiles were provided as arguments. Checking the `.phylum_project` file ...
 [+] No valid lockfiles in the `.phylum_project` file. An attempt will be made to detect lockfiles.
 [+] Detected lockfile(s): [PosixPath('/Users/maxrake/dev/phylum/phylum-ci/delme/requirements.txt'), PosixPath('/Users/maxrake/dev/phylum/phylum-ci/poetry.lock'), PosixPath('/Users/maxrake/dev/phylum/phylum-ci/delme/spdx-2.2.spdx.json'), PosixPath('/Users/maxrake/dev/phylum/phylum-ci/delme/spdx-2.3.spdx.json'), PosixPath('/Users/maxrake/dev/phylum/phylum-ci/delme/spdx-2.3.spdx.yaml'), PosixPath('/Users/maxrake/dev/phylum/phylum-ci/delme/spdx-2.2.spdx')]
 [-] Valid detected lockfiles: [delme/requirements.txt, delme/spdx-2.2.spdx, delme/spdx-2.2.spdx.json, delme/spdx-2.3.spdx.json, delme/spdx-2.3.spdx.yaml, poetry.lock]
 [+] lockfile(s) in use: [delme/requirements.txt, delme/spdx-2.2.spdx, delme/spdx-2.2.spdx.json, delme/spdx-2.3.spdx.json, delme/spdx-2.3.spdx.yaml, poetry.lock]
 [*] Checking `delme/requirements.txt` for changes ...
 [-] The lockfile `delme/requirements.txt` has not changed
 [*] Checking `delme/spdx-2.2.spdx` for changes ...
 [-] The lockfile `delme/spdx-2.2.spdx` has not changed
 [*] Checking `delme/spdx-2.2.spdx.json` for changes ...
 [-] The lockfile `delme/spdx-2.2.spdx.json` has not changed
 [*] Checking `delme/spdx-2.3.spdx.json` for changes ...
 [-] The lockfile `delme/spdx-2.3.spdx.json` has not changed
 [*] Checking `delme/spdx-2.3.spdx.yaml` for changes ...
 [-] The lockfile `delme/spdx-2.3.spdx.yaml` has not changed
 [*] Checking `poetry.lock` for changes ...
 [-] The lockfile `poetry.lock` has not changed
 [+] No lockfile has changed. Nothing to do.

../phylum-ci  8  22 on  detect_spdx [!?] is 📦 v0.25.0 via 🐍 v3.11.2 took 5s
❯
```
