### PR TITLE
feat!: Add `pnpm-lock.yaml` and `packages.lock.json` lockfile support

### DIFF
--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -2,12 +2,12 @@
 from phylum import __version__
 
 # This is the minimum CLI version supported for new installs.
-# Support for `requirements*.txt` lockfiles was added in v5.2.0
-MIN_CLI_VER_FOR_INSTALL = "v5.2.0"
+# Support for `pnpm-lock.yaml` and `packages.lock.json` lockfiles was added in v5.5.0
+MIN_CLI_VER_FOR_INSTALL = "v5.5.0"
 
 # This is the minimum CLI version supported for existing installs.
-# Support for `requirements*.txt` lockfiles was added in v5.2.0
-MIN_CLI_VER_INSTALLED = "v5.2.0"
+# Support for `pnpm-lock.yaml` and `packages.lock.json` lockfiles was added in v5.5.0
+MIN_CLI_VER_INSTALLED = "v5.5.0"
 
 # Keys are lowercase machine hardware names as returned from `uname -m`.
 # Values are the mapped rustc architecture.
@@ -33,6 +33,7 @@ SUPPORTED_LOCKFILES = {
     "package-lock.json": "npm",
     "npm-shrinkwrap.json": "npm",
     "yarn.lock": "yarn",
+    "pnpm-lock.yaml": "pnpm",
     # Ruby
     "Gemfile.lock": "gem",
     # Python
@@ -40,7 +41,8 @@ SUPPORTED_LOCKFILES = {
     "Pipfile.lock": "pipenv",
     "poetry.lock": "poetry",
     # C#
-    "*.csproj": "nuget",
+    "*.csproj": "msbuild",
+    "packages.lock.json": "nuget",
     # Java
     "effective-pom.xml": "mvn",
     "gradle.lockfile": "gradle",


### PR DESCRIPTION
Closes #235
Closes #270

BREAKING CHANGE: CLI installs prior to v5.5.0 are no longer supported. A Phylum CLI version with ability to parse `pnpm-lock.yaml` and `packages.lock.json` lockfiles is needed.
