### PR TITLE
feat: update the phylum analysis technique

### DIFF
--- a/src/phylum/ci/ci_azure.py
+++ b/src/phylum/ci/ci_azure.py
@@ -146,7 +146,7 @@ class CIAzure(CIBase):
 
     @property
     def phylum_label(self) -> str:
-        """Get a custom label for use when submitting jobs with `phylum analyze`."""
+        """Get a custom label for use when submitting jobs for analysis."""
         if is_in_pr():
             # This variable is only populated for PRs from GitHub which have a different PR ID and PR number
             pr_number = os.getenv("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER")

--- a/src/phylum/ci/ci_bitbucket.py
+++ b/src/phylum/ci/ci_bitbucket.py
@@ -105,7 +105,7 @@ class CIBitbucket(CIBase):
 
     @property
     def phylum_label(self) -> str:
-        """Get a custom label for use when submitting jobs with `phylum analyze`."""
+        """Get a custom label for use when submitting jobs for analysis."""
         if is_in_pr():
             pr_id = os.getenv("BITBUCKET_PR_ID", "unknown-ID")
             pr_src_branch = os.getenv("BITBUCKET_BRANCH", "unknown-branch")

--- a/src/phylum/ci/ci_github.py
+++ b/src/phylum/ci/ci_github.py
@@ -111,7 +111,7 @@ class CIGitHub(CIBase):
 
     @property
     def phylum_label(self) -> str:
-        """Get a custom label for use when submitting jobs with `phylum analyze`."""
+        """Get a custom label for use when submitting jobs for analysis."""
         pr_number = self.pr_event.get("pull_request", {}).get("number", "unknown-number")
         pr_src_branch = os.getenv("GITHUB_HEAD_REF", "unknown-ref")
         label = f"{self.ci_platform_name}_PR#{pr_number}_{pr_src_branch}"

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -87,7 +87,7 @@ class CIGitLab(CIBase):
 
     @property
     def phylum_label(self) -> str:
-        """Get a custom label for use when submitting jobs with `phylum analyze`."""
+        """Get a custom label for use when submitting jobs for analysis."""
         if is_in_mr():
             mr_iid = os.getenv("CI_MERGE_REQUEST_IID", "unknown-IID")
             mr_src_branch = os.getenv("CI_MERGE_REQUEST_SOURCE_BRANCH_NAME", "unknown-branch")

--- a/src/phylum/ci/ci_none.py
+++ b/src/phylum/ci/ci_none.py
@@ -41,7 +41,7 @@ class CINone(CIBase):
 
     @property
     def phylum_label(self) -> str:
-        """Get a custom label for use when submitting jobs with `phylum analyze`."""
+        """Get a custom label for use when submitting jobs for analysis."""
         current_branch = git_curent_branch_name()
         label = f"{self.ci_platform_name}_{current_branch}_{self.lockfile_hash_object}"
         label = re.sub(r"\s+", "-", label)

--- a/src/phylum/ci/ci_precommit.py
+++ b/src/phylum/ci/ci_precommit.py
@@ -84,7 +84,7 @@ class CIPreCommit(CIBase):
 
     @property
     def phylum_label(self) -> str:
-        """Get a custom label for use when submitting jobs with `phylum analyze`."""
+        """Get a custom label for use when submitting jobs for analysis."""
         current_branch = git_curent_branch_name()
         label = f"{self.ci_platform_name}_{current_branch}_{self.lockfile_hash_object}"
         label = re.sub(r"\s+", "-", label)

--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -2,14 +2,12 @@
 from phylum import __version__
 
 # This is the minimum CLI version supported for new installs.
-# `phylum analyze` usage and report out was broken in v5.3.1-rc1
-# and fixed in v5.3.1-rc2 by enabling complete extension based analysis.
-MIN_CLI_VER_FOR_INSTALL = "v5.3.1-rc2"
+# Support for `requirements*.txt` lockfiles was added in v5.2.0
+MIN_CLI_VER_FOR_INSTALL = "v5.2.0"
 
 # This is the minimum CLI version supported for existing installs.
-# `phylum analyze` usage and report out was broken in v5.3.1-rc1
-# and fixed in v5.3.1-rc2 by enabling complete extension based analysis.
-MIN_CLI_VER_INSTALLED = "v5.3.1-rc2"
+# Support for `requirements*.txt` lockfiles was added in v5.2.0
+MIN_CLI_VER_INSTALLED = "v5.2.0"
 
 # Keys are lowercase machine hardware names as returned from `uname -m`.
 # Values are the mapped rustc architecture.

--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -2,12 +2,14 @@
 from phylum import __version__
 
 # This is the minimum CLI version supported for new installs.
-# Support for `requirements*.txt` lockfiles was added in v5.2.0
-MIN_CLI_VER_FOR_INSTALL = "v5.2.0"
+# `phylum analyze` usage and report out was broken in v5.3.1-rc1
+# and fixed in v5.3.1-rc2 by enabling complete extension based analysis.
+MIN_CLI_VER_FOR_INSTALL = "v5.3.1-rc2"
 
 # This is the minimum CLI version supported for existing installs.
