### PR TITLE
feat: improve GitLab integration for partial checkouts

### DIFF
--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -125,7 +125,7 @@ class CIGitLab(CIBase):
             default_branch_name = git_default_branch_name(remote)
         default_branch = f"refs/remotes/{remote}/{default_branch_name}"
 
-        project_dir = Path(os.getenv("CI_PROJECT_DIR", "."))
+        project_dir = Path(os.getenv("CI_PROJECT_DIR", ".")).resolve()
         if not Path(project_dir, ".git", default_branch).resolve().exists():
             LOG.warning("The default remote branch is not available. Attempting to fetch it...")
             git_fetch(repo=remote, ref=default_branch_name, git_c_path=project_dir)

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -125,9 +125,10 @@ class CIGitLab(CIBase):
             default_branch_name = git_default_branch_name(remote)
         default_branch = f"refs/remotes/{remote}/{default_branch_name}"
 
-        if not Path(os.getenv("CI_PROJECT_DIR", "."), ".git", default_branch).resolve().exists():
+        project_dir = Path(os.getenv("CI_PROJECT_DIR", "."))
+        if not Path(project_dir, ".git", default_branch).resolve().exists():
             LOG.warning("The default remote branch is not available. Attempting to fetch it...")
-            git_fetch(repo=remote, ref=default_branch_name)
+            git_fetch(repo=remote, ref=default_branch_name, git_c_path=project_dir)
 
         if src_branch == default_branch:
             LOG.warning("Source branch is same as default branch. Proceeding with analysis of all dependencies ...")

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -10,6 +10,7 @@ GitLab References:
 from argparse import Namespace
 from functools import cached_property, lru_cache
 import os
+from pathlib import Path
 import re
 import shlex
 import subprocess
@@ -19,7 +20,7 @@ from typing import Optional
 import requests
 
 from phylum.ci.ci_base import CIBase
-from phylum.ci.git import git_default_branch_name, git_remote
+from phylum.ci.git import git_default_branch_name, git_fetch, git_remote
 from phylum.constants import PHYLUM_HEADER, PHYLUM_USER_AGENT, REQ_TIMEOUT
 from phylum.exceptions import pprint_subprocess_error
 from phylum.logger import LOG
@@ -123,6 +124,10 @@ class CIGitLab(CIBase):
         if not default_branch_name:
             default_branch_name = git_default_branch_name(remote)
         default_branch = f"refs/remotes/{remote}/{default_branch_name}"
+
+        if not Path(os.getenv("CI_PROJECT_DIR", "."), ".git", default_branch).resolve().exists():
+            LOG.warning("The default remote branch is not available. Attempting to fetch it...")
+            git_fetch(repo=remote, ref=default_branch_name)
 
         if src_branch == default_branch:
             LOG.warning("Source branch is same as default branch. Proceeding with analysis of all dependencies ...")

--- a/src/phylum/ci/git.py
+++ b/src/phylum/ci/git.py
@@ -49,6 +49,8 @@ def git_remote(git_c_path: Optional[Path] = None) -> str:
 def git_fetch(repo: Optional[str] = None, ref: Optional[str] = None, git_c_path: Optional[Path] = None) -> None:
     """Execute a `git fetch` command with optional repository and refspec specified.
 
+    See git documentation for more detail: https://git-scm.com/docs/git-fetch
+
     The optional `git_c_path` is used to tell `git` to run as if it were started in that
     path instead of the current working directory, which is the default when not provided.
     """

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from dulwich import porcelain
 import pytest
 
-from phylum.ci.git import git_repo_name
+from phylum.ci.git import git_fetch, git_repo_name
 
 # Names of a git repository that will be cloned locally
 CLONED_LOCAL_REPO_NAMES = [
@@ -45,3 +45,14 @@ def test_cloned_remote_repo_name(tmp_path):
     porcelain.clone(source="https://github.com/phylum-dev/phylum-ci.git", target=str(repo_path), depth=1)
     remote_repo_name = git_repo_name(git_c_path=repo_path)
     assert remote_repo_name == "phylum-ci", "The cloned remote repo name should be found"
+
+
+def test_fetch_default_remote_branch(tmp_path):
+    """Ensure `git_fetch` works with a cloned remote repo missing it's default remote branch ref."""
+    repo_path: Path = tmp_path / "cloned_remote_repo_name"
+    porcelain.clone(source="https://github.com/phylum-dev/phylum-ci.git", target=str(repo_path), depth=1)
+    default_remote_branch_ref = repo_path / ".git/refs/remotes/origin/main"
+    default_remote_branch_ref.unlink(missing_ok=True)
+    assert not default_remote_branch_ref.exists()
+    git_fetch(repo="origin", ref="main", git_c_path=repo_path)
+    assert default_remote_branch_ref.exists()


### PR DESCRIPTION
This change adds a `git` helper function named `git_fetch` which does what it says. The GitLab integration is updated to be more robust when determining the common ancestor commit. If the default remote branch is not available, which can happen for self-hosted instances of GitLab, the branch is fetched before attempting to use it in a `git merge-base` command.

Closes #289

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?

## Screenshots

The code in this PR was tested by making the Docker image `maxrake/phylum-ci:gitlab_fetch` and using this script in a branch's `.gitlab-ci.yml` file:

```
  script:
    - |
      env
      rm .git/refs/remotes/origin/main || true
      ls -alh .git/refs/remotes/origin || true
      phylum-ci || true
      ls -alh .git/refs/remotes/origin || true
```

...which produced the following output:

<img width="1447" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/68793e4c-6159-4d7f-9bc7-50346e034b4d">
