### PR TITLE
chore: add `ruff` to QA checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,8 @@ jobs:
           #   * The current GitHub integration expects to *only* be run in a PR context
           #   * The `phylum-ci` action will already be run for pull request triggers
           SKIP: phylum-ci
+          # Add annotations to the PR for any findings
+          RUFF_FORMAT: github
         run: poetry run tox run -e qa
 
   test-matrix:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,10 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: 7c551d39dfa69851607d85392ffa296568e92436  # frozen: v3.3.2
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: aad2f97dee13b682f514df846844b374cdd06e7c  # frozen: v0.0.264
     hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
+      - id: ruff
 
   - repo: https://github.com/dosisod/refurb
     rev: 7fb404137a6dbb8c7b346ffd904db5c17b1c24ed  # frozen: v1.16.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,6 +213,12 @@ The pull request should work for Python 3.8, 3.9, 3.10, and 3.11.
 Check <https://github.com/phylum-dev/phylum-ci/actions> and make sure that the tests
 pass for all supported Python versions.
 
+To ensure quality assurance (QA), a series of checks are performed in a `qa` test.
+This test essentially runs the `pre-commit` hooks to ensure proper formatting and linting over the repo.
+Sometimes it is necessary to bypass these checks (e.g., via `# noqa` directives). These exceptions should
+be rare and include a reason in the comment for the exclusion. Create a new issue and reference that, when
+more detail is needed or the exclusion is meant to be temporary.
+
 The [Semantic Pull Requests](https://github.com/apps/semantic-pull-requests) GitHub app is in use for this repository
 as a means to ensure each PR that gets merged back to the `main` branch adheres to the
 [conventional commit](https://www.conventionalcommits.org) strategy. This means that either the PR title (when

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![GitHub Workflow Status (branch)][workflow_shield]][workflow_test]
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)][CoC]
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)][pre-commit]
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)][black]
 [![Downloads](https://pepy.tech/badge/phylum/month)][downloads]
 [![Discord](https://img.shields.io/discord/1070071012353376387?logo=discord)][discord_invite]
 
@@ -19,6 +20,7 @@ Utilities for integrating Phylum into CI pipelines (and beyond)
 [workflow_test]: https://github.com/phylum-dev/phylum-ci/actions/workflows/test.yml
 [CoC]: https://github.com/phylum-dev/phylum-ci/blob/main/CODE_OF_CONDUCT.md
 [pre-commit]: https://github.com/pre-commit/pre-commit
+[black]: https://github.com/psf/black
 [downloads]: https://pepy.tech/project/phylum
 [discord_invite]: https://discord.gg/Fe6pr5eW6p
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,53 @@ paths = ["src", "tests"]
 python_version = "3.8"
 format = "github"
 
+[tool.ruff]
+# Reference: https://beta.ruff.rs/docs/settings
+line-length = 120
+target-version = "py38"
+force-exclude = true
+src = ["src", "tests"]
+select = [
+    # Using `ALL` has the risk that new rules may be enabled when `ruff` is updated but updates are
+    # automated, with a PR that includes enforced QA checks, to weekly dependency and pre-commit hook bumps.
+    "ALL"
+]
+ignore = [
+    # Reference: https://beta.ruff.rs/docs/rules/
+    #
+    # `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible. Prefer D211.
+    "D203", # one-blank-line-before-class
+    # `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible. Prefer D212.
+    "D213", # multi-line-summary-second-line
+    # Cached instance methods are okay in this project b/c instances are short lived and won't lead to memory leaks.
+    "B019", # cached-instance-method
+    # Assigning to a variable before a return statement is more readable and useful for debugging
+    "RET504",   # unnecessary-assign
+    # These ignores will be removed during https://github.com/phylum-dev/phylum-ci/issues/238
+    "ANN",  # flake8-annotations
+    "TCH",  # flake8-type-checking
+    # These ignores will be removed during https://github.com/phylum-dev/phylum-ci/issues/47
+    "EM",   # flake8-errmsg
+    "TRY",  # tryceratops
+    # This ignore will be removed during https://github.com/phylum-dev/phylum-ci/issues/23
+    "T20",  # flake8-print
+]
+
+[tool.ruff.per-file-ignores]
+"test_*.py" = [
+    # It is expected to use `assert` statements in `pytest` test code
+    "S101", # assert
+    # `subprocess` input is controlled in test code
+    "S603", # subprocess-without-shell-equals-true
+]
+
+[tool.ruff.isort]
+force-sort-within-sections = true
+
+[tool.ruff.pydocstyle]
+# Use PEP-257 style docstrings
+convention = "pep257"
+
 [tool.semantic_release]
 # Reference: https://python-semantic-release.readthedocs.io/en/latest/configuration.html
 branch = "main"

--- a/src/phylum/ci/ci_bitbucket.py
+++ b/src/phylum/ci/ci_bitbucket.py
@@ -16,14 +16,14 @@ Bitbucket References:
   * https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/
   * https://developer.atlassian.com/cloud/bitbucket/rest/intro/#pullrequest
 """
+from argparse import Namespace
+from functools import cached_property, lru_cache
 import os
 import re
 import shlex
 import subprocess
-import urllib.parse
-from argparse import Namespace
-from functools import cached_property, lru_cache
 from typing import Optional
+import urllib.parse
 
 import requests
 
@@ -61,7 +61,7 @@ def is_in_pr() -> bool:
 class CIBitbucket(CIBase):
     """Provide methods for a Bitbucket Pipelines environment."""
 
-    def __init__(self, args: Namespace) -> None:
+    def __init__(self, args: Namespace) -> None:  # noqa: D107 ; the base __init__ docstring is better here
         super().__init__(args)
         self.ci_platform_name = "Bitbucket Pipelines"
         if is_in_pr():
@@ -167,7 +167,7 @@ class CIBitbucket(CIBase):
         cmd = ["git", "merge-base", src_branch, tgt_branch]
         print(f" [*] Finding common ancestor commit with command: {shlex.join(cmd)}")
         try:
-            common_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
+            common_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()  # noqa: S603
         except subprocess.CalledProcessError as err:
             ref_url = "https://support.atlassian.com/bitbucket-cloud/docs/git-clone-behavior/"
             print(f" [!] The common ancestor commit could not be found: {err}")

--- a/src/phylum/ci/ci_github.py
+++ b/src/phylum/ci/ci_github.py
@@ -10,12 +10,13 @@ GitHub References:
   * https://docs.github.com/en/rest/pulls/comments
   * https://docs.github.com/en/rest/guides/working-with-comments#pull-request-comments
 """
-import json
-import os
-import re
-import subprocess
 from argparse import Namespace
 from functools import cached_property
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
 from typing import Optional
 
 import requests
@@ -42,13 +43,13 @@ See the GitHub Token Documentation for more info:
 class CIGitHub(CIBase):
     """Provide methods for a GitHub Actions environment."""
 
-    def __init__(self, args: Namespace) -> None:
+    def __init__(self, args: Namespace) -> None:  # noqa: D107 ; the base __init__ docstring is better here
         # This is the recommended workaround for container actions, to avoid the `unsafe repository` error.
         # It is added before super().__init__(args) so that lockfile change detection will be set properly.
         # See https://github.com/actions/checkout/issues/766 (git CVE-2022-24765) for more detail.
         github_workspace = os.getenv("GITHUB_WORKSPACE", "/github/workspace")
         cmd = ["git", "config", "--global", "--add", "safe.directory", github_workspace]
-        subprocess.run(cmd, check=True)
+        subprocess.run(cmd, check=True)  # noqa: S603
 
         super().__init__(args)
         self.ci_platform_name = "GitHub Actions"
@@ -76,10 +77,11 @@ class CIGitHub(CIBase):
         # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
         if os.getenv("GITHUB_EVENT_NAME") != "pull_request":
             raise SystemExit(" [!] The workflow event must be `pull_request`")
-        github_event_path = os.getenv("GITHUB_EVENT_PATH")
-        if github_event_path is None:
+        github_event_path_envvar = os.getenv("GITHUB_EVENT_PATH")
+        if github_event_path_envvar is None:
             raise SystemExit(" [!] Could not read the `GITHUB_EVENT_PATH` environment variable")
-        with open(github_event_path, encoding="utf-8") as f:
+        github_event_path = Path(github_event_path_envvar)
+        with github_event_path.open(encoding="utf-8") as f:
             pr_event = json.load(f)
         self._pr_event = pr_event
 

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -7,12 +7,12 @@ GitLab References:
   * https://docs.gitlab.com/ee/ci/jobs/ci_job_token.html
   * https://docs.gitlab.com/ee/api/notes.html#merge-requests
 """
+from argparse import Namespace
+from functools import cached_property, lru_cache
 import os
 import re
 import shlex
 import subprocess
-from argparse import Namespace
-from functools import cached_property, lru_cache
 from typing import Optional
 
 import requests
@@ -44,7 +44,7 @@ def is_in_mr() -> bool:
 class CIGitLab(CIBase):
     """Provide methods for a GitLab CI environment."""
 
-    def __init__(self, args: Namespace) -> None:
+    def __init__(self, args: Namespace) -> None:  # noqa: D107 ; the base __init__ docstring is better here
         super().__init__(args)
         self.ci_platform_name = "GitLab CI"
         if is_in_mr():
@@ -128,7 +128,7 @@ class CIGitLab(CIBase):
         cmd = ["git", "merge-base", src_branch, default_branch]
         print(f" [*] Finding common ancestor commit with command: {shlex.join(cmd)}")
         try:
-            common_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
+            common_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()  # noqa: S603
         except subprocess.CalledProcessError as err:
             ref_url = "https://docs.gitlab.com/ee/ci/runners/configure_runners.html#git-strategy"
             print(f" [!] The common ancestor commit could not be found: {err}")

--- a/src/phylum/ci/ci_none.py
+++ b/src/phylum/ci/ci_none.py
@@ -5,10 +5,10 @@ This might be useful for running locally.
 This is also the fallback implementation to use when no known CI platform is detected.
 """
 import argparse
-import re
-import subprocess
 from functools import cached_property
 from pathlib import Path
+import re
+import subprocess
 from typing import Optional
 
 from phylum.ci.ci_base import CIBase
@@ -18,7 +18,7 @@ from phylum.ci.git import git_curent_branch_name, git_remote
 class CINone(CIBase):
     """Provide methods for operating outside of a known CI environment."""
 
-    def __init__(self, args: argparse.Namespace) -> None:
+    def __init__(self, args: argparse.Namespace) -> None:  # noqa: D107 ; the base __init__ docstring is better here
         super().__init__(args)
         self.ci_platform_name = "No CI"
 
@@ -50,7 +50,7 @@ class CINone(CIBase):
         remote = git_remote()
         cmd = ["git", "merge-base", "HEAD", f"refs/remotes/{remote}/HEAD"]
         try:
-            common_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
+            common_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()  # noqa: S603
         except subprocess.CalledProcessError as err:
             print(f" [!] The common ancestor commit could not be found: {err}")
             print(f" [!] stdout:\n{err.stdout}")

--- a/src/phylum/ci/ci_precommit.py
+++ b/src/phylum/ci/ci_precommit.py
@@ -9,11 +9,11 @@ References:
   * https://pre-commit.com/index.html#arguments-pattern-in-hooks
 """
 import argparse
+from functools import cached_property
+from pathlib import Path
 import re
 import subprocess
 import sys
-from functools import cached_property
-from pathlib import Path
 from typing import List, Optional
 
 from phylum.ci.ci_base import CIBase
@@ -23,7 +23,8 @@ from phylum.ci.git import git_curent_branch_name
 class CIPreCommit(CIBase):
     """Provide methods for operating within a pre-commit hook."""
 
-    def __init__(self, args: argparse.Namespace, remainder: List[str]) -> None:
+    def __init__(self, args: argparse.Namespace, remainder: List[str]) -> None:  # noqa: D107
+        # The base __init__ docstring is better here
         self.extra_args = remainder
         super().__init__(args)
         self.ci_platform_name = "pre-commit"
@@ -37,7 +38,8 @@ class CIPreCommit(CIBase):
         super()._check_prerequisites()
 
         cmd = ["git", "diff", "--cached", "--name-only"]
-        staged_files = subprocess.run(cmd, check=True, text=True, capture_output=True).stdout.strip().split("\n")
+        output = subprocess.run(cmd, check=True, text=True, capture_output=True).stdout  # noqa: S603
+        staged_files = output.strip().split("\n")
         extra_arg_paths = [Path(extra_arg).resolve() for extra_arg in self.extra_args]
 
         print(" [*] Checking extra args for valid pre-commit scenarios ...")
@@ -87,7 +89,7 @@ class CIPreCommit(CIBase):
         """Find the common ancestor commit."""
         cmd = ["git", "rev-parse", "--verify", "HEAD"]
         try:
-            common_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
+            common_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()  # noqa: S603
         except subprocess.CalledProcessError as err:
             print(f" [!] The common ancestor commit could not be found: {err}")
             print(f" [!] stdout:\n{err.stdout}")

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -162,7 +162,7 @@ def get_args(args: Optional[Sequence[str]] = None) -> Tuple[argparse.Namespace, 
 
 
 def main(args: Optional[Sequence[str]] = None) -> int:
-    """Main entrypoint."""
+    """Provide the main entrypoint."""
     parsed_args, remainder_args = get_args(args=args)
 
     # Perform version check and normalization here so as to minimize GitHub API calls when
@@ -182,12 +182,11 @@ def main(args: Optional[Sequence[str]] = None) -> int:
     print(f" [+] lockfile(s) in use: {ci_env.lockfiles}")
     if ci_env.force_analysis:
         print(" [+] Forced analysis specified with flag or otherwise set. Proceeding with analysis ...")
+    elif ci_env.is_any_lockfile_changed:
+        print(" [+] A lockfile has changed. Proceeding with analysis ...")
     else:
-        if ci_env.is_any_lockfile_changed:
-            print(" [+] A lockfile has changed. Proceeding with analysis ...")
-        else:
-            print(" [+] No lockfile has changed. Nothing to do.")
-            return 0
+        print(" [+] No lockfile has changed. Nothing to do.")
+        return 0
 
     # Generate a label to use for analysis and report it
     print(f" [+] Label to use for analysis: {ci_env.phylum_label}")

--- a/src/phylum/ci/common.py
+++ b/src/phylum/ci/common.py
@@ -1,7 +1,7 @@
 """Provide common data structures for the package."""
 import dataclasses
-import json
 from enum import IntEnum
+import json
 from typing import List
 
 
@@ -11,7 +11,7 @@ class PackageDescriptor:
 
     name: str
     version: str
-    type: str
+    type: str  # noqa: A003 ; shadowing built-in `type` is okay since renaming here would be more confusing
 
 
 # Type alias
@@ -24,7 +24,7 @@ class JobPolicyEvalResult:
 
     is_failure: bool
     incomplete_count: int
-    output: str  # noqa: F841 ; unused attribute, but kept to maintain consistency with the corresponding Phylum type
+    output: str
     report: str
 
 
@@ -41,7 +41,7 @@ class ReturnCode(IntEnum):
 class DataclassJSONEncoder(json.JSONEncoder):
     """Custom JSON Encoder class that is able to serialize dataclass objects."""
 
-    def default(self, o):
+    def default(self, o):  # noqa: D102 ; the parent's docstring is better here
         if dataclasses.is_dataclass(o):
             return dataclasses.asdict(o)
         return super().default(o)

--- a/src/phylum/ci/lockfile.py
+++ b/src/phylum/ci/lockfile.py
@@ -3,13 +3,13 @@
 A Phylum project can consist of multiple lockfiles.
 This class represents a single lockfile.
 """
+from functools import cached_property, lru_cache
 import json
+from pathlib import Path
 import shutil
 import subprocess
 import tempfile
 import textwrap
-from functools import cached_property, lru_cache
-from pathlib import Path
 from typing import List, Optional, TypeVar
 
 from phylum.ci.common import PackageDescriptor, Packages
@@ -36,14 +36,14 @@ class Lockfile:
         """Return a debug printable string representation of the `Lockfile` object."""
         # NOTE: Any change from this format should be made carefully as caller's
         #       may be relying on `repr(lockfile)` to provide the relative path.
-        #       Example: print(f"Relative path to lockfile: `{lockfile!r}`")
+        #       Example: print(f"Relative path to lockfile: `{lockfile!r}`")    # noqa: ERA001 ; commented code intended
         return str(self.path.relative_to(Path.cwd()))
 
     def __str__(self) -> str:
         """Return the nicely printable string representation of the `Lockfile` object."""
         # NOTE: Any change from this format should be made carefully as caller's
         #       may be relying on `str(lockfile)` to provide the path.
-        #       Example: print(f"Path to lockfile: `{lockfile}`")
+        #       Example: print(f"Path to lockfile: `{lockfile}`")   # noqa: ERA001 ; commented code intended
         return str(self.path)
 
     def __lt__(self: Self, other: Self) -> bool:
@@ -120,7 +120,7 @@ class Lockfile:
         """Get the current lockfile packages."""
         try:
             cmd = [str(self.cli_path), "parse", str(self.path)]
-            parse_result = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
+            parse_result = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()  # noqa: S603
         except subprocess.CalledProcessError as err:
             print(f" [!] There was an error running the command: {' '.join(err.cmd)}")
             print(f" [!] stdout:\n{err.stdout}")
@@ -141,7 +141,12 @@ class Lockfile:
         try:
             # Use the `repr` form to get the relative path to the lockfile
             cmd = ["git", "rev-parse", "--verify", f"{self.common_ancestor_commit}:{self!r}"]
-            prev_lockfile_object = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
+            prev_lockfile_object = subprocess.run(
+                cmd,  # noqa: S603
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
         except subprocess.CalledProcessError as err:
             # There could be a true error, but the working assumption when here is a previous version does not exist
             print(f" [?] There *may* be an issue with the attempt to get the previous lockfile object: {err}")
@@ -157,7 +162,12 @@ class Lockfile:
         with tempfile.NamedTemporaryFile(mode="w+") as prev_lockfile_fd:
             try:
                 cmd = ["git", "cat-file", "blob", prev_lockfile_object]
-                prev_lockfile_contents = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout
+                prev_lockfile_contents = subprocess.run(
+                    cmd,  # noqa: S603
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                ).stdout
                 prev_lockfile_fd.write(prev_lockfile_contents)
                 prev_lockfile_fd.flush()
             except subprocess.CalledProcessError as err:
@@ -168,7 +178,12 @@ class Lockfile:
                 return []
             try:
                 cmd = [str(self.cli_path), "parse", prev_lockfile_fd.name]
-                parse_result = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
+                parse_result = subprocess.run(
+                    cmd,  # noqa: S603
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                ).stdout.strip()
             except subprocess.CalledProcessError as err:
                 print(f" [!] There was an error running the command: {' '.join(err.cmd)}")
                 print(f" [!] stdout:\n{err.stdout}")
@@ -178,7 +193,7 @@ class Lockfile:
                     [!] Due to error, assuming no previous lockfile packages.
                         Please report this as a bug if you believe `{self!r}`
                         is a valid lockfile at revision `{self.common_ancestor_commit}`.
-                    """
+                    """  # noqa: COM812 ; FP due to multiline string in function call
                 )
                 print(msg)
                 return []

--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -65,7 +65,7 @@ PHYLUM_USER_AGENT = f"phylum-ci/{__version__}"
 # Environment variable name to hold the Phylum CLI token used to access the backend API.
 # The API token can also be set via the environment variable `PHYLUM_API_KEY`, which will take precedence over
 # the `offline_access` parameter in the `settings.yaml` file.
-ENVVAR_NAME_TOKEN = "PHYLUM_API_KEY"  # nosec ; this is NOT a hard-coded password
+ENVVAR_NAME_TOKEN = "PHYLUM_API_KEY"  # noqa: S105 ; this is NOT a hard-coded password
 
 # Environment variable name to hold the URI of the Phylum API instance used to access the backend API.
 ENVVAR_NAME_API_URI = "PHYLUM_API_URI"

--- a/src/phylum/github.py
+++ b/src/phylum/github.py
@@ -75,29 +75,28 @@ def github_request(
         rate_limit_reset_header = int(time.mktime(time.localtime()) + seconds_in_hour)
     reset_time = time.asctime(time.localtime(rate_limit_reset_header))
 
-    if resp.status_code == requests.codes.forbidden:
-        # There are several reasons why a 403 status code (FORBIDDEN) could be returned:
-        #   * API rate limit exceeded
-        #   * API secondary rate limit exceeded
-        #   * Failed login limit exceeded
-        #   * Requests with no `User-Agent` header
-        # Reference: https://docs.github.com/rest/overview/resources-in-the-rest-api
-
-        # The most likely reason is that the rate limit has been exceeded so check for that.
-        # The other possible forbidden cases are not common enough to check for here.
-        # Reference: https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting
-        if rate_limit_remaining == "0":
-            msg = textwrap.dedent(
-                f"""\
-                [!] GitHub API rate limit of {rate_limit} requests/hour was exceeded for URL: {api_url}
-                    The current time is:  {current_time}
-                    Rate limit resets at: {reset_time}
-                    Options include waiting to try again after the rate limit resets or to make authenticated
-                    requests by providing a GitHub token in the `GITHUB_TOKEN` environment variable. Reference:
-                    {PAT_REF}
-                """
-            )
-            raise SystemExit(msg)
+    # There are several reasons why a 403 status code (FORBIDDEN) could be returned:
+    #   * API rate limit exceeded
+    #   * API secondary rate limit exceeded
+    #   * Failed login limit exceeded
+    #   * Requests with no `User-Agent` header
+    # Reference: https://docs.github.com/rest/overview/resources-in-the-rest-api
+    #
+    # The most likely reason is that the rate limit has been exceeded so check for that.
+    # The other possible forbidden cases are not common enough to check for here.
+    # Reference: https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting
+    if resp.status_code == requests.codes.forbidden and rate_limit_remaining == "0":
+        msg = textwrap.dedent(
+            f"""\
+            [!] GitHub API rate limit of {rate_limit} requests/hour was exceeded for URL: {api_url}
+                The current time is:  {current_time}
+                Rate limit resets at: {reset_time}
+                Options include waiting to try again after the rate limit resets or to make authenticated
+                requests by providing a GitHub token in the `GITHUB_TOKEN` environment variable. Reference:
+                {PAT_REF}
+            """  # noqa: COM812 ; FP due to multiline string in function call
+        )
+        raise SystemExit(msg)
 
     # TODO: Make this a debug level log output statement
     #       https://github.com/phylum-dev/phylum-ci/issues/23
@@ -112,7 +111,7 @@ def github_request(
             [!] A bad request was made to the GitHub API:
                 {err}
                 Response text: {resp.text.strip()}
-            """
+            """  # noqa: COM812 ; FP due to multiline string in function call
         )
         raise SystemExit(msg) from err
 

--- a/src/phylum/init/cli.py
+++ b/src/phylum/init/cli.py
@@ -1,20 +1,20 @@
 """Console script for phylum-init."""
 import argparse
+from functools import lru_cache
 import os
 import pathlib
+from pathlib import Path
 import platform
 import shutil
 import subprocess
 import sys
 import tempfile
-import zipfile
-from functools import lru_cache
-from pathlib import Path
 from typing import List, Optional, Tuple
+import zipfile
 
-import requests
 from packaging.utils import canonicalize_version
 from packaging.version import InvalidVersion, Version
+import requests
 from ruamel.yaml import YAML
 
 from phylum import __version__
@@ -58,7 +58,7 @@ def get_expected_phylum_bin_path():
 def get_phylum_cli_version(cli_path: Path) -> str:
     """Get the version of the installed and active Phylum CLI and return it."""
     cmd = [str(cli_path), "--version"]
-    version = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip().lower()
+    version = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip().lower()  # noqa: S603
 
     # Starting with Python 3.9, the str.removeprefix() method was introduced to do this same thing
     prefix = "phylum "
@@ -236,9 +236,8 @@ def is_token_set(phylum_settings_path, token=None):
 
     if configured_token is None:
         return False
-    if token is not None:
-        if token != configured_token:
-            return False
+    if token is not None and token != configured_token:
+        return False
 
     return True
 
@@ -274,7 +273,7 @@ def process_token_option(args):
 
 
 def setup_token(token: str) -> None:
-    """Setup the CLI credentials with a provided token."""
+    """Configure the CLI credentials with a provided token."""
     phylum_settings_path = get_phylum_settings_path()
     ensure_settings_file()
     yaml = YAML()
@@ -297,7 +296,7 @@ def ensure_settings_file() -> None:
         if phylum_bin_path is None:
             raise SystemExit(" [!] Could not find the path to the Phylum CLI. Unable to ensure the settings file.")
         cmd = [str(phylum_bin_path), "version"]
-        subprocess.run(cmd, check=True)
+        subprocess.run(cmd, check=True)  # noqa: S603
 
 
 def process_uri_option(args: argparse.Namespace) -> None:
@@ -340,13 +339,13 @@ def confirm_setup() -> None:
     if is_token_set(get_phylum_settings_path()):
         # Check that the token and API URI were setup correctly by using them to display the current auth status
         cmd = [str(phylum_bin_path), "auth", "status"]
-        subprocess.run(cmd, check=True)
+        subprocess.run(cmd, check=True)  # noqa: S603
     else:
         print(" [!] Existing token not found. Can't confirm setup.")
 
     # Print the help message to aid log review
     cmd = [str(phylum_bin_path), "--help"]
-    subprocess.run(cmd, check=True)
+    subprocess.run(cmd, check=True)  # noqa: S603
 
 
 def get_args(args=None):
@@ -413,7 +412,7 @@ def get_args(args=None):
 
 
 def main(args=None):
-    """Main entrypoint."""
+    """Provide the main entrypoint."""
     args = get_args(args=args)
 
     # Perform version check and normalization here so as to minimize GitHub API calls when
@@ -475,7 +474,7 @@ def main(args=None):
             cmd = ["install", "-m", "0755", "phylum", "/usr/local/bin/phylum"]
         else:
             cmd = ["sh", "install.sh"]
-        subprocess.run(cmd, check=True, cwd=extracted_dir)
+        subprocess.run(cmd, check=True, cwd=extracted_dir)  # noqa: S603
 
     process_uri_option(args)
     process_token_option(args)

--- a/src/phylum/init/sig.py
+++ b/src/phylum/init/sig.py
@@ -44,7 +44,7 @@ PHYLUM_RSA_PUBKEY = bytes(
         CPPnPlCwuCIyUPezCP5XYczuHfaWeuwArlwdJFSUpMTc+SqO6REKgL9yvpqsO5Ia
         sQIDAQAB
         -----END PUBLIC KEY-----
-        """
+        """  # noqa: COM812 ; FP due to multiline string in function call
     ),
     encoding="ASCII",
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+"""Create a package for tests.
+
+This package is not intended to be included when building a wheel, but it will be when building a source distribution.
+"""

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -1,0 +1,5 @@
+"""Create a package for functional tests.
+
+The tests in this package are meant to confirm the functionality of individual `phylum` packages. They can be bigger and
+slower than unit tests. It is more acceptable to use `subprocess` calls here to confirm behavior.
+"""

--- a/tests/functional/test_ci.py
+++ b/tests/functional/test_ci.py
@@ -4,8 +4,7 @@ import sys
 
 from phylum import __version__
 from phylum.ci import SCRIPT_NAME
-
-from ..constants import PYPROJECT
+from tests.constants import PYPROJECT
 
 
 def test_run_as_module():
@@ -14,8 +13,8 @@ def test_run_as_module():
     This is the `python -m <module_name>` format to "run library module as a script."
     NOTE: The <module_name> is specified as the dotted path to the package where the `__main__.py` module exists.
     """
-    cmd = f"{sys.executable} -m phylum.ci --help".split()
-    ret = subprocess.run(cmd)
+    cmd = [sys.executable, "-m", "phylum.ci", "--help"]
+    ret = subprocess.run(cmd, check=False)
     assert ret.returncode == 0, "Running the package as a module failed"
 
 
@@ -24,7 +23,7 @@ def test_run_as_script():
     scripts = PYPROJECT.get("tool", {}).get("poetry", {}).get("scripts", {})
     assert scripts, "There should be at least one script entry point"
     assert SCRIPT_NAME in scripts, f"The {SCRIPT_NAME} script should be a defined entry point"
-    ret = subprocess.run([SCRIPT_NAME, "-h"])
+    ret = subprocess.run([SCRIPT_NAME, "-h"], check=False)
     assert ret.returncode == 0, f"{SCRIPT_NAME} entry point failed"
 
 
@@ -32,8 +31,8 @@ def test_version_option():
     """Ensure the correct program name and version is displayed when using the `--version` option."""
     # The argparse module adds a newline to the output
     expected_output = f"{SCRIPT_NAME} {__version__}\n"
-    cmd = f"{sys.executable} -m phylum.ci --version".split()
-    ret = subprocess.run(cmd, capture_output=True, encoding="utf-8")
+    cmd = [sys.executable, "-m", "phylum.ci", "--version"]
+    ret = subprocess.run(cmd, check=False, capture_output=True, encoding="utf-8")
     assert not ret.stderr, "Nothing should be written to stderr"
     assert ret.returncode == 0, "A non-successful return code was provided"
     assert ret.stdout == expected_output, "Output did not match expected input"

--- a/tests/functional/test_init.py
+++ b/tests/functional/test_init.py
@@ -1,13 +1,12 @@
 """"Test the phylum-init command line interface (CLI)."""
+from pathlib import Path
 import subprocess
 import sys
-from pathlib import Path
 
 from phylum import __version__
 from phylum.init import SCRIPT_NAME, sig
 from phylum.init.cli import save_file_from_url
-
-from ..constants import PYPROJECT
+from tests.constants import PYPROJECT
 
 
 def test_run_as_module():
@@ -16,8 +15,8 @@ def test_run_as_module():
     This is the `python -m <module_name>` format to "run library module as a script."
     NOTE: The <module_name> is specified as the dotted path to the package where the `__main__.py` module exists.
     """
-    cmd = f"{sys.executable} -m phylum.init --help".split()
-    ret = subprocess.run(cmd)
+    cmd = [sys.executable, "-m", "phylum.init", "--help"]
+    ret = subprocess.run(cmd, check=False)
     assert ret.returncode == 0, "Running the package as a module failed"
 
 
@@ -26,7 +25,7 @@ def test_run_as_script():
     scripts = PYPROJECT.get("tool", {}).get("poetry", {}).get("scripts", {})
     assert scripts, "There should be at least one script entry point"
     assert SCRIPT_NAME in scripts, f"The {SCRIPT_NAME} script should be a defined entry point"
-    ret = subprocess.run([SCRIPT_NAME, "-h"])
+    ret = subprocess.run([SCRIPT_NAME, "-h"], check=False)
     assert ret.returncode == 0, f"{SCRIPT_NAME} entry point failed"
 
 
@@ -34,8 +33,8 @@ def test_version_option():
     """Ensure the correct program name and version is displayed when using the `--version` option."""
     # The argparse module adds a newline to the output
     expected_output = f"{SCRIPT_NAME} {__version__}\n"
-    cmd = f"{sys.executable} -m phylum.init --version".split()
-    ret = subprocess.run(cmd, capture_output=True, encoding="utf-8")
+    cmd = [sys.executable, "-m", "phylum.init", "--version"]
+    ret = subprocess.run(cmd, check=False, capture_output=True, encoding="utf-8")
     assert not ret.stderr, "Nothing should be written to stderr"
     assert ret.returncode == 0, "A non-successful return code was provided"
     assert ret.stdout == expected_output, "Output did not match expected input"

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,4 @@
+"""Create a package for unit tests.
+
+The tests in this package should be small, fast, and focused on testing individual modules or functions therein.
+"""

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -2,8 +2,8 @@
 
 from pathlib import Path
 
-import pytest
 from dulwich import porcelain
+import pytest
 
 from phylum.ci.git import git_repo_name
 
@@ -16,7 +16,7 @@ CLONED_LOCAL_REPO_NAMES = [
 
 # Names of a git repository that will be initialized locally
 # Separate lists are used because cloned local repos with a name ending in `.git` are not supported
-INITIALIZED_LOCAL_REPO_NAMES = CLONED_LOCAL_REPO_NAMES + ["local_repo.git"]
+INITIALIZED_LOCAL_REPO_NAMES = [*CLONED_LOCAL_REPO_NAMES, "local_repo.git"]
 
 
 @pytest.mark.parametrize("repo_name", INITIALIZED_LOCAL_REPO_NAMES)

--- a/tests/unit/test_package_metadata.py
+++ b/tests/unit/test_package_metadata.py
@@ -6,8 +6,7 @@ from packaging.requirements import Requirement
 from packaging.version import Version
 
 from phylum import PKG_NAME, PKG_SUMMARY, __author__, __email__, __version__
-
-from ..constants import PYPROJECT
+from tests.constants import PYPROJECT
 
 
 def test_project_version():
@@ -21,7 +20,8 @@ def test_python_version():
     """Ensure the python version used to test is a supported version."""
     supported_minor_versions = (8, 9, 10, 11)
     python_version = sys.version_info
-    assert python_version.major == 3, "Only Python 3 is supported"
+    acceptable_python_major_version = 3
+    assert python_version.major == acceptable_python_major_version, "Only Python 3 is supported"
     assert python_version.minor in supported_minor_versions, "Attempting to run unsupported Python version"
 
 

--- a/tests/unit/test_sig.py
+++ b/tests/unit/test_sig.py
@@ -14,27 +14,24 @@ def test_phylum_pubkey_is_bytes():
 
 def test_phylum_pubkey_is_constant():
     """Ensure the RSA public key in use by Phylum has not changed."""
-    expected_key = bytes(
-        dedent(
-            """\
-            -----BEGIN PUBLIC KEY-----
-            MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyGgvuy6CWSgJuhKY8oVz
-            42udH1F2yIlaBoxAdQFuY2zxPSSpK9zv34B7m0JekuC5WCYfW0gS2Z8Ryu2RVdQh
-            7DXvQb7qwzZT0H11K9Pw8hIHBvZPM+d61GWgWDc3k/rFwMmqd+kytVZy0mVxNdv4
-            P2qvy6BNaiUI7yoB1ahR/6klfkPit0X7pkK9sTHwW+/WcYitTQKnEnRzA3q8EmA7
-            rbU/sFEypzBA3C3qNJZyKSwy47kWXhC4xXUS2NXvew4FoVU6ybMoeDApwsx1AgTu
-            CPPnPlCwuCIyUPezCP5XYczuHfaWeuwArlwdJFSUpMTc+SqO6REKgL9yvpqsO5Ia
-            sQIDAQAB
-            -----END PUBLIC KEY-----
-            """
-        ),
-        encoding="ASCII",
-    )
-    assert sig.PHYLUM_RSA_PUBKEY == expected_key, "The key should not be changing"
+    key_text = """\
+        -----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyGgvuy6CWSgJuhKY8oVz
+        42udH1F2yIlaBoxAdQFuY2zxPSSpK9zv34B7m0JekuC5WCYfW0gS2Z8Ryu2RVdQh
+        7DXvQb7qwzZT0H11K9Pw8hIHBvZPM+d61GWgWDc3k/rFwMmqd+kytVZy0mVxNdv4
+        P2qvy6BNaiUI7yoB1ahR/6klfkPit0X7pkK9sTHwW+/WcYitTQKnEnRzA3q8EmA7
+        rbU/sFEypzBA3C3qNJZyKSwy47kWXhC4xXUS2NXvew4FoVU6ybMoeDApwsx1AgTu
+        CPPnPlCwuCIyUPezCP5XYczuHfaWeuwArlwdJFSUpMTc+SqO6REKgL9yvpqsO5Ia
+        sQIDAQAB
+        -----END PUBLIC KEY-----
+        """
+    expected_key = bytes(dedent(key_text), encoding="ASCII")
+    assert expected_key == sig.PHYLUM_RSA_PUBKEY, "The key should not be changing"
 
 
 def test_phylum_pubkey_is_rsa():
     """Ensure the public key in use by Phylum is in fact a 2048 bit RSA key."""
     key = load_pem_public_key(sig.PHYLUM_RSA_PUBKEY)
     assert isinstance(key, rsa.RSAPublicKey)
-    assert key.key_size == 2048
+    expected_rsa_pubkey_size_in_bits = 2048
+    assert key.key_size == expected_rsa_pubkey_size_in_bits


### PR DESCRIPTION
`ruff` is the hot new linter for Python. It is written in Rust and is extremely fast. It also has tremendous support and constant updates. It replaces some of the existing (`pyupgrade`) and planned (e.g., `bandit`, `flake8`, `isort`, and `pylint`) QA tools that are outlined in #14. More new rules are added all the time. The initial configuration enables `ALL` rules by default and then selectively ignores specific rules based on conflicts, preference, and existing issues in the backlog.

Using `ALL` has the risk that new rules may be enabled when `ruff` is updated but updates are automated, with a PR that includes enforced QA checks, to weekly dependency and pre-commit hook bumps. Therefore, the real risk is that a developer on this project may have a local version of `ruff` installed that is newer than the one used for the `pre-commit` hook. That should limit the exposure to no more than a week of "early" rules and may still result in improved code quality.

The list of actions taken in this PR include:

* Add a custom `ruff` configuration in `pyproject.toml`
  * All rules are enabled by default
  * Specific rules and rule sets are disabled
* Remove the `pyupgrade` pre-commit hook
  * Those checks are covered by `ruff`
* Add the `ruff` pre-commit hook
  * This will enforce the rules in the QA check
* Enable GitHub PR annotations for any findings
* Add `noqa` comments, with reasons, where appropriate
* Sort imports based on the `isort` configuration
* Adhere to PEP-257 docstrings everywhere
* Update the `CONTRIBUTING` guide to discuss QA expectations
* Make updates to resolve all outstanding findings
* Add a `black` badge to the `README` to show the formatting style used

Related to #14