-# Support for `requirements*.txt` lockfiles was added in v5.2.0
-MIN_CLI_VER_INSTALLED = "v5.2.0"
+# `phylum analyze` usage and report out was broken in v5.3.1-rc1
+# and fixed in v5.3.1-rc2 by enabling complete extension based analysis.
+MIN_CLI_VER_INSTALLED = "v5.3.1-rc2"
 
 # Keys are lowercase machine hardware names as returned from `uname -m`.
 # Values are the mapped rustc architecture.

--- a/src/phylum/exts/__init__.py
+++ b/src/phylum/exts/__init__.py
@@ -1,0 +1,1 @@
+"""Package for custom Phylum CLI extensions."""

--- a/src/phylum/exts/ci/PhylumExt.toml
+++ b/src/phylum/exts/ci/PhylumExt.toml
@@ -1,0 +1,5 @@
+name = "ci"
+description = "Phylum CI analysis"
+
+[permissions]
+read = ["/"]

--- a/src/phylum/exts/ci/__init__.py
+++ b/src/phylum/exts/ci/__init__.py
@@ -1,4 +1,4 @@
-"""."""
+"""Package for custom Phylum analysis extension."""
 import pathlib
 
 # Provide the path to this extension's directory

--- a/src/phylum/exts/ci/__init__.py
+++ b/src/phylum/exts/ci/__init__.py
@@ -1,0 +1,5 @@
+"""."""
+import pathlib
+
+# Provide the path to this extension's directory
+CI_EXT_PATH = pathlib.Path(__file__).resolve().parent

--- a/src/phylum/exts/ci/main.ts
+++ b/src/phylum/exts/ci/main.ts
@@ -1,0 +1,55 @@
+import { Package, PhylumApi } from "phylum";
+
+// Ensure required arguments are present.
+const args = Deno.args.slice(0);
+if (args.length < 4) {
+    console.error(
+        "Usage: phylum ci <PROJECT> <LABEL> [--group <GROUP>] <BASE> <LOCKFILE...>",
+    );
+    Deno.exit(1);
+}
+
+// Find optional groups argument.
+let group = undefined;
+const groupArgsIndex = args.indexOf("--group");
+if (groupArgsIndex != -1) {
+    const groupArgs = args.splice(groupArgsIndex, 2);
+    group = groupArgs[1];
+}
+
+// Parse remaining arguments.
+const project = args[0];
+const label = args[1];
+const base = args[2];
+const lockfiles = args.splice(3);
+
+// Parse new lockfiles.
+let packages: Package[] = [];
+for (const lockfile of lockfiles) {
+    const lockfileDeps = await PhylumApi.parseLockfile(lockfile);
+    packages = packages.concat(lockfileDeps.packages);
+}
+
+// Deserialize base dependencies.
+const baseDepsJson = await Deno.readTextFile(base);
+const baseDeps = JSON.parse(baseDepsJson);
+
+// Short-circuit if there are no dependencies.
+if (packages.length == 0) {
+    console.log("{}");
+    Deno.exit(0);
+}
+
+// Submit analysis job.
+const jobID = await PhylumApi.analyze(
+    packages,
+    project,
+    group,
+    label,
+);
+
+// Get analysis job results.
+const jobStatus = await PhylumApi.getJobStatus(jobID, baseDeps);
+
+// Output results as JSON.
+console.log(JSON.stringify(jobStatus));


### PR DESCRIPTION
This change starts the shift away from `phylum analyze` commands in favor of using a custom Phylum CLI extension to provide analysis results. The extension is not installed because doing so would not work for all CI environments, namely those that create containers from the Docker image with a non-root user that expects to access the extension files installed by the root user.

Instead of dis-allowing all CLI installs for versions prior to v5.3.1-rc2, this change "straddles" both modes of generating a Phylum analysis: the `phylum analyze` call from CLI releases prior to v5.3.1-rc1 and the use of the new custom extension for CLI releases >= v5.3.1-rc2.

Changes made include:

* Add a new `phylum.exts` sub-package to hold custom CLI extensions
* Add a new `phylum.exts.ci` sub-package to hold first custom extension
  * The "ci" extension performs Phylum analysis
  * It takes inputs as in prior versions, but with different options
  * It returns results in the same format as CLI versions < v5.3.1-rc1
* Call the custom `ci` extension via `phylum extension run`
  * Installing the extension for `phylum ci` calls breaks integrations
* Update language specific to the use of the `phylum analyze` command

Closes #268

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
  - manual testing completed
- [x] Have you updated all affected documentation?

## Screenshots

The Docker image works in the Azure DevOps CI environment:

<img width="1522" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/11023600-c26b-4b21-bebf-c2e51f9c4c56">
