### PR TITLE
fix: incorrect new dependency logic

### DIFF
--- a/src/phylum/ci/common.py
+++ b/src/phylum/ci/common.py
@@ -12,7 +12,7 @@ class PackageDescriptor:
     name: str
     version: str
     type: str  # noqa: A003 ; shadowing built-in `type` is okay since renaming here would be more confusing
-    lockfile: Optional[str] = None
+    lockfile: Optional[str] = dataclasses.field(compare=False, default=None)
 
 
 # Type alias


### PR DESCRIPTION
This change fixes a problem where _any_ change in a lockfile results in the finding that _all_ dependencies from the lockfile are new. This was introduced in #282, when the `PackageDescriptor` dataclass added the `lockfile` attribute.

The issue is that the `Lockfile` class uses the `PackageDescriptor` dataclass to make comparisons and compute unique sets of dependencies. The `get_previous_lockfile_packages` function works by writing the previous lockfile object to a temporary file and then parsing that file with the `phylum parse` command. The temporary file will never have the same name as the current lockfile and so the `lockfile` attribute will be different for _all_ dependencies in the given lockfile.

Making this change ensures the `lockfile` attribute of the dataclass is not included when generating equality and comparison methods. There is not a problem with this exclusion because the `Lockfile` class still only operates on one lockfile at a time and keeps track of the lockfile's path separately, in the `path` property.

## Testing Results

<details><summary>Example of the behavior BEFORE the changes in this PR (a known bad dependency was added)</summary>
<p>

