### PR TITLE
feat: add `npm-shrinkwrap.json` and `requirements*.txt` to supported lockfiles

### DIFF
--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -2,12 +2,12 @@
 from phylum import __version__
 
 # This is the minimum CLI version supported for new installs.
-# The switch to policy based analysis was made in v5.0.0-rc2
-MIN_CLI_VER_FOR_INSTALL = "v5.0.0-rc2"
+# Support for `requirements*.txt` lockfiles was added in v5.2.0
+MIN_CLI_VER_FOR_INSTALL = "v5.2.0"
 
 # This is the minimum CLI version supported for existing installs.
-# The switch to policy based analysis was made in v5.0.0-rc2
-MIN_CLI_VER_INSTALLED = "v5.0.0-rc2"
+# Support for `requirements*.txt` lockfiles was added in v5.2.0
+MIN_CLI_VER_INSTALLED = "v5.2.0"
 
 # Keys are lowercase machine hardware names as returned from `uname -m`.
 # Values are the mapped rustc architecture.
@@ -31,11 +31,12 @@ SUPPORTED_PLATFORMS = {
 SUPPORTED_LOCKFILES = {
     # Javascript/Typescript
     "package-lock.json": "npm",
+    "npm-shrinkwrap.json": "npm",
     "yarn.lock": "yarn",
     # Ruby
     "Gemfile.lock": "gem",
     # Python
-    "requirements.txt": "pip",
+    "requirements*.txt": "pip",
     "Pipfile.lock": "pipenv",
     "poetry.lock": "poetry",
     # C#


### PR DESCRIPTION
This change is meant to be a stop-gap until #244 replaces the `phylum-ci` implementation of automatic lockfile detection. However, that issue is going to also add manifest support...which requires more research, planning, coordination, and time.

Closes #234
