### PR TITLE
feat: enforce strict engine control for `npm`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,6 +145,7 @@ LABEL maintainer="Phylum, Inc. <engineering@phylum.io>"
 LABEL org.opencontainers.image.source="https://github.com/phylum-dev/phylum-ci"
 
 ENV PHYLUM_VENV="/opt/venv"
+ENV GLOBAL_HOME="/usr/local"
 
 # Some tools get installed and used based on a home directory. This can cause trouble
 # when using a container started from this image with a UID:GID that does not map to
@@ -157,20 +158,23 @@ ENV PHYLUM_VENV="/opt/venv"
 # The following tools are susceptible to this issue and therefore have been provided
 # with explicit install/home directories that allow them to be globally accessible.
 #
+# Node and npm
+# Ref: https://github.com/tj/n
+ENV N_PREFIX="${GLOBAL_HOME}/n"
 # Corepack, Yarn, and pnpm
 # Ref: https://github.com/nodejs/corepack#environment-variables
-ENV COREPACK_HOME="/usr/local/corepack/.cache/node/corepack"
+ENV COREPACK_HOME="${GLOBAL_HOME}/corepack"
 # Rust, Cargo, and rustup
 # Ref: https://rust-lang.github.io/rustup/installation/index.html#choosing-where-to-install
-ENV RUSTUP_HOME="/usr/local/rustup"
-ENV CARGO_HOME="/usr/local/cargo"
+ENV RUSTUP_HOME="${GLOBAL_HOME}/rustup"
+ENV CARGO_HOME="${GLOBAL_HOME}/cargo"
 # Gradle
 # Ref: https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_environment_variables
-ENV GRADLE_HOME="/usr/local/gradle"
+ENV GRADLE_HOME="${GLOBAL_HOME}/gradle"
 ENV GRADLE_USER_HOME="${GRADLE_HOME}/.gradle"
 
-ENV GO_PATH="/usr/local/go/bin"
-ENV PATH=${PHYLUM_VENV}/bin:$PATH:${GRADLE_HOME}/bin:${GO_PATH}:${CARGO_HOME}/bin
+ENV GO_PATH="${GLOBAL_HOME}/go"
+ENV PATH=$PATH:${PHYLUM_VENV}/bin:${N_PREFIX}/bin:${GRADLE_HOME}/bin:${CARGO_HOME}/bin:${GO_PATH}/bin
 
 ENV PYTHONDONTWRITEBYTECODE=1
 
@@ -192,7 +196,6 @@ RUN \
     apt-get upgrade --yes; \
     apt-get install --yes --no-install-recommends \
         git \
-        npm \
         bundler \
         maven \
         curl \
@@ -202,17 +205,24 @@ RUN \
     # Make ENTRYPOINT alternative script available
     chmod +x "${PHYLUM_VENV}/bin/entrypoint.sh"; \
     #
-    # Install Phylum CLI
-    phylum-init -vvv --phylum-release "${CLI_VER:-latest}" --global-install; \
-    #
-    # Install and enable `corepack` with cached instances of the latest major versions of `yarn` and `pnpm` tools
-    npm install -g corepack@latest; \
-    corepack pack yarn@stable pnpm@latest; \
-    corepack enable yarn pnpm; \
-    #
     # Create an "alias" for `curl` with secure and common options
     printf '#!/bin/bash\ncurl --proto "=https" --tlsv1.2 -sSfL "$@"\n' > /usr/bin/curls; \
     chmod +x /usr/bin/curls; \
+    #
+    # Install Phylum CLI
+    phylum-init -vvv --phylum-release "${CLI_VER:-latest}" --global-install; \
+    #
+    # Install `node` and `npm` with `n`
+    # Ref: https://github.com/tj/n
+    curls -o n.sh https://raw.githubusercontent.com/tj/n/master/bin/n; \
+    chmod +x n.sh && ./n.sh install lts; \
+    npm config set --global engine-strict=true; \
+    ./n.sh rm lts && rm n.sh; \
+    #
+    # Install and enable `corepack` with cached instances of the latest major versions of `yarn` and `pnpm` tools
+    npm install --global corepack@latest; \
+    corepack pack yarn@stable pnpm@latest; \
+    corepack enable yarn pnpm; \
     #
     # Manual install of `gradle`
     GRADLE_VERSION=$(curls https://services.gradle.org/versions/current | jq -r '.version'); \
@@ -234,8 +244,8 @@ RUN \
     GO_DL_SHA256=$(echo "${GO_DL_REL}" | jq -r '.sha256'); \
     curls -o go.tgz "https://go.dev/dl/${GO_DL_FILENAME}"; \
     printf "%s *go.tgz" "${GO_DL_SHA256}" | sha256sum -c -; \
-    rm -rf /usr/local/go; \
-    tar -C /usr/local -xzf go.tgz; \
+    rm -rf "${GLOBAL_HOME}/go"; \
+    tar -C "${GLOBAL_HOME}" -xzf go.tgz; \
     rm go.tgz; \
     #
     # Manual install of Rust to get `cargo` tool


### PR DESCRIPTION
Recently, the Docker image creation started generating a warning when attempting to install the `latest` version of `corepack`:

```
#21 178.0 + npm install -g corepack@latest
#21 182.5 npm WARN EBADENGINE Unsupported engine {
#21 182.5 npm WARN EBADENGINE   package: 'corepack@0.21.0',
#21 182.5 npm WARN EBADENGINE   required: { node: '>=18.17.1' },
#21 182.6 npm WARN EBADENGINE   current: { node: 'v18.13.0', npm: '9.2.0' }
#21 182.6 npm WARN EBADENGINE }
```

This started when the `latest` version of `corepack` was updated to specify a higher `engine` range in it's `package.json`. The resulting image _appeared_ to still function, but it is unclear if that is just a coincidence. This change makes it obvious when there is an unsupported engine by changing the warning to an error, with the `engine-strict` config setting:

https://docs.npmjs.com/cli/v10/using-npm/config#engine-strict

This worked as adding a failing test and to get the "test" to pass, a newer version of `node` and `npm` are installed, using the `n` version management tool. The overall image size remained the same.

## Testing

Changes from this PR have been built in a Docker image and hosted [on Docker Hub for my account](https://hub.docker.com/r/maxrake/phylum-ci/tags), as the `strict_npm` tag.