```
../phylum-ci  8  16 on  compare_true [!+] via 🐳 desktop-linux is 📦 v0.35.0 via 🐍 v3.11.5
❯ poetry run pre-commit run --all-files phylum-ci
analyze dependencies with phylum-ci......................................Failed
- hook id: phylum-ci
- exit code: 1

Logging initialized to level 10 (DEBUG)
Phylum CLI version not specified
Found installed Phylum CLI version: v5.7.0
Minimum supported Phylum CLI version required for install: v5.7.0
Making request to GitHub API URL:
https://api.github.com/repos/phylum-dev/cli/releases
49 GitHub API requests remaining until window resets at: Wed Sep  6 14:29:29
2023
Using Phylum CLI version: v5.7.0
Extra arguments provided. Assuming a Python `pre-commit` working environment.
Confirming pre-requisites ...
`git` binary found on the PATH
Checking extra args for valid pre-commit scenarios ...
All the extra args are staged files
No valid lockfiles were provided as arguments. Checking the `.phylum_project`
file ...
Lockfile(s) provided in `.phylum_project` file: [PosixPath('poetry.lock')]
Existing Phylum CLI instance found: v5.7.0 at /Users/maxrake/.local/bin/phylum
Using Phylum CLI instance: v5.7.0 at /Users/maxrake/.local/bin/phylum
Valid provided lockfiles: [poetry.lock]
Valid pre-commit scenario found: lockfile(s) found in extra arguments
All pre-requisites met
Project name not provided as argument. Checking the `.phylum_project` file ...
Project name provided in `.phylum_project` file: phylum-ci
Attempting to create a Phylum project with the name: phylum-ci ...
Using Phylum group: phylum_bot
Project phylum-ci already exists. Continuing with it ...
Lockfiles in use: [poetry.lock]
The lockfile poetry.lock has changed
A lockfile has changed. Proceeding with analysis ...
Label to use for analysis: pre-commit_compare_true_53b8ec6
Only considering newly added dependencies ...
New dependencies in `poetry.lock`: [PackageDescriptor(name='attrs',
version='23.1.0', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='bleach', version='6.0.0', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='cachetools', version='5.3.1',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='certifi',
version='2023.7.22', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='cffi', version='1.15.1', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='cfgv', version='3.4.0',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='chardet',
version='5.2.0', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='charset-normalizer', version='3.2.0', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='click', version='8.1.7',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='click-log',
version='0.4.0', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='colorama', version='0.4.6', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='commonmark', version='0.9.1',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='cryptography',
version='41.0.3', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='distlib', version='0.3.7', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='docutils', version='0.20.1',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='dotty-dict',
version='1.3.1', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='dulwich', version='0.21.6', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='exceptiongroup',
version='1.1.3', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='filelock', version='3.12.3', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='gitdb', version='4.0.10',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='gitpython',
version='3.1.34', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='identify', version='2.5.27', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='idna', version='3.4',
type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='importlib-metadata', version='6.8.0', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='importlib-resources',
version='6.0.1', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='iniconfig', version='2.0.0', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='invoke', version='2.2.0',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='jaraco-classes',
version='3.3.0', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='jeepney', version='0.8.0', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='jsonschema', version='4.19.0',
type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='jsonschema-specifications', version='2023.7.1',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='keyring',
version='24.2.0', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='levenshtein', version='0.21.1', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='more-itertools',
version='10.1.0', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='nodeenv', version='1.8.0', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='packaging', version='23.1',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='pathspec',
version='0.11.2', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='pkginfo', version='1.9.6', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='pkgutil-resolve-name',
version='1.3.10', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='platformdirs', version='3.10.0', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='pluggy', version='1.3.0',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='pre-commit',
version='3.4.0', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='pycparser', version='2.21', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='pygments', version='2.16.1',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='pyproject-api',
version='1.6.1', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='pytest', version='7.4.1', type='pypi',
lockfile='poetry.lock'),
PackageDescriptor(name='pytest-github-actions-annotate-failures',
version='0.2.0', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='python-gitlab', version='3.15.0', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='python-semantic-release',
version='7.34.6', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='pywin32-ctypes', version='0.2.2', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='pyyaml', version='5.3.1',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='rapidfuzz',
version='3.2.0', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='readme-renderer', version='41.0', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='referencing', version='0.30.2',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='requests',
version='2.31.0', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='requests-toolbelt', version='1.0.0', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='rfc3986', version='2.0.0',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='rich',
version='12.6.0', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='rich-cli', version='1.8.0', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='rich-click', version='1.6.1',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='rich-codex',
version='1.2.6', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='rich-rst', version='1.1.7', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='rpds-py', version='0.10.0',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='ruamel-yaml',
version='0.17.32', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='ruamel-yaml-clib', version='0.2.7', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='secretstorage',
version='3.3.3', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='semver', version='2.13.0', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='setuptools', version='68.1.2',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='six',
version='1.16.0', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='smmap', version='5.0.0', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='textual', version='0.1.18',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='tomli',
version='2.0.1', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='tomlkit', version='0.12.1', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='tox', version='4.11.1',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='tox-gh-actions',
version='3.1.3', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='tqdm', version='4.66.1', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='twine', version='3.8.0',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='types-requests',
version='2.31.0.2', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='types-urllib3', version='1.26.25.14', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='typing-extensions',
version='4.7.1', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='urllib3', version='2.0.4', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='virtualenv', version='20.24.4',
type='pypi', lockfile='poetry.lock'), PackageDescriptor(name='webencodings',
version='0.5.1', type='pypi', lockfile='poetry.lock'),
PackageDescriptor(name='wheel', version='0.41.2', type='pypi',
lockfile='poetry.lock'), PackageDescriptor(name='zipp', version='3.16.2',
type='pypi', lockfile='poetry.lock')]
85 unique newly added dependencies
Performing analysis. This may take a few seconds.
Using analysis command: /Users/maxrake/.local/bin/phylum extension run --yes
/Users/maxrake/dev/phylum/phylum-ci/src/phylum/exts/ci phylum-ci
pre-commit_compare_true_53b8ec6 --group phylum_bot
/var/folders/gh/wnf14j7n4q34y2t36hq2jz800000gn/T/base_jl91vnuf.json
/Users/maxrake/dev/phylum/phylum-ci/poetry.lock
The analysis is complete and there were failures
Analysis output:

╔══════════════════════════════════════════════════════════════════════════════╗
║                Phylum OSS Supply Chain Risk Analysis - FAILED                ║
╚══════════════════════════════════════════════════════════════════════════════╝

This repository analyzes the risk of new dependencies. An administrator of this repository has set requirements via Phylum policy.

If you see this comment, one or more dependencies have failed Phylum's risk analysis.


                         Package: pyyaml@5.3.1 failed.

            PyYAML@5.3.1 is vulnerable to Improper Input Validation

Risk Domain: Software Vulnerability
Risk Level: critical

Reason: risk level cannot exceed medium

View this project in the Phylum UI (https://app.phylum.io/projects/56f7f1b0-7f63-47a4-9f5e-8194772b2e13?group=phylum_bot&label=pre-commit_compare_true_53b8ec6)
Return code: 1
```

