### PR TITLE
fix: ensure lockfiles are files

### DIFF
--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -145,6 +145,10 @@ class CIBase(ABC):
                 LOG.warning("Provided lockfile does not exist: %s", provided_lockfile)
                 self.returncode = ReturnCode.LOCKFILE_FILTER
                 continue
+            if not provided_lockfile.is_file():
+                LOG.warning("Provided lockfile is not a file: %s", provided_lockfile)
+                self.returncode = ReturnCode.LOCKFILE_FILTER
+                continue
             if not provided_lockfile.stat().st_size:
                 LOG.warning("Provided lockfile is an empty file: %s", provided_lockfile)
                 self.returncode = ReturnCode.LOCKFILE_FILTER

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -138,7 +138,10 @@ class CIBase(ABC):
 
     @progress_spinner("Filtering lockfiles")
     def filter_lockfiles(self, provided_lockfiles: List[Path]) -> Lockfiles:
-        """Filter potential lockfiles and return the valid ones in sorted order."""
+        """Filter potential lockfiles and return the valid ones in sorted order.
+
+        A unique return code is set when *no* provided lockfiles pass through the filtering checks.
+        """
         lockfiles = []
         for provided_lockfile in provided_lockfiles:
             if not provided_lockfile.exists():

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -143,15 +143,12 @@ class CIBase(ABC):
         for provided_lockfile in provided_lockfiles:
             if not provided_lockfile.exists():
                 LOG.warning("Provided lockfile does not exist: %s", provided_lockfile)
-                self.returncode = ReturnCode.LOCKFILE_FILTER
                 continue
             if not provided_lockfile.is_file():
                 LOG.warning("Provided lockfile is not a file: %s", provided_lockfile)
-                self.returncode = ReturnCode.LOCKFILE_FILTER
                 continue
             if not provided_lockfile.stat().st_size:
                 LOG.warning("Provided lockfile is an empty file: %s", provided_lockfile)
-                self.returncode = ReturnCode.LOCKFILE_FILTER
                 continue
             cmd = [str(self.cli_path), "parse", str(provided_lockfile)]
             try:
@@ -159,9 +156,10 @@ class CIBase(ABC):
             except subprocess.CalledProcessError as err:
                 pprint_subprocess_error(err)
                 LOG.warning("Provided lockfile failed to parse as a known lockfile type: %s", provided_lockfile)
-                self.returncode = ReturnCode.LOCKFILE_FILTER
                 continue
             lockfiles.append(Lockfile(provided_lockfile, self.cli_path, self.common_ancestor_commit))
+        if not lockfiles:
+            self.returncode = ReturnCode.LOCKFILE_FILTER
         return sorted(lockfiles)
 
     @property


### PR DESCRIPTION
The change ensures that lockfiles that are not files are filtered out before processing. This change aligns with the corresponding one made in the CLI (https://github.com/phylum-dev/cli/pull/1202). It is done separately here because https://github.com/phylum-dev/phylum-ci/issues/244 (Replace lockfile detection with `phylum status`) has not been implemented yet. Plus, this allows for a fix without changing the minimum supported CLI version.

This change also ensures that the return code is not set (to 10) for lockfile filter issues unless *no* lockfiles result from the filtering. Otherwise, it is possible to fail CI pipelines (due to a non-zero return code) when the reason for failure was simply that a provided/detected lockfile was not valid...but at least one other lockfile was and all valid lockfiles then passed analysis with the active policy.

## Screenshots

Testing was done locally, by creating two directories named `requirements.txt` and `Cargo.lock`.

The behavior before this fix:
* notice the subprocess errors
* notice the return code of 10, even though there were _some_ lockfiles that passed filtering

<img width="1597" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/7285249e-b84e-4558-b776-ca972cb2a4a6">

---

The behavior with the changes in this PR:
* notice the helpful warnings _without_ any subprocess errors
* notice the return code of 0 instead of 10

<img width="1597" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/e3459e0c-7d99-4b80-b7bd-f521e94476e1">