### PR TITLE
feat!: add CycloneDX lockfile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)][CoC]
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)][pre-commit]
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)][black]
-[![Downloads](https://pepy.tech/badge/phylum/month)][downloads]
+[![Downloads](https://static.pepy.tech/badge/phylum/month)][downloads]
 [![Discord](https://img.shields.io/discord/1070071012353376387?logo=discord)][discord_invite]
 
 Utilities for integrating Phylum into CI pipelines (and beyond)

--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -2,14 +2,12 @@
 from phylum import __version__
 
 # This is the minimum CLI version supported for new installs.
-# Support for `pnpm-lock.yaml` and `packages.lock.json` lockfiles was added in v5.5.0
-# Support for `packages.*.lock.json` _detection_ was added in v5.6.0, but _parsing_ works with v5.5.0
-MIN_CLI_VER_FOR_INSTALL = "v5.5.0"
+# Support for CycloneDX lockfiles was added in v5.7.0
+MIN_CLI_VER_FOR_INSTALL = "v5.7.0"
 
 # This is the minimum CLI version supported for existing installs.
-# Support for `pnpm-lock.yaml` and `packages.lock.json` lockfiles was added in v5.5.0
-# Support for `packages.*.lock.json` _detection_ was added in v5.6.0, but _parsing_ works with v5.5.0
-MIN_CLI_VER_INSTALLED = "v5.5.0"
+# Support for CycloneDX lockfiles was added in v5.7.0
+MIN_CLI_VER_INSTALLED = "v5.7.0"
 
 # Keys are lowercase machine hardware names as returned from `uname -m`.
 # Values are the mapped rustc architecture.
@@ -58,6 +56,8 @@ SUPPORTED_LOCKFILES = {
     "*.spdx.yaml": "spdx",
     "*.spdx.yml": "spdx",
     "*.spdx": "spdx",
+    "*bom.json": "cyclonedx",
+    "*bom.xml": "cyclonedx",
 }
 
 # Timeout value, in seconds, to tell the Python Requests package to stop waiting for a response.


### PR DESCRIPTION
This change also updates a shield in the README to a new URL so it will continue to show instead of a broken link.

BREAKING CHANGE: CLI installs prior to v5.7.0 are no longer supported. A Phylum CLI version with ability to parse CycloneDX lockfiles is needed.