### PR TITLE
ci: add `refurb` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     rev: 2c336ac3638c1bccb6e138816826f4a7066ef5e6  # frozen: v1.15.0
     hooks:
       - id: refurb
-        args: [--format, github]
+        args: [--python-version, "3.8", --format, github]
 
   # NOTE: don't use this config for your own repositories. Instead, see
   #       "Git pre-commit Integration" in `docs/sync/git_precommit.md`

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,12 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
 
+  - repo: https://github.com/dosisod/refurb
+    rev: 2c336ac3638c1bccb6e138816826f4a7066ef5e6  # frozen: v1.15.0
+    hooks:
+      - id: refurb
+        args: [--format, github]
+
   # NOTE: don't use this config for your own repositories. Instead, see
   #       "Git pre-commit Integration" in `docs/sync/git_precommit.md`
   - repo: local

--- a/src/phylum/ci/ci_azure.py
+++ b/src/phylum/ci/ci_azure.py
@@ -115,7 +115,7 @@ class CIAzure(CIBase):
         self.triggering_repo = os.getenv("BUILD_REPOSITORY_PROVIDER", "unknown")
         print(f" [+] Triggering repository: {self.triggering_repo}")
         # "TfsGit" is the legacy name for "Azure Repos Git"
-        if self.triggering_repo not in ["TfsGit", "GitHub"]:
+        if self.triggering_repo not in ("TfsGit", "GitHub"):
             raise SystemExit(f" [!] Triggering repository `{self.triggering_repo}` not supported")
 
         azure_token = os.getenv("AZURE_TOKEN", "")

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -246,7 +246,7 @@ class CIBase(ABC):
         if bool(subprocess.run(cmd, stdout=subprocess.DEVNULL).returncode):
             raise SystemExit(" [!] A Phylum API key is required to continue.")
 
-        print(f" [+] Using Phylum CLI instance: {cli_version} at {str(cli_path)}")
+        print(f" [+] Using Phylum CLI instance: {cli_version} at {cli_path}")
         return cli_path
 
     @property

--- a/src/phylum/init/cli.py
+++ b/src/phylum/init/cli.py
@@ -203,8 +203,7 @@ def save_file_from_url(url: str, path: Path) -> None:
     print("Done")
 
     print(f" [*] Saving {url} file to {path} ...", end="")
-    with open(path, "wb") as f:
-        f.write(req.content)
+    path.write_bytes(req.content)
     print("Done")
 
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -7,5 +7,5 @@ HERE = pathlib.Path(__file__).resolve().parent
 PROJECT_ROOT = HERE.parent
 PYPROJECT_TOML_PATH = PROJECT_ROOT / "pyproject.toml"
 
-with open(PYPROJECT_TOML_PATH, "rb") as f:
+with PYPROJECT_TOML_PATH.open("rb") as f:
     PYPROJECT = tomli.load(f)


### PR DESCRIPTION
This change adds `refurb` to the QA checks and updates the code to adhere to it's findings. From the [refurb README](https://github.com/dosisod/refurb#why-does-this-exist), the tool is "heavily inspired by clippy, the built-in linter for Rust."

The defaults are used, except for specifying the minimum supported Python version (currently 3.8) so that changes won't be suggested that only exist in newer versions of Python. Additionally, the format when using the pre-commit hook is set to `github`. Even though this is slightly harder to parse when running the hook locally, the benefit outweighs that cost in the way annotations will be added to PRs:

<img width="798" alt="image" src="https://user-images.githubusercontent.com/18729796/230253634-1a458ae1-8709-4cd2-8033-89c4855dcb21.png">

