### PR TITLE
feat!: provide ability to specify Phylum API URI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,13 @@
 #
 # Another build arg is exposed to optionally specify the Phylum CLI version to install:
 #
-# $ docker build --tag phylum-ci --build-arg CLI_VER=v3.8.0 .
+# $ docker build --tag phylum-ci --build-arg CLI_VER=v4.8.0 .
+#
+# The PHYLUM_API_URI build arg is exposed to optionally specify the URI of a Phylum API
+# instance to use:
+#
+# $ export PHYLUM_API_URI=https://api.staging.phylum.io
+# $ docker build --tag phylum-ci --build-arg PHYLUM_API_URI .
 #
 # Another build arg is exposed to optionally specify a GitHub Personal Access Token (PAT):
 #
@@ -113,6 +119,10 @@ FROM python:3.11-slim-bullseye
 # Values should be provided in a format acceptable to the `phylum-init` script.
 # When not defined, the value will default to `latest`.
 ARG CLI_VER
+
+# PHYLUM_API_URI is an optional build argument that can be used to specify
+# the URI of a Phylum API instance to use.
+ARG PHYLUM_API_URI
 
 # GITHUB_TOKEN is an optional build argument that can be used to provide a
 # GitHub Personal Access Token (PAT) in order to make authenticated requests

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -216,6 +216,7 @@ class CIBase(ABC):
             "--phylum-release", specified_version,
             "--target", self.args.target,
             "--phylum-token", self.args.token,
+            "--api-uri", self.args.uri,
         ]
         # fmt: on
         cli_path, cli_version = get_phylum_bin_path()

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -18,7 +18,7 @@ from phylum.ci.ci_gitlab import CIGitLab
 from phylum.ci.ci_none import CINone
 from phylum.ci.ci_precommit import CIPreCommit
 from phylum.ci.common import ReturnCode
-from phylum.constants import TOKEN_ENVVAR_NAME
+from phylum.constants import HELP_MSG_API_URI, HELP_MSG_TARGET, HELP_MSG_TOKEN, HELP_MSG_VERSION
 from phylum.init.cli import default_phylum_cli_version, get_target_triple, version_check
 
 
