### PR TITLE
ci: update and fix QA configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,10 @@ jobs:
           # Skip the `phylum-ci` pre-commit hook since:
           #   * The current GitHub integration expects to *only* be run in a PR context
           #   * The `phylum-ci` action will already be run for pull request triggers
-          SKIP: phylum-ci
+          # Skip the `no-commit-to-branch` pre-commit hook since:
+          #   * It will cause failures in CI when merging a PR back to `main`
+          #   * The hook is meant to be used locally, where blocking before CI can run is the goal
+          SKIP: phylum-ci,no-commit-to-branch
           # Add annotations to the PR for any findings
           RUFF_FORMAT: github
         run: poetry run tox run -e qa

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: black
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: fdea37e497cb28d3b745dc9d07d64ae69d66fbd1  # frozen: v0.0.271
+    rev: 5bd2636577fce68326b4fa0bea1769f02d7025bf  # frozen: v0.0.272
     hooks:
       - id: ruff
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,10 +110,10 @@ ignore = [
     "D203", # one-blank-line-before-class
     # `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible. Prefer D212.
     "D213", # multi-line-summary-second-line
-    # Most `flake8-fixme` (T0) rules are incompatible with `flake8-todos` (TD). Prefer TD.
-    "T001",   # line-contains-fixme
-    "T002",   # line-contains-todo
-    "T003",   # line-contains-xxx
+    # These `flake8-fixme` (FIX) rules are incompatible with `flake8-todos` (TD). Prefer TD.
+    "FIX001",   # line-contains-fixme
+    "FIX002",   # line-contains-todo
+    "FIX003",   # line-contains-xxx
     # Cached instance methods are okay in this project b/c instances are short lived and won't lead to memory leaks.
     "B019", # cached-instance-method
     # Assigning to a variable before a return statement is more readable and useful for debugging


### PR DESCRIPTION
The changes in #257 introduced an error with the `no-commit-to-branch` pre-commit hook. It causes failures in CI when merging a PR back to `main`. The hook is now skipped in CI to avoid that error. This is acceptable because the hook is meant to be used locally, where blocking a commit before the code can get to the point of running in CI is the goal.

The update to conform to `ruff` release v0.0.271 is also adjusted here. That project realized that the `T` rule prefix for the `flake8-fixme` rules was overloading the `TD` and `T20` rule prefixes. A new release - https://github.com/astral-sh/ruff/releases/tag/v0.0.272 - came out a day later and changed the prefix from `T` to `FIX`. The pre-commit hook and configuration were updated to account for this release.
