### PR TITLE
fix: link to Phylum UI project clipped in logs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -306,22 +306,6 @@ files = [
 test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 
 [[package]]
-name = "connect-markdown-renderer"
-version = "2.0.1"
-description = "Connect Markdown Renderer"
-category = "main"
-optional = false
-python-versions = ">=3.7,<4"
-files = [
-    {file = "connect-markdown-renderer-2.0.1.tar.gz", hash = "sha256:fbaefff195a6c347a7f89e75a09e78f6be35c903d72a2766c8f263ca75758757"},
-    {file = "connect_markdown_renderer-2.0.1-py3-none-any.whl", hash = "sha256:8d726b947d877697a42f528799908481685bf0db6a17b4e6d715389bfae9cccd"},
-]
-
-[package.dependencies]
-markdown-it-py = ">=2.1.0,<3.0.0"
-rich = ">=12.4.1,<13.0.0"
-
-[[package]]
 name = "cryptography"
 version = "40.0.1"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
@@ -821,43 +805,6 @@ files = [
 
 [package.dependencies]
 rapidfuzz = ">=2.3.0,<3.0.0"
-
-[[package]]
-name = "markdown-it-py"
-version = "2.2.0"
-description = "Python port of markdown-it. Markdown parsing, done right!"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "markdown-it-py-2.2.0.tar.gz", hash = "sha256:7c9a5e412688bc771c67432cbfebcdd686c93ce6484913dccf06cb5a0bea35a1"},
-    {file = "markdown_it_py-2.2.0-py3-none-any.whl", hash = "sha256:5a35f8d1870171d9acc47b99612dc146129b631baf04970128b568f190d0cc30"},
-]
-
-[package.dependencies]
-mdurl = ">=0.1,<1.0"
-
-[package.extras]
-benchmarking = ["psutil", "pytest", "pytest-benchmark"]
-code-style = ["pre-commit (>=3.0,<4.0)"]
-compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
-linkify = ["linkify-it-py (>=1,<3)"]
-plugins = ["mdit-py-plugins"]
-profiling = ["gprof2dot"]
-rtd = ["attrs", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
-testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
-
-[[package]]
-name = "mdurl"
-version = "0.1.2"
-description = "Markdown URL utilities"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
-    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
-]
 
 [[package]]
 name = "more-itertools"
@@ -1884,4 +1831,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "ca73dc7c24f70784e26f2ad3ae76f27e31c27a2d74d969e601f3f197a935e9b2"
+content-hash = "f3453c1dca3d0f6c94b85f0be3883a0af6e135b8172f316f998d42385a271d9f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,8 @@ requests = "*"
 cryptography = "*"
 packaging = "*"
 "ruamel.yaml" = "*"
-connect-markdown-renderer = "*"
 pathspec = "*"
+rich = "*"
 
 [tool.poetry.group.test]
 optional = true

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -19,13 +19,14 @@ from pathlib import Path
 from typing import List, Optional
 
 import pathspec
-from connect.utils.terminal.markdown import render
 from packaging.version import Version
+from rich.markdown import Markdown
 from ruamel.yaml import YAML
 
 from phylum.ci.common import DataclassJSONEncoder, JobPolicyEvalResult, ReturnCode
 from phylum.ci.git import git_hash_object, git_repo_name
 from phylum.ci.lockfile import Lockfile, Lockfiles
+from phylum.console import console
 from phylum.constants import ENVVAR_NAME_TOKEN, MIN_CLI_VER_INSTALLED, SUPPORTED_LOCKFILES
 from phylum.init.cli import get_phylum_bin_path
 from phylum.init.cli import main as phylum_init