@@ -150,11 +150,7 @@ def get_args(args: Optional[Sequence[str]] = None) -> Tuple[argparse.Namespace, 
         "-k",
         "--phylum-token",
         dest="token",
-        help=f"""Phylum user token. Can also specify this option's value by setting the `{TOKEN_ENVVAR_NAME}`
-            environment variable. The value specified with this option takes precedence when both are provided.
-            Leave this option and it's related environment variable unspecified to either (1) use an existing token
-            already set in the Phylum config file or (2) to manually populate the token with a `phylum auth login` or
-            `phylum auth register` command after install.""",
+        help=HELP_MSG_TOKEN,
     )
     analysis_group.add_argument(
         "-p",
@@ -179,10 +175,10 @@ def get_args(args: Optional[Sequence[str]] = None) -> Tuple[argparse.Namespace, 
             detail: https://docs.phylum.io/docs/phylum-package-score#risk-domains""",
     )
     threshold_group.add_argument(
-        "-u",
+        "-v",
         "--vul-threshold",
         type=threshold_check,
-        help="v(u)lnerability risk score threshold value.",
+        help="(v)ulnerability risk score threshold value.",
     )
     threshold_group.add_argument(
         "-m",
@@ -220,15 +216,19 @@ def get_args(args: Optional[Sequence[str]] = None) -> Tuple[argparse.Namespace, 
         "--phylum-release",
         dest="version",
         # NOTE: `default` and `type` values are not used here in an effort to minimize rate limited GitHub API calls.
-        help="""The version of the Phylum CLI to install. Can be specified as `latest` or a specific tagged release,
-            with or without the leading `v`. Default behavior is to use the installed version and fall back to `latest`
-            when no CLI is already installed.""",
+        help=HELP_MSG_VERSION,
     )
     cli_group.add_argument(
         "-t",
         "--target",
         default=get_target_triple(),
-        help="The target platform type where the CLI will be installed.",
+        help=HELP_MSG_TARGET,
+    )
+    cli_group.add_argument(
+        "-u",
+        "--api-uri",
+        dest="uri",
+        help=HELP_MSG_API_URI,
     )
     cli_group.add_argument(
         "-i",

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -177,7 +177,7 @@ def get_args(args: Optional[Sequence[str]] = None) -> Tuple[argparse.Namespace, 
     threshold_group.add_argument(
         "--vul-threshold",
         type=threshold_check,
-        help="(v)ulnerability risk score threshold value.",
+        help="vulnerability risk score threshold value.",
     )
     threshold_group.add_argument(
         "-m",

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -175,7 +175,6 @@ def get_args(args: Optional[Sequence[str]] = None) -> Tuple[argparse.Namespace, 
             detail: https://docs.phylum.io/docs/phylum-package-score#risk-domains""",
     )
     threshold_group.add_argument(
-        "-v",
         "--vul-threshold",
         type=threshold_check,
         help="(v)ulnerability risk score threshold value.",

--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -25,11 +25,6 @@ SUPPORTED_PLATFORMS = {
     "darwin": "apple-darwin",
 }
 
-# Environment variable name to hold the Phylum CLI token used to access the backend API.
-# The API token can also be set via the environment variable `PHYLUM_API_KEY`, which will take precedence over
-# the `offline_access` parameter in the `settings.yaml` file.
-TOKEN_ENVVAR_NAME = "PHYLUM_API_KEY"  # nosec ; this is NOT a hard-coded password
-
 # These are the currently supported lockfiles.
 # Keys are the standard lockfile filename, optionally specified with glob syntax.
 # Values are the name of the tool that generates the lockfile.
@@ -66,3 +61,28 @@ REQ_TIMEOUT: float = 10.0
 # User-Agent header to use when making web requests, to identify this tool instead of falling
 # back to the default provided by the Python Requests package (e.g., `python-requests/2.28.1`).
 PHYLUM_USER_AGENT = f"phylum-ci/{__version__}"
+
+# Environment variable name to hold the Phylum CLI token used to access the backend API.
+# The API token can also be set via the environment variable `PHYLUM_API_KEY`, which will take precedence over
+# the `offline_access` parameter in the `settings.yaml` file.
+TOKEN_ENVVAR_NAME = "PHYLUM_API_KEY"  # nosec ; this is NOT a hard-coded password
+
+# Environment variable name to hold the URI of the Phylum API instance used to access the backend API.
+API_URI_ENVVAR_NAME = "PHYLUM_API_URI"
+
+# These are help messages that are used for both `phylum-init` and `phylum-ci` and specified here to stay DRY
+HELP_MSG_TARGET = "The target platform type where the CLI will be installed."
+HELP_MSG_VERSION = """The version of the Phylum CLI to install. Can be specified as `latest` or a specific tagged
+    release, with or without the leading `v`. Default behavior is to use the installed version and fall back to `latest`
+    when no CLI is already installed."""
+HELP_MSG_TOKEN = f"""Phylum user token. Can also specify this option's value by setting the `{TOKEN_ENVVAR_NAME}`
+    environment variable. The value specified with this option takes precedence when both are provided. Leave this
+    option and it's related environment variable unspecified to either (1) use an existing token already set in the
+    Phylum settings file or (2) to manually populate the token with a `phylum auth login` or `phylum auth register`
+    command after install."""
+HELP_MSG_API_URI = f"""URI of Phylum API instance to use. Can also specify this option's value by setting the
+    `{API_URI_ENVVAR_NAME}` environment variable. The value specified with this option takes precedence when both are
+    provided. When not specified, the CLI will use the default value for the PRODUCTION instance for new installs and
+    the existing value in the Phylum settings file when available.
+    Example: specify 'https://api.staging.phylum.io' to point to the STAGING instance.
+    Hint: ensure the value for `--phylum-token` is correct for the instance specified here."""

--- a/src/phylum/init/cli.py
+++ b/src/phylum/init/cli.py
@@ -363,7 +363,7 @@ def main(args=None):
         args.version = version_check(args.version)
     else:
         print(" [+] Phylum CLI version not specified")
-        args.version = default_phylum_cli_version()
+        args.version = version_check(default_phylum_cli_version())
     print(f" [*] Using Phylum CLI version: {args.version}")
 
     if args.list_releases:


### PR DESCRIPTION
This change adds the ability to specify the URI of a Phylum API
instance to use. It does this by adding options to both the `phylum-ci`
and `phylum-init` entrypoint scripts. It also allows for specifying the
option's value by setting the `PHYLUM_API_URI` environment variable. The
value specified with the option takes precedence when both are provided.
When not specified, the CLI will use the default value for the
PRODUCTION instance for new installs and the existing value in the
Phylum settings file, when available, for updated installs.

The Dockerfile was also updated to take advantage of this feature by
adding an optional build argument.

For example, specify 'https://api.staging.phylum.io/' as an option or
envvar to point to the STAGING instance. Regardless of the instance
selected, ensure the value for the Phylum token is correct for that
instance.

These changes allow for easier testing on the STAGING environment or
any self-hosted API instances (e.g., on-prem support). It may also spur
the CLI to support the `PHYLUM_API_URI` environment variable in the same
way that it does for `PHYLUM_API_KEY`.

Additionally, a fix for a missing version check normalization was made.
This fix was previously applied for the `phylum-ci` entrypoint but
missed for the `phylum-init` entrypoint. When no CLI version is
specified and no CLI is installed, the version was reported as `latest`
instead of the corresponding version in "vMajor.Minor.Bugfix" format.

BREAKING CHANGE: The short option `-u` for `--vul-threshold` was removed.