### PR TITLE
refactor: use git command to check branch exists

### DIFF
--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -20,7 +20,7 @@ from typing import Optional
 import requests
 
 from phylum.ci.ci_base import CIBase
-from phylum.ci.git import git_default_branch_name, git_fetch, git_remote
+from phylum.ci.git import git_branch_exists, git_default_branch_name, git_fetch, git_remote
 from phylum.constants import PHYLUM_HEADER, PHYLUM_USER_AGENT, REQ_TIMEOUT
 from phylum.exceptions import pprint_subprocess_error
 from phylum.logger import LOG
@@ -126,7 +126,7 @@ class CIGitLab(CIBase):
         default_branch = f"refs/remotes/{remote}/{default_branch_name}"
 
         project_dir = Path(os.getenv("CI_PROJECT_DIR", ".")).resolve()
-        if not Path(project_dir, ".git", default_branch).resolve().exists():
+        if not git_branch_exists(default_branch, git_c_path=project_dir):
             LOG.warning("The default remote branch is not available. Attempting to fetch it...")
             git_fetch(repo=remote, ref=default_branch_name, git_c_path=project_dir)
 

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from dulwich import porcelain
 import pytest
 
-from phylum.ci.git import git_fetch, git_repo_name
+from phylum.ci.git import git_branch_exists, git_fetch, git_repo_name
 
 # Names of a git repository that will be cloned locally
 CLONED_LOCAL_REPO_NAMES = [
@@ -51,8 +51,10 @@ def test_fetch_default_remote_branch(tmp_path):
     """Ensure `git_fetch` works with a cloned remote repo missing it's default remote branch ref."""
     repo_path: Path = tmp_path / "cloned_remote_repo_name"
     porcelain.clone(source="https://github.com/phylum-dev/phylum-ci.git", target=str(repo_path), depth=1)
-    default_remote_branch_ref = repo_path / ".git/refs/remotes/origin/main"
-    default_remote_branch_ref.unlink(missing_ok=True)
-    assert not default_remote_branch_ref.exists()
+    default_remote_branch_ref = "refs/remotes/origin/main"
+    assert git_branch_exists(default_remote_branch_ref, git_c_path=repo_path)
+    default_remote_branch_ref_path = repo_path / ".git" / default_remote_branch_ref
+    default_remote_branch_ref_path.unlink(missing_ok=True)
+    assert not git_branch_exists(default_remote_branch_ref, git_c_path=repo_path)
     git_fetch(repo="origin", ref="main", git_c_path=repo_path)
-    assert default_remote_branch_ref.exists()
+    assert git_branch_exists(default_remote_branch_ref, git_c_path=repo_path)


### PR DESCRIPTION
This change creates a new predicate function named `git_branch_exists` that makes use of the `git show-ref` command, with a specific syntax meant for checking whether a specific branch exists (See the reference command documentation: https://git-scm.com/docs/git-show-ref). This allows the GitLab CI integration to get away from using git internals directly.

## Screenshots

The code in this PR was tested by making the Docker image `maxrake/phylum-ci:git_branch_exists` and using this script in a branch's `.gitlab-ci.yml` file:

```
  script:
    - |
      env
      rm .git/refs/remotes/origin/main || true
      ls -alh .git/refs/remotes/origin || true
      phylum-ci || true
      ls -alh .git/refs/remotes/origin || true
```

...which produced the following output:

<img width="1365" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/7b75b605-cb43-4b9a-9b14-c118e0ccc3dc">
