### PR TITLE
build: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,12 +28,12 @@ repos:
       - id: black
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: b9a5dc23ed421f99c0fe14b9ace2cbc7fbf710bd  # frozen: v0.0.284
+    rev: b9787ef94f0d06972b93b36730548f0d928f26f9  # frozen: v0.0.285
     hooks:
       - id: ruff
 
   - repo: https://github.com/dosisod/refurb
-    rev: 165c224b436bae8fc25c859553de6355a25b4577  # frozen: v1.19.0
+    rev: 37d7d4b6f2c71b7338eaeac0fc11d6c28265af34  # frozen: v1.20.0
     hooks:
       - id: refurb
 

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -258,9 +258,9 @@ class CIBase(ABC):
 
         # Exit condition: a Phylum API key should be in place or available at this point.
         # Ensure stdout is piped to DEVNULL, to keep the token from being printed in (CI log) output.
+        # We want the return code here and don't want to raise when non-zero.
         cmd = [str(cli_path), "auth", "token"]
-        # pylint: disable-next=subprocess-run-check ; we want the return code here and don't want to raise when non-zero
-        if bool(subprocess.run(cmd, stdout=subprocess.DEVNULL).returncode):  # noqa: S603
+        if bool(subprocess.run(cmd, stdout=subprocess.DEVNULL).returncode):  # noqa: S603, PLW1510
             msg = "A Phylum API key is required to continue."
             raise SystemExit(msg)
 

--- a/src/phylum/logger.py
+++ b/src/phylum/logger.py
@@ -62,7 +62,7 @@ def add_logging_level(level_name: str, level_num: int, method_name: Optional[str
 
     def for_logger_class(self, message, *args, **kwargs):
         if self.isEnabledFor(level_num):
-            # pylint: disable-next=protected-access ; this is the name used in the logging class
+            # This private member access is required; it is the name used in the logging class
             self._log(level_num, message, args, **kwargs)
 
     def for_logging_module(message, *args, **kwargs):


### PR DESCRIPTION
The latest release of `ruff` added a new rule that would cause CI to fail. It is `subprocess-run-without-check` (PLW1510) and is part of the effort to convert `pylint` rules to `ruff`. Even though `pylint` is not enforced on this repository, there was a disable message to prevent local use of it from firing. Ruff has come a long way and the last remaining vestiges of `pylint` have been removed from this repo. Long live Ruff!

The pre-commit hooks and ignore directives were updated now, in anticipation of the next weekly dependency bump so that one will be more likely to pass CI.