</p>
</details> 

<details><summary>Example of the behavior AFTER the changes in this PR</summary>
<p>

```
../phylum-ci  8  16 on  compare_true [!+] via 🐳 desktop-linux is 📦 v0.35.0 via 🐍 v3.11.5
❯ poetry run pre-commit run --all-files phylum-ci
analyze dependencies with phylum-ci......................................Failed
- hook id: phylum-ci
- exit code: 1

Logging initialized to level 10 (DEBUG)
Phylum CLI version not specified
Found installed Phylum CLI version: v5.7.0
Minimum supported Phylum CLI version required for install: v5.7.0
Making request to GitHub API URL:
https://api.github.com/repos/phylum-dev/cli/releases
50 GitHub API requests remaining until window resets at: Wed Sep  6 14:29:29
2023
Using Phylum CLI version: v5.7.0
Extra arguments provided. Assuming a Python `pre-commit` working environment.
Confirming pre-requisites ...
`git` binary found on the PATH
Checking extra args for valid pre-commit scenarios ...
All the extra args are staged files
No valid lockfiles were provided as arguments. Checking the `.phylum_project`
file ...
Lockfile(s) provided in `.phylum_project` file: [PosixPath('poetry.lock')]
Existing Phylum CLI instance found: v5.7.0 at /Users/maxrake/.local/bin/phylum
Using Phylum CLI instance: v5.7.0 at /Users/maxrake/.local/bin/phylum
Valid provided lockfiles: [poetry.lock]
Valid pre-commit scenario found: lockfile(s) found in extra arguments
All pre-requisites met
Project name not provided as argument. Checking the `.phylum_project` file ...
Project name provided in `.phylum_project` file: phylum-ci
Attempting to create a Phylum project with the name: phylum-ci ...
Using Phylum group: phylum_bot
Project phylum-ci already exists. Continuing with it ...
Lockfiles in use: [poetry.lock]
The lockfile poetry.lock has changed
A lockfile has changed. Proceeding with analysis ...
Label to use for analysis: pre-commit_compare_true_53b8ec6
Only considering newly added dependencies ...
New dependencies in `poetry.lock`: [PackageDescriptor(name='pyyaml',
version='5.3.1', type='pypi', lockfile='poetry.lock')]
1 unique newly added dependencies
Performing analysis. This may take a few seconds.
Using analysis command: /Users/maxrake/.local/bin/phylum extension run --yes
/Users/maxrake/dev/phylum/phylum-ci/src/phylum/exts/ci phylum-ci
pre-commit_compare_true_53b8ec6 --group phylum_bot
/var/folders/gh/wnf14j7n4q34y2t36hq2jz800000gn/T/base_ij159dbn.json
/Users/maxrake/dev/phylum/phylum-ci/poetry.lock
The analysis is complete and there were failures
Analysis output:

╔══════════════════════════════════════════════════════════════════════════════╗
║                Phylum OSS Supply Chain Risk Analysis - FAILED                ║
╚══════════════════════════════════════════════════════════════════════════════╝

This repository analyzes the risk of new dependencies. An administrator of this repository has set requirements via Phylum policy.

If you see this comment, one or more dependencies have failed Phylum's risk analysis.


                         Package: pyyaml@5.3.1 failed.

            PyYAML@5.3.1 is vulnerable to Improper Input Validation

Risk Domain: Software Vulnerability
Risk Level: critical

Reason: risk level cannot exceed medium

View this project in the Phylum UI (https://app.phylum.io/projects/56f7f1b0-7f63-47a4-9f5e-8194772b2e13?group=phylum_bot&label=pre-commit_compare_true_53b8ec6)
Return code: 1
```

</p>
</details>

Notice the difference in "unique newly added dependencies" going from 85 to 1.