### PR TITLE
ci: add `vulture` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,11 @@ repos:
       - id: refurb
         args: [--python-version, "3.8", --format, github]
 
+  - repo: https://github.com/jendrikseipp/vulture
+    rev: f7a85d47ad6da8cf1d408b737a0a0b396aa5d300  # frozen: v2.7
+    hooks:
+      - id: vulture
+
   # NOTE: don't use this config for your own repositories. Instead, see
   #       "Git pre-commit Integration" in `docs/sync/git_precommit.md`
   - repo: local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ tox = "*"
 [tool.black]
 line-length = 120
 
+[tool.vulture]
+paths = ["src", "tests"]
+
 [tool.semantic_release]
 # Reference: https://python-semantic-release.readthedocs.io/en/latest/configuration.html
 branch = "main"

--- a/src/phylum/ci/common.py
+++ b/src/phylum/ci/common.py
@@ -24,7 +24,7 @@ class JobPolicyEvalResult:
 
     is_failure: bool
     incomplete_count: int
-    output: str
+    output: str  # noqa: F841 ; unused attribute, but kept to maintain consistency with the corresponding Phylum type
     report: str
 
 


### PR DESCRIPTION
This change adds `vulture` to the QA checks and updates the code to adhere to it's findings. From the [`vulture`
README](https://github.com/jendrikseipp/vulture), the tool "finds unused code in Python programs."

The defaults are used and the tool is run against the `src` and `tests` directories. This tool was used during the recent major refactoring effort in which the switch away from thresholds and towards policies was made. There was a lot of deleted code and the tool made it very easy to identify the remaining dead code.