@@ -369,7 +370,9 @@ class CIBase(ABC):
         ensure those comments are unique and not added multiple times as the review changes but no lockfile does.
         """
         # Post the markdown output, rendered for terminal/log output
-        print(f" [+] Analysis output:\n{render(self.analysis_report)}")
+        print(" [+] Analysis output:\n")
+        report_md = Markdown(self.analysis_report, hyperlinks=False)
+        console.print(report_md, soft_wrap=True)
 
     def analyze(self) -> ReturnCode:
         """Analyze the results gathered from passing the lockfile(s) to `phylum analyze`."""

--- a/src/phylum/console.py
+++ b/src/phylum/console.py
@@ -1,0 +1,46 @@
+"""Provide a console object that can be used throughout the application.
+
+The `rich` library is used here for excellent control over the console.
+Reference: https://rich.readthedocs.io/en/latest/index.html
+"""
+
+from rich.console import Console
+from rich.theme import Theme
+
+# Create a custom Phylum theme by setting unique style values for a subset of the markdown styles that `rich` supports.
+# The full list of markdown styles, as of the time of this writing, is included here to make it easier to understand
+# what can be modified. The default styles are also included so any future changes will not cause unexpected output.
+# The colors chosen are from the standard 8-bit colors supported in terminals and are close to the range of blue colors
+# that make up the Phylum logo. These colors are also able to be represented by a name instead of a hex or RGB value.
+# References:
+#   * https://rich.readthedocs.io/en/latest/style.html
+#   * https://rich.readthedocs.io/en/latest/appendix/colors.html
+PHYLUM_STYLES = {
+    # Styles that have been modified from the default:
+    "markdown.code": "bold reverse",
+    "markdown.h1.border": "dodger_blue2",
+    "markdown.h1": "dodger_blue2",
+    "markdown.h2": "deep_sky_blue3",
+    "markdown.h3": "underline cornflower_blue",
+    "markdown.h4": "steel_blue1",
+    "markdown.h5": "turquoise2",
+    "markdown.h6": "cyan1",
+    "markdown.h7": "bright_cyan",
+    "markdown.item.bullet": "bold blue",
+    "markdown.item.number": "bold blue",
+    # The `rich` default styles:
+    "markdown.strong": "bold",
+    "markdown.emph": "italic",
+    "markdown.paragraph": "none",
+    "markdown.text": "none",
+    "markdown.code_block": "dim cyan on black",
+    "markdown.block_quote": "magenta",
+    "markdown.list": "cyan",
+    "markdown.item": "none",
+    "markdown.hr": "yellow",
+    "markdown.link": "bright_blue",
+    "markdown.link_url": "blue",
+}
+
+phylum_theme = Theme(styles=PHYLUM_STYLES)
+console = Console(theme=phylum_theme)


### PR DESCRIPTION
With the change to policy based operation, the analysis report is no longer generated within `phylum-ci`. Instead it comes from the `report` element of the "evaluate policy" endpoint offered by the API. This report includes a link to view the project in the Phylum UI. The link is often longer than the width of the terminal used in some CI environments which causes the link to get "clipped" and therefore no longer functional as a clickable URL. This is a regression of issue #140, which was previously fixed in #186.

This change removes the `connect-markdown-renderer` dependency and adds `rich` as a main dependency. `connect-markdown-renderer` was chosen before because it extends the markdown rendering functionality provided by `rich` to include additional elements like tables. The new report format does not include tables and the markdown it does have is all renderable by `rich`, which _does_ allow for more control over the console.

A `console` module was added to provide a console object that can be used throughout the application. That console makes use of a custom Phylum theme that sets unique styles for a subset of the markdown styles that `rich` supports. The console is used to print the analysis report as rendered markdown, but without using hyperlinks. Most importantly, soft wrap is enabled for any text that doesn't fit so it will run on to the following line(s) instead of broken up by having line breaks inserted.

Ref: #140

## Screenshots

What the output in a CI environment looks like before this fix:

<img width="1923" alt="image" src="https://user-images.githubusercontent.com/18729796/231584049-a58a60d6-643e-46c9-a4f2-18f85674ff0f.png">

---

What the output looks like after this fix:

<img width="2323" alt="image" src="https://user-images.githubusercontent.com/18729796/232119531-8fd6ce89-5e69-43ba-8393-ff10dcfe6d3c.png">

---

What the color/rendering looks like before this change:

<img width="1010" alt="image" src="https://user-images.githubusercontent.com/18729796/232120315-4727a024-8adf-4aea-9d03-d4a61b8476c0.png">

---

What the color/rendering looks like after this change:

<img width="1010" alt="image" src="https://user-images.githubusercontent.com/18729796/232120540-35051811-1d51-414a-949d-4c6ee71afb33.png">
