### PR TITLE
fix: integrations should check for previous comments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ src = ["src", "tests"]
 select = [
     # Using `ALL` has the risk that new rules may be enabled when `ruff` is updated but updates are
     # automated, with a PR that includes enforced QA checks, to weekly dependency and pre-commit hook bumps.
-    "ALL"
+    "ALL",
 ]
 ignore = [
     # Reference: https://beta.ruff.rs/docs/rules/
@@ -113,19 +113,19 @@ ignore = [
     # `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible. Prefer D212.
     "D213", # multi-line-summary-second-line
     # These `flake8-fixme` (FIX) rules are incompatible with `flake8-todos` (TD). Prefer TD.
-    "FIX001",   # line-contains-fixme
-    "FIX002",   # line-contains-todo
-    "FIX003",   # line-contains-xxx
+    "FIX001", # line-contains-fixme
+    "FIX002", # line-contains-todo
+    "FIX003", # line-contains-xxx
     # Cached instance methods are okay in this project b/c instances are short lived and won't lead to memory leaks.
     "B019", # cached-instance-method
     # Assigning to a variable before a return statement is more readable and useful for debugging
-    "RET504",   # unnecessary-assign
+    "RET504", # unnecessary-assign
     # Allowing exception handling within loops improves readability with ony a negligible performance impact.
-    "PERF203",  # try-except-in-loop
+    "PERF203", # try-except-in-loop
     # These ignores will be removed during https://github.com/phylum-dev/phylum-ci/issues/238
-    "ANN",  # flake8-annotations
-    "TCH",  # flake8-type-checking
-    "FA",   # flake8-future-annotations
+    "ANN", # flake8-annotations
+    "TCH", # flake8-type-checking
+    "FA",  # flake8-future-annotations
 ]
 
 [tool.ruff.per-file-ignores]

--- a/src/phylum/ci/ci_azure.py
+++ b/src/phylum/ci/ci_azure.py
@@ -23,13 +23,13 @@ import re
 import shlex
 import subprocess
 import textwrap
-from typing import Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 import urllib.parse
 
 import requests
 
 from phylum.ci.ci_base import CIBase
-from phylum.ci.ci_github import post_github_comment
+from phylum.ci.ci_github import get_most_recent_phylum_comment_github, post_github_comment
 from phylum.ci.git import git_default_branch_name, git_remote
 from phylum.constants import PHYLUM_HEADER, PHYLUM_USER_AGENT, REQ_TIMEOUT
 from phylum.exceptions import pprint_subprocess_error
@@ -251,6 +251,14 @@ class CIAzure(CIBase):
     @property
     def phylum_comment_exists(self) -> bool:
         """Predicate for detecting whether a Phylum-generated comment exists."""
+        if not is_in_pr():
+            # Comments only exist in the context of a PR
+            return False
+        if self.triggering_repo == "TfsGit":
+            return bool(get_most_recent_phylum_comment_azure(self.azure_token))
+        if self.triggering_repo == "GitHub":
+            comments_url = get_github_comments_url()
+            return bool(get_most_recent_phylum_comment_github(comments_url, self.github_token))
         return False
 
     def post_output(self) -> None:
@@ -261,30 +269,13 @@ class CIAzure(CIBase):
         Post output as a comment on the GitHub PR for PR triggers and GitHub hosted repos.
         """
         super().post_output()
-
         if not is_in_pr():
             # Can't post the output to the PR when there is no PR
             return
-
         if self.triggering_repo == "TfsGit":
             post_azure_comment(self.azure_token, self.analysis_report)
         elif self.triggering_repo == "GitHub":
-            github_api_root_url = "https://api.github.com"
-
-            owner_repo = os.getenv("BUILD_REPOSITORY_NAME")
-            if not owner_repo:
-                msg = "The GitHub owner and repository could not be found."
-                raise SystemExit(msg)
-            pr_number = os.getenv("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER")
-            if not pr_number:
-                msg = "The GitHub PR number could not be found."
-                raise SystemExit(msg)
-
-            # API Reference: https://docs.github.com/en/rest/issues/comments
-            # This is the same endpoint for listing all PR comments (GET) and creating new ones (POST)
-            pr_comments_api_endpoint = f"/repos/{owner_repo}/issues/{pr_number}/comments"
-            comments_url = f"{github_api_root_url}{pr_comments_api_endpoint}"
-
+            comments_url = get_github_comments_url()
             post_github_comment(comments_url, self.github_token, self.analysis_report)
 
 
@@ -306,85 +297,90 @@ def get_pr_branches() -> Tuple[str, str]:
     return src_branch, tgt_branch
 
 
-def post_azure_comment(azure_token: str, comment: str) -> None:
-    """Post a comment on an Azure Repos Pull Request (PR).
+# This is a cached function due to the desire to limit API calls.
+# The function is meant to be used internally, where it is known that the comments on the PR at the time
+# of first execution will suffice for the duration of the rest of the lifetime of the running integration.
+@lru_cache(maxsize=1)
+def get_most_recent_phylum_comment_azure(azure_token: str) -> Optional[str]:
+    """Get the raw text of the most recently posted Phylum-generated comment for Azure Repos PRs.
 
-    The comment will only be created if there isn't already a Phylum comment
-    or if the most recently posted Phylum comment does not contain the same content.
+    Return `None` when one does not exist.
     """
-    # API References:
-    #   * Basics: https://learn.microsoft.com/rest/api/azure/devops
-    #   * PR Threads - List: https://learn.microsoft.com/rest/api/azure/devops/git/pull-request-threads/list
-    #   * PR Threads - Create: https://learn.microsoft.com/rest/api/azure/devops/git/pull-request-threads/create
-
-    # This is the latest available API version a/o NOV 2022. While it is a "preview" version, it was chosen to
-    # lean forward in an effort to maintain relevance and recency for a longer period of time going forward.
-    # It does appear that the APIs for PR Threads are stable between this version and the previous major version
-    # with accessible documentation.
-    api_version = "7.1-preview.1"
+    if not is_in_pr():
+        # It only makes sense to reference this property in the context of a PR
+        return None
 
     # SYSTEM_TEAMPROJECT provides the name that corresponds to SYSTEM_TEAMPROJECTID.
     # SYSTEM_TEAMPROJECTID is used in the API calls since it should never change.
     team_project_id = os.getenv("SYSTEM_TEAMPROJECTID")
     team_project_name = os.getenv("SYSTEM_TEAMPROJECT")
-    instance = os.getenv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI")
-    repo_id = os.getenv("BUILD_REPOSITORY_ID")
-    pr_id = os.getenv("SYSTEM_PULLREQUEST_PULLREQUESTID")
-    resource_path = f"/_apis/git/repositories/{repo_id}/pullRequests/{pr_id}/threads"
+    pr_threads_url = get_azure_pr_threads_url()
+    headers = get_headers(azure_token)
+    query_params, query_params_encoded = get_query_params()
 
-    # This is the same endpoint for listing all PR threads (GET) and creating new ones (POST)
-    pr_threads_url = f"{instance}{team_project_id}{resource_path}"
-
-    # To provide the personal access token through an HTTP header, you must first convert it to a base64 string.
-    # NOTE: The colon (`:`) appended to the front of the PAT is intentional as it is expected by the endpoints.
-    b64_ado_pat = base64.b64encode(bytes(f":{azure_token}", encoding="ascii")).decode(encoding="ascii")
-
-    query_params = {"api-version": api_version}
-    headers = {
-        "User-Agent": PHYLUM_USER_AGENT,
-        "Authorization": f"Basic {b64_ado_pat}",
-    }
-
-    query_params_encoded = urllib.parse.urlencode(query_params, safe="/", quote_via=urllib.parse.quote)
-    LOG.info("Getting list of all current PR threads with GET URL: %s?%s ...", pr_threads_url, query_params_encoded)
+    LOG.info("Getting all current PR threads with GET URL: %s?%s ...", pr_threads_url, query_params_encoded)
     LOG.debug("The team project ID %s maps to name: %s", team_project_id, team_project_name)
     resp = requests.get(pr_threads_url, params=query_params, headers=headers, timeout=REQ_TIMEOUT)
     resp.raise_for_status()
     if resp.status_code != requests.codes.OK:
         msg = f"Are the permissions on the Azure token `AZURE_TOKEN` correct? {AZURE_PAT_ERR_MSG}"
         raise SystemExit(msg)
-    pr_threads = resp.json()
+    pr_threads_resp: Dict = resp.json()
+
+    pr_threads_count = pr_threads_resp.get("count", 0)
+    LOG.debug("PR threads found: %s", pr_threads_count)
+    if not pr_threads_count:
+        LOG.debug("No existing pull request comments found.")
+        return None
+
+    LOG.info("Checking pull request threads for existing Phylum-generated comments ...")
+    pr_threads: List = pr_threads_resp.get("value", [])
+    # NOTE: The API call returns the comments in ascending order by ID...thus the need to reverse the list.
+    #       Detecting Phylum comments is done simply by looking for those that start with a known string value.
+    #       We only care about the most recent Phylum comment.
+    pr_thread: Dict
+    for pr_thread in reversed(pr_threads):
+        thread_comments = pr_thread.get("comments", [])
+        thread_comment: Dict
+        for thread_comment in thread_comments:
+            # All Phylum generated comments will be the first in their own thread
+            if thread_comment.get("id", 0) != 1:
+                continue
+            thread_comment_content: str = thread_comment.get("content", "")
+            if thread_comment_content.lstrip().startswith(PHYLUM_HEADER.strip()):
+                LOG.debug("The most recently posted Phylum pull request comment was found.")
+                return thread_comment_content
+
+    LOG.debug("No existing Phylum pull request comments found.")
+    return None
+
+
+def post_azure_comment(azure_token: str, comment: str) -> None:
+    """Post a comment on an Azure Repos Pull Request (PR).
+
+    The comment will only be created if there isn't already a Phylum comment
+    or if the most recently posted Phylum comment does not contain the same content.
+    """
+    if not is_in_pr():
+        msg = "Must be working in the context of a pull request pipeline"
+        raise SystemExit(msg)
 
     LOG.info("Checking pull request threads for existing comment content to avoid duplication ...")
-    pr_threads_count = pr_threads.get("count", 0)
-    LOG.debug("PR threads found: %s", pr_threads_count)
-    if pr_threads_count:
-        pr_threads = pr_threads.get("value", [])
-        is_phylum_comment_found = False
-        # NOTE: The API call returns the comments in ascending order by ID...thus the need to reverse the list.
-        #       Detecting Phylum comments is done simply by looking for those that start with a known string value.
-        #       We only care about the most recent Phylum comment.
-        for pr_thread in reversed(pr_threads):
-            thread_comments = pr_thread.get("comments", [])
-            for thread_comment in thread_comments:
-                # All Phylum generated comments will be the first in their own thread
-                if thread_comment.get("id", 0) != 1:
-                    continue
-                if thread_comment.get("content", "").lstrip().startswith(PHYLUM_HEADER.strip()):
-                    LOG.debug("The most recently posted Phylum pull request comment was found.")
-                    is_phylum_comment_found = True
-                    if thread_comment.get("content", "") == comment:
-                        LOG.debug("It contains the same content as the current analysis. Nothing to do.")
-                        return
-                    LOG.debug("It does not contain the same content as the current analysis.")
-                    break
-            if is_phylum_comment_found:
-                break
-        if not is_phylum_comment_found:
-            LOG.debug("No existing Phylum pull request comments found.")
+    most_recent_phylum_comment = get_most_recent_phylum_comment_azure(azure_token)
+    if most_recent_phylum_comment:
+        LOG.debug("The most recently posted Phylum pull request comment was found.")
+        if most_recent_phylum_comment == comment:
+            LOG.debug("It contains the same content as the current analysis. Nothing to do.")
+            return
+        LOG.debug("It does not contain the same content as the current analysis.")
+    else:
+        LOG.debug("No existing Phylum pull request comments found.")
 
     # If we got here, then the most recent Phylum PR comment does not match the current analysis output or
     # there were no Phylum PR comments. Either way, create a new PR comment.
+    pr_threads_url = get_azure_pr_threads_url()
+    headers = get_headers(azure_token)
+    query_params, query_params_encoded = get_query_params()
     req_body = {
         "comments": [
             {
@@ -398,3 +394,71 @@ def post_azure_comment(azure_token: str, comment: str) -> None:
     LOG.info("Creating new pull request thread with POST URL: %s?%s ...", pr_threads_url, query_params_encoded)
     resp = requests.post(pr_threads_url, params=query_params, json=req_body, headers=headers, timeout=REQ_TIMEOUT)
     resp.raise_for_status()
+
+
+def get_headers(azure_token: str) -> Dict[str, str]:
+    """Provide the headers to use when making Azure Pipelines API calls."""
+    # To provide the personal access token through an HTTP header, you must first convert it to a base64 string.
+    # NOTE: The colon (`:`) appended to the front of the PAT is intentional as it is expected by the endpoints.
+    b64_ado_pat = base64.b64encode(bytes(f":{azure_token}", encoding="ascii")).decode(encoding="ascii")
+    headers = {
+        "User-Agent": PHYLUM_USER_AGENT,
+        "Authorization": f"Basic {b64_ado_pat}",
+    }
+    return headers
+
+
+def get_query_params() -> Tuple[Dict, str]:
+    """Provide the query parameters to use when making Azure Pipelines API calls."""
+    # This is the latest available API version a/o SEP 2023. While it is a "preview" version, it was chosen to
+    # lean forward in an effort to maintain relevance and recency for a longer period of time going forward.
+    # It does appear that the APIs for PR Threads are stable between this version and the previous major version
+    # with accessible documentation.
+    api_version = "7.2-preview.1"
+    query_params = {"api-version": api_version}
+    query_params_encoded = urllib.parse.urlencode(query_params, safe="/", quote_via=urllib.parse.quote)
+    return query_params, query_params_encoded
+
+
+def get_azure_pr_threads_url() -> str:
+    """Get the Azure Pipelines pull request threads API URL and return it."""
+    # API References:
+    #   * Basics: https://learn.microsoft.com/rest/api/azure/devops
+    #   * PR Threads - List: https://learn.microsoft.com/rest/api/azure/devops/git/pull-request-threads/list
+    #   * PR Threads - Create: https://learn.microsoft.com/rest/api/azure/devops/git/pull-request-threads/create
+
+    if not is_in_pr():
+        msg = "Must be working in the context of a pull request pipeline"
+        raise SystemExit(msg)
+
+    # SYSTEM_TEAMPROJECT provides the name that corresponds to SYSTEM_TEAMPROJECTID.
+    # SYSTEM_TEAMPROJECTID is used in the API calls since it should never change.
+    team_project_id = os.getenv("SYSTEM_TEAMPROJECTID")
+    instance = os.getenv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI")
+    repo_id = os.getenv("BUILD_REPOSITORY_ID")
+    pr_id = os.getenv("SYSTEM_PULLREQUEST_PULLREQUESTID")
+    resource_path = f"/_apis/git/repositories/{repo_id}/pullRequests/{pr_id}/threads"
+
+    # This is the same endpoint for listing all PR threads (GET) and creating new ones (POST)
+    pr_threads_url = f"{instance}{team_project_id}{resource_path}"
+    return pr_threads_url
+
+
+def get_github_comments_url() -> str:
+    """Get the GitHub comments API URL and return it."""
+    github_api_root_url = "https://api.github.com"
+
+    owner_repo = os.getenv("BUILD_REPOSITORY_NAME")
+    if not owner_repo:
+        msg = "The GitHub owner and repository could not be found."
+        raise SystemExit(msg)
+    pr_number = os.getenv("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER")
+    if not pr_number:
+        msg = "The GitHub PR number could not be found."
+        raise SystemExit(msg)
+
+    # API Reference: https://docs.github.com/en/rest/issues/comments
+    # This is the same endpoint for listing all PR comments (GET) and creating new ones (POST)
+    pr_comments_api_endpoint = f"/repos/{owner_repo}/issues/{pr_number}/comments"
+    comments_url = f"{github_api_root_url}{pr_comments_api_endpoint}"
+    return comments_url

--- a/src/phylum/ci/ci_azure.py
+++ b/src/phylum/ci/ci_azure.py
@@ -144,7 +144,7 @@ class CIAzure(CIBase):
         """Get the custom Personal Access Token (PAT) in use."""
         return self._github_token
 
-    @property
+    @cached_property
     def phylum_label(self) -> str:
         """Get a custom label for use when submitting jobs for analysis."""
         if is_in_pr():
@@ -247,6 +247,11 @@ class CIAzure(CIBase):
         self.update_lockfiles_change_status(diff_base_sha, err_msg)
 
         return any(lockfile.is_lockfile_changed for lockfile in self.lockfiles)
+
+    @property
+    def phylum_comment_exists(self) -> bool:
+        """Predicate for detecting whether a Phylum-generated comment exists."""
+        return False
 
     def post_output(self) -> None:
         """Post the output of the analysis.

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -272,7 +272,7 @@ class CIBase(ABC):
         """Get the report from the overall analysis, in markdown format."""
         return self._analysis_report
 
-    @property
+    @cached_property
     @abstractmethod
     def phylum_label(self) -> str:
         """Get a custom label for use when submitting jobs for analysis.
@@ -319,6 +319,15 @@ class CIBase(ABC):
         """Get the lockfiles' collective modification status.
 
         Implementations should return `True` if any lockfile has changed and `False` otherwise.
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def phylum_comment_exists(self) -> bool:
+        """Predicate for detecting whether a Phylum-generated comment exists.
+
+        Implementations should return `True` if an existing Phylum-generated comment exists and `False` otherwise.
         """
         raise NotImplementedError
 

--- a/src/phylum/ci/ci_bitbucket.py
+++ b/src/phylum/ci/ci_bitbucket.py
@@ -23,7 +23,7 @@ import re
 import shlex
 import subprocess
 import textwrap
-from typing import Optional
+from typing import Dict, List, Optional
 import urllib.parse
 
 import requests
@@ -286,8 +286,8 @@ class CIBitbucket(CIBase):
         LOG.debug("The repository UUID %s maps to workspace and repository name: %s", repo_uuid, repo_full_name)
         req = requests.get(url, params=query_params, headers=self.headers, timeout=REQ_TIMEOUT)
         req.raise_for_status()
-        pr_comments_resp: dict = req.json()
-        pr_comments_values: list = pr_comments_resp.get("values", [])
+        pr_comments_resp: Dict = req.json()
+        pr_comments_values: List = pr_comments_resp.get("values", [])
         if pr_comments_values:
             # NOTE: The API call normally returns all the comments in chronological order. Query parameters are used to
             #       only return the most recent Phylum comment, if one exists, since this is the only one we care about.

--- a/src/phylum/ci/ci_bitbucket.py
+++ b/src/phylum/ci/ci_bitbucket.py
@@ -103,7 +103,7 @@ class CIBitbucket(CIBase):
         """Get the Bitbucket token (e.g., repository, project, or workspace access token)."""
         return self._bitbucket_token
 
-    @property
+    @cached_property
     def phylum_label(self) -> str:
         """Get a custom label for use when submitting jobs for analysis."""
         if is_in_pr():
@@ -204,6 +204,11 @@ class CIBitbucket(CIBase):
 
         return any(lockfile.is_lockfile_changed for lockfile in self.lockfiles)
 
+    @property
+    def phylum_comment_exists(self) -> bool:
+        """Predicate for detecting whether a Phylum-generated comment exists."""
+        return False
+
     def post_output(self) -> None:
         """Post the output of the analysis.
 
@@ -260,7 +265,7 @@ class CIBitbucket(CIBase):
         req.raise_for_status()
         pr_comments = req.json()
 
-        LOG.info("Checking existing pull request comments for existing content to avoid duplication ...")
+        LOG.info("Checking pull request comments for existing content to avoid duplication ...")
         if pr_comments.get("values"):
             # NOTE: The API call normally returns all the comments in chronological order. Query parameters are used to
             #       only return the most recent Phylum comment, if one exists, since this is the only one we care about.

--- a/src/phylum/ci/ci_github.py
+++ b/src/phylum/ci/ci_github.py
@@ -109,7 +109,7 @@ class CIGitHub(CIBase):
         """Get the `pull_request` webhook event payload."""
         return self._pr_event
 
-    @property
+    @cached_property
     def phylum_label(self) -> str:
         """Get a custom label for use when submitting jobs for analysis."""
         pr_number = self.pr_event.get("pull_request", {}).get("number", "unknown-number")
@@ -143,6 +143,11 @@ class CIGitHub(CIBase):
         self.update_lockfiles_change_status(pr_base_sha, err_msg)
 
         return any(lockfile.is_lockfile_changed for lockfile in self.lockfiles)
+
+    @property
+    def phylum_comment_exists(self) -> bool:
+        """Predicate for detecting whether a Phylum-generated comment exists."""
+        return False
 
     def post_output(self) -> None:
         """Post the output of the analysis.

--- a/src/phylum/ci/ci_github.py
+++ b/src/phylum/ci/ci_github.py
@@ -11,14 +11,14 @@ GitHub References:
   * https://docs.github.com/en/rest/guides/working-with-comments#pull-request-comments
 """
 from argparse import Namespace
-from functools import cached_property
+from functools import cached_property, lru_cache
 import json
 import os
 from pathlib import Path
 import re
 import subprocess
 import textwrap
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import requests
 
@@ -109,6 +109,18 @@ class CIGitHub(CIBase):
         """Get the `pull_request` webhook event payload."""
         return self._pr_event
 
+    @property
+    def comments_url(self) -> str:
+        """Get the API endpoint for working with comments."""
+        # The `comments_url` is the full API endpoint for this particular GitHub issue/PR.
+        # API Reference: https://docs.github.com/en/rest/issues/comments
+        # This is the same endpoint for listing all PR comments (GET) and creating new ones (POST).
+        comments_url = self.pr_event.get("pull_request", {}).get("comments_url")
+        if comments_url is None:
+            msg = "The API for posting a GitHub comment was not found."
+            raise SystemExit(msg)
+        return comments_url
+
     @cached_property
     def phylum_label(self) -> str:
         """Get a custom label for use when submitting jobs for analysis."""
@@ -147,7 +159,7 @@ class CIGitHub(CIBase):
     @property
     def phylum_comment_exists(self) -> bool:
         """Predicate for detecting whether a Phylum-generated comment exists."""
-        return False
+        return bool(_get_most_recent_phylum_comment(self.comments_url, self.github_token))
 
     def post_output(self) -> None:
         """Post the output of the analysis.
@@ -157,12 +169,42 @@ class CIGitHub(CIBase):
         """
         super().post_output()
 
-        comments_url = self.pr_event.get("pull_request", {}).get("comments_url")
-        if comments_url is None:
-            msg = "The API for posting a GitHub comment was not found."
-            raise SystemExit(msg)
+        post_github_comment(self.comments_url, self.github_token, self.analysis_report)
 
-        post_github_comment(comments_url, self.github_token, self.analysis_report)
+
+# This is a cached function due to the desire to limit API calls.
+# The function is meant to only be used internally, where it is known that the comments on the PR at the time
+# of first execution will suffice for the duration of the rest of the lifetime of the running integration.
+@lru_cache(maxsize=1)
+def _get_most_recent_phylum_comment(comments_url: str, github_token: str) -> Optional[str]:
+    """Get the raw text of the most recently posted Phylum-generated comment.
+
+    Return `None` when one does not exist.
+
+    The `comments_url` should be the full API endpoint for a particular GitHub issue/PR.
+    API Reference: https://docs.github.com/en/rest/issues/comments
+    This is the same endpoint for listing all PR comments (GET) and creating new ones (POST).
+    """
+    query_params = {"per_page": 100}
+    LOG.info("Getting all current pull request comments with GET URL: %s ...", comments_url)
+    pr_comments: List = github_request(comments_url, params=query_params, github_token=github_token)
+
+    if not pr_comments:
+        LOG.debug("No existing pull request comments found.")
+        return None
+
+    # NOTE: The API call returns the comments in ascending order by ID...thus the need to reverse the list.
+    #       Detecting Phylum comments is done simply by looking for those that start with a known string value.
+    #       We only care about the most recent Phylum comment.
+    pr_comment: Dict
+    for pr_comment in reversed(pr_comments):
+        comment_body: str = pr_comment.get("body", "")
+        if comment_body.lstrip().startswith(PHYLUM_HEADER.strip()):
+            LOG.debug("The most recently posted Phylum pull request comment was found.")
+            return comment_body
+
+    LOG.debug("No existing Phylum pull request comments found.")
+    return None
 
 
 def post_github_comment(comments_url: str, github_token: str, comment: str) -> None:
@@ -175,24 +217,16 @@ def post_github_comment(comments_url: str, github_token: str, comment: str) -> N
     The comment will only be created if there isn't already a Phylum comment
     or if the most recently posted Phylum comment does not contain the same content.
     """
-    query_params = {"per_page": 100}
-    LOG.info("Getting all current pull request comments with GET URL: %s ...", comments_url)
-    pr_comments: List = github_request(comments_url, params=query_params, github_token=github_token)
-
     LOG.info("Checking pull request comments for existing content to avoid duplication ...")
-    if not pr_comments:
-        LOG.debug("No existing pull request comments found.")
-    # NOTE: The API call returns the comments in ascending order by ID...thus the need to reverse the list.
-    #       Detecting Phylum comments is done simply by looking for those that start with a known string value.
-    #       We only care about the most recent Phylum comment.
-    for pr_comment in reversed(pr_comments):
-        if pr_comment.get("body", "").lstrip().startswith(PHYLUM_HEADER.strip()):
-            LOG.debug("The most recently posted Phylum pull request comment was found.")
-            if pr_comment.get("body", "") == comment:
-                LOG.debug("It contains the same content as the current analysis. Nothing to do.")
-                return
-            LOG.debug("It does not contain the same content as the current analysis.")
-            break
+    most_recent_phylum_comment = _get_most_recent_phylum_comment(comments_url, github_token)
+    if most_recent_phylum_comment:
+        LOG.debug("The most recently posted Phylum pull request comment was found.")
+        if most_recent_phylum_comment == comment:
+            LOG.debug("It contains the same content as the current analysis. Nothing to do.")
+            return
+        LOG.debug("It does not contain the same content as the current analysis.")
+    else:
+        LOG.debug("No existing Phylum pull request comments found.")
 
     # If we got here, then the most recent Phylum PR comment does not match the current analysis output or
     # there were no Phylum PR comments. Either way, create a new PR comment.

--- a/src/phylum/ci/ci_github.py
+++ b/src/phylum/ci/ci_github.py
@@ -159,7 +159,7 @@ class CIGitHub(CIBase):
     @property
     def phylum_comment_exists(self) -> bool:
         """Predicate for detecting whether a Phylum-generated comment exists."""
-        return bool(_get_most_recent_phylum_comment(self.comments_url, self.github_token))
+        return bool(get_most_recent_phylum_comment_github(self.comments_url, self.github_token))
 
     def post_output(self) -> None:
         """Post the output of the analysis.
@@ -173,11 +173,11 @@ class CIGitHub(CIBase):
 
 
 # This is a cached function due to the desire to limit API calls.
-# The function is meant to only be used internally, where it is known that the comments on the PR at the time
+# The function is meant to be used internally, where it is known that the comments on the PR at the time
 # of first execution will suffice for the duration of the rest of the lifetime of the running integration.
 @lru_cache(maxsize=1)
-def _get_most_recent_phylum_comment(comments_url: str, github_token: str) -> Optional[str]:
-    """Get the raw text of the most recently posted Phylum-generated comment.
+def get_most_recent_phylum_comment_github(comments_url: str, github_token: str) -> Optional[str]:
+    """Get the raw text of the most recently posted Phylum-generated comment for GitHub PRs.
 
     Return `None` when one does not exist.
 
@@ -218,7 +218,7 @@ def post_github_comment(comments_url: str, github_token: str, comment: str) -> N
     or if the most recently posted Phylum comment does not contain the same content.
     """
     LOG.info("Checking pull request comments for existing content to avoid duplication ...")
-    most_recent_phylum_comment = _get_most_recent_phylum_comment(comments_url, github_token)
+    most_recent_phylum_comment = get_most_recent_phylum_comment_github(comments_url, github_token)
     if most_recent_phylum_comment:
         LOG.debug("The most recently posted Phylum pull request comment was found.")
         if most_recent_phylum_comment == comment:

--- a/src/phylum/ci/ci_github.py
+++ b/src/phylum/ci/ci_github.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import re
 import subprocess
 import textwrap
-from typing import Optional
+from typing import List, Optional
 
 import requests
 
@@ -177,7 +177,7 @@ def post_github_comment(comments_url: str, github_token: str, comment: str) -> N
     """
     query_params = {"per_page": 100}
     LOG.info("Getting all current pull request comments with GET URL: %s ...", comments_url)
-    pr_comments = github_request(comments_url, params=query_params, github_token=github_token)
+    pr_comments: List = github_request(comments_url, params=query_params, github_token=github_token)
 
     LOG.info("Checking pull request comments for existing content to avoid duplication ...")
     if not pr_comments:

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -181,7 +181,6 @@ class CIGitLab(CIBase):
             return False
 
         # Detecting Phylum notes is done simply by looking for notes that start with a known string value.
-        # TODO: Convert this into a function and swap the `PHYLUM_HEADER` out for a value unique to this integration.
         for mr_note in self.mr_notes:
             if mr_note.get("body", "").lstrip().startswith(PHYLUM_HEADER.strip()):
                 LOG.debug("A Phylum-generated merge request note was found.")

--- a/src/phylum/ci/ci_none.py
+++ b/src/phylum/ci/ci_none.py
@@ -39,7 +39,7 @@ class CINone(CIBase):
             msg = "This script expects to be run from the top level of a `git` repository"
             raise SystemExit(msg)
 
-    @property
+    @cached_property
     def phylum_label(self) -> str:
         """Get a custom label for use when submitting jobs for analysis."""
         current_branch = git_curent_branch_name()
@@ -77,3 +77,9 @@ class CINone(CIBase):
         remote = git_remote()
         self.update_lockfiles_change_status(f"refs/remotes/{remote}/HEAD...")
         return any(lockfile.is_lockfile_changed for lockfile in self.lockfiles)
+
+    @property
+    def phylum_comment_exists(self) -> bool:
+        """Predicate for detecting whether a Phylum-generated comment exists."""
+        # There are no historical comments in this implementation
+        return False

--- a/src/phylum/ci/ci_precommit.py
+++ b/src/phylum/ci/ci_precommit.py
@@ -82,7 +82,7 @@ class CIPreCommit(CIBase):
             LOG.error("Unrecognized arguments: [code]%s[/]", " ".join(self.extra_args), extra={"markup": True})
             sys.exit(0)
 
-    @property
+    @cached_property
     def phylum_label(self) -> str:
         """Get a custom label for use when submitting jobs for analysis."""
         current_branch = git_curent_branch_name()
@@ -118,3 +118,9 @@ class CIPreCommit(CIBase):
                 LOG.debug("The lockfile [code]%r[/] has [b]NOT[/] changed", lockfile, extra={"markup": True})
                 lockfile.is_lockfile_changed = False
         return any(lockfile.is_lockfile_changed for lockfile in self.lockfiles)
+
+    @property
+    def phylum_comment_exists(self) -> bool:
+        """Predicate for detecting whether a Phylum-generated comment exists."""
+        # There are no historical comments in this implementation
+        return False

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -191,12 +191,14 @@ def main(args: Optional[Sequence[str]] = None) -> int:
     # Detect which CI environment, if any, we are in
     ci_env = detect_ci_platform(parsed_args, remainder_args)
 
-    # Bail early if there are no changes to any lockfile
+    # Bail early when possible
     LOG.debug("Lockfiles in use: %s", ci_env.lockfiles)
     if ci_env.force_analysis:
         LOG.info("Forced analysis specified with flag or otherwise set. Proceeding with analysis ...")
     elif ci_env.is_any_lockfile_changed:
         LOG.info("A lockfile has changed. Proceeding with analysis ...")
+    elif ci_env.phylum_comment_exists:
+        LOG.info("Existing Phylum comment found. Proceeding with analysis ...")
     else:
         LOG.warning("No lockfile has changed. Nothing to do.")
         return 0

--- a/src/phylum/github.py
+++ b/src/phylum/github.py
@@ -2,7 +2,7 @@
 import os
 import textwrap
 import time
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 import requests
 
@@ -52,13 +52,13 @@ def github_request(
     params: Optional[dict] = None,
     github_token: Optional[str] = None,
     timeout: float = REQ_TIMEOUT,
-) -> dict:
+) -> Any:
     """Make a request to a given GitHub API endpoint and return the response.
 
     A limited amount of specific failure cases are checked to provide detailed information to users.
     All failure cases cause the system to exit with a failure code and a detailed message.
 
-    Valid GitHub API requests will return a JSON-formatted response body, which is returned as a Python dict.
+    Valid GitHub API requests will return a JSON-formatted response body, usually a dict or list.
     """
     headers = get_headers(github_token=github_token)
 

--- a/src/phylum/init/cli.py
+++ b/src/phylum/init/cli.py
@@ -309,7 +309,7 @@ def setup_token(token: str) -> None:
     phylum_settings_path = get_phylum_settings_path()
     ensure_settings_file()
     yaml = YAML()
-    settings: dict = yaml.load(phylum_settings_path.read_text(encoding="utf-8"))
+    settings: Dict = yaml.load(phylum_settings_path.read_text(encoding="utf-8"))
     settings.setdefault("auth_info", {})
     settings["auth_info"]["offline_access"] = token
     with phylum_settings_path.open("w", encoding="utf-8") as f:
@@ -350,7 +350,7 @@ def process_uri_option(args: argparse.Namespace) -> None:
     settings_file_existed = phylum_settings_path.exists()
     ensure_settings_file()
     yaml = YAML()
-    settings: dict = yaml.load(phylum_settings_path.read_text(encoding="utf-8"))
+    settings: Dict = yaml.load(phylum_settings_path.read_text(encoding="utf-8"))
     configured_uri = settings.get("connection", {}).get("uri")
 
     if api_uri:

--- a/src/phylum/init/cli.py
+++ b/src/phylum/init/cli.py
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 import zipfile
 
 from packaging.utils import canonicalize_version
@@ -112,7 +112,7 @@ def get_latest_version() -> str:
     """Get the "latest" version programmatically and return it."""
     # API Reference: https://docs.github.com/en/rest/releases/releases#get-the-latest-release
     github_api_url = "https://api.github.com/repos/phylum-dev/cli/releases/latest"
-    req_json = github_request(github_api_url)
+    req_json: Dict = github_request(github_api_url)
 
     # The "name" entry stores the GitHub Release name, which could be set to something other than the version.
     # Using the "tag_name" entry is better since the tags are much more tightly coupled with the release version.
@@ -132,9 +132,10 @@ def supported_releases() -> List[str]:
     query_params = {"per_page": 100}
     LOG.debug("Minimum supported Phylum CLI version required for install: %s", MIN_CLI_VER_FOR_INSTALL)
 
-    req_json = github_request(github_api_url, params=query_params)
+    req_json: List = github_request(github_api_url, params=query_params)
 
     cli_releases = {}
+    rel: Dict
     for rel in req_json:
         # The "name" entry stores the GitHub Release name, which could be set to something other than the version.
         # Using the "tag_name" entry is better since the tags are much more tightly coupled with the release version.
@@ -182,7 +183,7 @@ def supported_targets(release_tag: str) -> List[str]:
     # API Reference: https://docs.github.com/en/rest/releases/releases#get-a-release-by-tag-name
     github_api_url = f"https://api.github.com/repos/phylum-dev/cli/releases/tags/{release_tag}"
 
-    req_json = github_request(github_api_url)
+    req_json: Dict = github_request(github_api_url)
 
     assets = req_json.get("assets", [])
     targets: List[str] = []


### PR DESCRIPTION
This change affects all integrations that deal with comments/notes on
PRs/MRs. Previously, these integrations would not account for the
possibility that Phylum-generated comments already exist on the PR/MR.
That led to situations where a FAILED comment was the last one posted
even though actions (commits) were taken to rectify the bad dependencies.
This gap was enabled because the "changed" lockfile looks no different
than the one it is being compared to (e.g., the default branch). The
additional effect of this behavior was that the integration would bail
early and an analysis would therefore not be submitted, leaving the
project in an old/bad/incorrect state when viewed on that label.

The change here is to ensure previous Phylum-generated comments *are*
taken into account. If any are found, an analysis is submitted, even if
the lockfile has not otherwise changed from the one which it is compared.

Actions taken include:

* Add `phylum_comment_exists` predicate as abstract property to `CIBase`
  * Update the main logic to NOT bail when there is an existing comment
  * Return false for the `CINone` and `CIPReCommit` implementations
    * They will never have historical comments
* Update the GitLab integration to properly check for existing comments
  * Account for when in a merge request pipeline context
* Update Bitbucket integration to properly check for existing comments
  * Account for when in a pull request pipeline context
  * Use query parameters to get the most recent Phylum-generated comment
    * Simplify the `phylum_comment_exists` logic with this consolidation
* Update GitHub integration to properly check for existing comments
  * Create function to get the most recent Phylum-generated comment
    * Simplify the `phylum_comment_exists` logic with this consolidation
* Update Azure integration to properly check for existing comments
  * Create function to get the most recent Phylum-generated comment
    * Simplify the `phylum_comment_exists` logic with this consolidation
  * Account for the triggering repo being either GitHub or Azure Repos
* Format and refactor throughout
* Change `phylum_label` to a cached property since it is now called more
  * Limit the number of subprocess calls
* Refactor and format throughout
  * Add more type hints
  * Ensure existing type hints are backwards compatible to Python 3.8
  * Format `pyproject.toml`

Closes #303

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
  - Automated tests do not exist for these integrations yet
  - Manual testing was performed (see screenshots below)
- [x] Have you updated all affected documentation?

## Screenshots

For each supported integration, two screenshots are shown as proof of functionality. The first screenshot shows the PR/MR timeline showing the behavior from before and then after using the changes from this branch. The second screenshot shows the logs from the last pipeline run, showing that the lockfile has not changed but a comment/note was found and therefore an analysis was run.

<details><summary>GitLab</summary>
<p>

<img width="978" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/289d7c3a-0fd2-499e-8678-f497731e5044">

---

<img width="703" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/d7faa923-deb5-4c20-9c01-b8188451c94f">

</p>
</details> 

<details><summary>Bitbucket</summary>
<p>

<img width="972" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/467cf118-021c-48ce-a577-e02bea8bb8f5">

---

<img width="1117" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/7a2ecc00-4f23-4d5b-9b00-f715ab4a823e">

</p>
</details> 

<details><summary>GitHub</summary>
<p>

<img width="922" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/699aa907-9de1-411f-b5d1-46953f98d75f">

---

<img width="691" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/13d1af1a-f8fa-417f-b8f0-87e260792878">

</p>
</details> 

<details><summary>Azure Pipelines - Azure Repos</summary>
<p>

<img width="987" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/a0d8ca38-247b-4857-b19c-1ac549d35521">

---

<img width="1325" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/d8789f4f-4dcc-436c-a88c-d5fbfb32c2cc">

</p>
</details> 

<details><summary>Azure Pipelines - GitHub</summary>
<p>

<img width="925" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/a1a1f8f2-aae1-4713-bc6a-040563deb2e3">

---

<img width="1313" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/56f903cf-c1f9-4c87-a691-a97cb67b5a24">

</p>
</details> 