### PR TITLE
fix: more container tools broken when home-less

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -152,6 +152,26 @@ ENV PHYLUM_VENV="/opt/venv"
 ENV PATH=${PHYLUM_VENV}/bin:$PATH
 ENV PYTHONDONTWRITEBYTECODE=1
 
+# Some tools get installed and used based on a home directory. This can cause trouble
+# when using a container started from this image with a UID:GID that does not map to
+# a user/group account in the container. Examples include:
+#
+#   * The installation directory is `/root` and the container user has no access
+#   * The tool relies on the existence of a $HOME directory, which may not be true
+#     * https://medium.com/redbubble/running-a-docker-container-as-a-non-root-user-7d2e00f8ee15
+#
+# The following tools are susceptible to this issue and therefore have been provided
+# with explicit install/home directories that allow them to be globally accessible.
+#
+# Specify a common, globally accessible directory to use instead of $HOME
+ENV INSTALL_DIR="/usr/local"
+# Phylum, pip, and any other tool that supports the XDG spec
+# Ref: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+ENV XDG_DATA_HOME="${INSTALL_DIR}/share"
+ENV XDG_CONFIG_HOME="${INSTALL_DIR}/.config"
+ENV XDG_STATE_HOME="${INSTALL_DIR}/state"
+ENV XDG_CACHE_HOME="${INSTALL_DIR}/.cache"
+
 # Copy only Python packages to limit the image size. This includes the
 # `phylum` package with it's `phylum-ci` and `phylum-init` entry points.
 COPY --from=builder ${PHYLUM_VENV} ${PHYLUM_VENV}
@@ -165,6 +185,12 @@ RUN set -eux; \
     chmod +x "${PHYLUM_VENV}/bin/entrypoint.sh"; \
     # Install Phylum CLI
     phylum-init -vvv --phylum-release "${CLI_VER:-latest}" --global-install; \
+    # Create a git config file in a location accessible for $HOME-less users
+    # Ref: https://git-scm.com/docs/git-config#FILES
+    mkdir -vp "${XDG_CONFIG_HOME}/git" && touch "${XDG_CONFIG_HOME}/git/config"; \
+    # Ensure the XDG directories have permissions for non-root users
+    mkdir -vp "${XDG_DATA_HOME}" "${XDG_CONFIG_HOME}" "${XDG_STATE_HOME}" "${XDG_CACHE_HOME}"; \
+    chmod -vR 777 "${XDG_DATA_HOME}" "${XDG_CONFIG_HOME}" "${XDG_STATE_HOME}" "${XDG_CACHE_HOME}"; \
     # Cleanup
     apt-get purge --yes --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*; \


### PR DESCRIPTION
This was initially addressed in #329, but it has since been found that some more tools get used based on a home directory. These additional findings are due to testing lockfile generation more fully and not simply relying on the successful installation and access of each required tool from a non-root user/group that does not map to a user/group account already in the container.

The following additional tools are susceptible to the same issue and therefore have been provided with explicit install/home directories that allow them to be globally accessible:

* Phylum, `pip`, and any other tool that supports the XDG spec
* Dotnet
* Go
* Git

The XDG and `git` changes were also applied to the slim image creation since Phylum, `pip`, and `git` are available there.

## Testing

Changes from this PR have been built in Docker images and hosted [on Docker Hub for my account](https://hub.docker.com/r/maxrake/phylum-ci/tags), as the `more_homeless` and `more_homeless_slim` tags.

Testing was completed with the private `isildurs_bane` repo.