### PR TITLE
ci: update QA configuration

### DIFF
--- a/.github/workflows/auto_updates.yml
+++ b/.github/workflows/auto_updates.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           poetry env use python${{ matrix.python-version }}
           poetry lock --check
-          poetry lock --no-update
+          poetry lock --no-update --no-cache
           poetry install --verbose --no-root --sync --with qa
 
       # Update hooks before dependencies because otherwise `pre-commit` may be updated and used before it can be trusted

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           poetry env use python${{ matrix.python-version }}
           poetry lock --check
-          poetry lock --no-update
+          poetry lock --no-update --no-cache
           poetry install --verbose --no-root --sync --with test,ci
 
       - name: Make developmental release version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           poetry env use python${{ matrix.python-version }}
           poetry lock --check
-          poetry lock --no-update
+          poetry lock --no-update --no-cache
           poetry install --verbose --sync --with test,ci
 
       - name: Set PHYLUM_ORIGINAL_VER value

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           poetry env use python${{ matrix.python-version }}
           poetry lock --check
-          poetry lock --no-update
+          poetry lock --no-update --no-cache
           poetry install --verbose --no-root --sync --with qa
 
       - name: Run tox via poetry
@@ -82,7 +82,7 @@ jobs:
         run: |
           poetry env use python${{ matrix.python-version }}
           poetry lock --check
-          poetry lock --no-update
+          poetry lock --no-update --no-cache
           poetry install --verbose --no-root --sync --with test,ci
 
       - name: Run tox via poetry
@@ -119,7 +119,7 @@ jobs:
         run: |
           poetry env use python${{ matrix.python-version }}
           poetry lock --check
-          poetry lock --no-update
+          poetry lock --no-update --no-cache
           poetry install --verbose --no-root --sync
 
       - name: Build docker image from source

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,10 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: no-commit-to-branch
 
   - repo: https://github.com/psf/black
     rev: bf7a16254ec96b084a6caf3d435ec18f0f245cc7  # frozen: 23.3.0
@@ -24,7 +28,7 @@ repos:
       - id: black
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 14b59ee3b18bd49d0816d1f36820c97110e780cc  # frozen: v0.0.270
+    rev: fdea37e497cb28d3b745dc9d07d64ae69d66fbd1  # frozen: v0.0.271
     hooks:
       - id: ruff
 
@@ -55,7 +59,7 @@ repos:
         args: [--check]
       # The `--check` option is the only one that will run when the `--no-update` option is also provided
       - id: poetry-lock
-        args: [--no-update]
+        args: [--no-update, --no-cache]
 
   # NOTE: don't use this config for your own repositories. Instead, see
   #       "Git pre-commit Integration" in `docs/sync/git_precommit.md`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,10 @@ ignore = [
     "D203", # one-blank-line-before-class
     # `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible. Prefer D212.
     "D213", # multi-line-summary-second-line
+    # Most `flake8-fixme` (T0) rules are incompatible with `flake8-todos` (TD). Prefer TD.
+    "T001",   # line-contains-fixme
+    "T002",   # line-contains-todo
+    "T003",   # line-contains-xxx
     # Cached instance methods are okay in this project b/c instances are short lived and won't lead to memory leaks.
     "B019", # cached-instance-method
     # Assigning to a variable before a return statement is more readable and useful for debugging


### PR DESCRIPTION
The latest release of `ruff` added new rules:
https://github.com/charliermarsh/ruff/releases/tag/v0.0.271. Most of the rules did not hit on any of the existing code. A new ruleset, `flake8-fixme`, was added and it directly conflicts with another ruleset, `flake8-todos`. `flake8-todos` is preferred because it allows for TODO/FIXME/XXX comments in code...so long as they are formatted in a particular way. `flake8-fixme` does not allow for these statements at all. The configuration was updated to ignore the conflicting `flake8-fixme` rules.

A few more `pre-commit` hooks were added and the revision for the `ruff` hook was updated to match the latest release.

Running the `poetry-check` hook locally revealed a gap in coverage. The hook failed because the local cache of packages did not match the current state on PyPI. The `ruamel.yaml.clib` package, for v0.2.7 (current latest), has files that have been added and removed since the last time the `poetry.lock` file was updated in CI. This was corrected by ensuring all instances of `poetry lock --no-update` were updated to add the `--no-cache` option. That way, every time the check is performed the results will be deterministic and based on the current state of files for the package(s). If there is a mis-match now (a failure of the hook), it means the package(s) or it's file(s) have changed...which is cause for further inspection/analysis.
