### PR TITLE
feat: cache parsing results of current dependency files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,7 +270,7 @@ poetry run phylum-init -h
 ```
 
 To iterate during development of the `phylum-ci` integrations, it can be helpful to force the analysis of the
-lockfile(s), even when it has not changed. It can also be useful to ensure all dependencies are considered.
+dependency file(s), even when it has not changed. It can also be useful to ensure all dependencies are considered.
 To do so, use the flags:
 
 ```sh

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -22,8 +22,8 @@ from packaging.version import Version
 from rich.markdown import Markdown
 
 from phylum.ci.common import DataclassJSONEncoder, JobPolicyEvalResult, LockfileEntries, LockfileEntry, ReturnCode
+from phylum.ci.depfile import Depfile, Depfiles, parse_current_depfile
 from phylum.ci.git import git_hash_object, git_repo_name
-from phylum.ci.lockfile import Lockfile, Lockfiles, parse_current_depfile
 from phylum.console import console
 from phylum.constants import ENVVAR_NAME_TOKEN, MIN_CLI_VER_INSTALLED
 from phylum.exceptions import PhylumCalledProcessError, pprint_subprocess_error
@@ -105,36 +105,36 @@ class CIBase(ABC):
             self._returncode = value
 
     @cached_property
-    def lockfiles(self) -> Lockfiles:
-        """Get the package lockfile(s) in lexicographic order.
+    def depfiles(self) -> Depfiles:
+        """Get the package dependency file(s) in lexicographic order.
 
-        The package lockfile(s) can be specified as an option or contained in the `.phylum_project` file.
-        Lockfiles provided as an input option will be preferred over any entries in the `.phylum_project` file.
+        The package dependency file(s) can be specified as an option or contained in the `.phylum_project` file.
+        Dependency files provided as an input option will be preferred over any entries in the `.phylum_project` file.
 
-        When no valid lockfiles are provided otherwise, an attempt will be made to automatically detect them.
+        When no valid dependency files are provided otherwise, an attempt will be made to automatically detect them.
         """
         arg_lockfiles: Optional[list[list[Path]]] = self.args.lockfile
         if arg_lockfiles:
             # flatten the list of lists
             provided_arg_lockfiles = [LockfileEntry(path) for sub_list in arg_lockfiles for path in sub_list]
             LOG.debug("Dependency files provided as arguments: %s", provided_arg_lockfiles)
-            valid_lockfiles = self.filter_lockfiles(provided_arg_lockfiles)
-            if valid_lockfiles:
-                LOG.debug("Valid provided dependency files: %s", valid_lockfiles)
-                return valid_lockfiles
+            valid_depfiles = self.filter_depfiles(provided_arg_lockfiles)
+            if valid_depfiles:
+                LOG.debug("Valid provided dependency files: %s", valid_depfiles)
+                return valid_depfiles
 
         LOG.info("No valid dependency files were provided as arguments. An attempt will be made to detect them.")
-        lockfile_entries: list[OrderedDict] = self._project_settings.get("lockfiles", [])
-        detected_lockfiles = [LockfileEntry(lfe.get("path", ""), lfe.get("type", "auto")) for lfe in lockfile_entries]
-        if lockfile_entries and self._project_settings.get("root"):
-            LOG.debug("Dependency files provided in `.phylum_project` file: %s", detected_lockfiles)
+        depfile_entries: list[OrderedDict] = self._project_settings.get("lockfiles", [])
+        detected_depfiles = [LockfileEntry(lfe.get("path", ""), lfe.get("type", "auto")) for lfe in depfile_entries]
+        if depfile_entries and self._project_settings.get("root"):
+            LOG.debug("Dependency files provided in `.phylum_project` file: %s", detected_depfiles)
         else:
-            LOG.debug("Detected dependency files: %s", detected_lockfiles)
-        if detected_lockfiles:
-            valid_lockfiles = self.filter_lockfiles(detected_lockfiles)
-            if valid_lockfiles:
-                LOG.debug("Valid detected dependency files: %s", valid_lockfiles)
-                return valid_lockfiles
+            LOG.debug("Detected dependency files: %s", detected_depfiles)
+        if detected_depfiles:
+            valid_depfiles = self.filter_depfiles(detected_depfiles)
+            if valid_depfiles:
+                LOG.debug("Valid detected dependency files: %s", valid_depfiles)
+                return valid_depfiles
 
         msg = """\
             No valid dependency files were detected.
@@ -142,36 +142,36 @@ class CIBase(ABC):
         raise SystemExit(textwrap.dedent(msg))
 
     @progress_spinner("Filtering dependency files")
-    def filter_lockfiles(self, provided_lockfiles: LockfileEntries) -> Lockfiles:
-        """Filter potential lockfiles and return the valid ones in sorted order."""
-        lockfiles = []
-        for provided_lockfile in provided_lockfiles:
+    def filter_depfiles(self, provided_depfiles: LockfileEntries) -> Depfiles:
+        """Filter potential dependency files and return the valid ones in sorted order."""
+        depfiles = []
+        for provided_depfile in provided_depfiles:
             # Make sure it exists
-            if not provided_lockfile.path.exists():
-                LOG.warning("Provided dependency file does not exist: %s", provided_lockfile.path)
-                self.returncode = ReturnCode.LOCKFILE_FILTER
+            if not provided_depfile.path.exists():
+                LOG.warning("Provided dependency file does not exist: %s", provided_depfile.path)
+                self.returncode = ReturnCode.DEPFILE_FILTER
                 continue
             # Make sure it is not an empty file
-            if not provided_lockfile.path.stat().st_size:
-                LOG.warning("Provided dependency file is an empty file: %s", provided_lockfile.path)
-                self.returncode = ReturnCode.LOCKFILE_FILTER
+            if not provided_depfile.path.stat().st_size:
+                LOG.warning("Provided dependency file is an empty file: %s", provided_depfile.path)
+                self.returncode = ReturnCode.DEPFILE_FILTER
                 continue
             # Make sure it can be parsed by Phylum CLI
             try:
-                _ = parse_current_depfile(self.cli_path, provided_lockfile.type, provided_lockfile.path)
+                _ = parse_current_depfile(self.cli_path, provided_depfile.type, provided_depfile.path)
             except subprocess.CalledProcessError as err:
                 pprint_subprocess_error(err)
-                _path, _type = provided_lockfile.path, provided_lockfile.type
+                _path, _type = provided_depfile.path, provided_depfile.type
                 msg = f"""\
                     Provided dependency file [code]{_path}[/] failed to parse as lockfile type [code]{_type}[/].
                     If this is a manifest, consider supplying lockfile type explicitly in the `.phylum_project` file.
                     For more info, see: https://docs.phylum.io/docs/lockfile_generation
                     Please report this as a bug if you believe [code]{_path}[/] is a valid {_type} dependency file."""
                 LOG.warning(textwrap.dedent(msg), extra={"markup": True})
-                self.returncode = ReturnCode.LOCKFILE_FILTER
+                self.returncode = ReturnCode.DEPFILE_FILTER
                 continue
-            lockfiles.append(Lockfile(provided_lockfile, self.cli_path, self.common_ancestor_commit))
-        return sorted(lockfiles)
+            depfiles.append(Depfile(provided_depfile, self.cli_path, self.common_ancestor_commit))
+        return sorted(depfiles)
 
     @property
     def all_deps(self) -> bool:
@@ -298,23 +298,24 @@ class CIBase(ABC):
         raise NotImplementedError
 
     @property
-    def lockfile_hash_object(self) -> str:
-        """Get the lockfile hash object of the first changed lockfile and return it.
+    def depfile_hash_object(self) -> str:
+        """Get the dependency file hash object of the first changed dependency file and return it.
 
-        Since there can be many changed lockfiles, find and use only the hash object of the first changed lockfile.
-        Since it is possible that no lockfile has changed (e.g., when forcing analysis), default to first lockfile.
-        When found, only the first seven characters of the hash object will be returned, which is a git "short SHA-1".
+        Since there can be many changed dependency files, find and use only the hash object of the
+        first changed dependency file. Since it is possible that no dependency file has changed
+        (e.g., when forcing analysis), default to first dependency file. When found, only the first
+        seven characters of the hash object will be returned, which is a git "short SHA-1".
         Reference: https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection
         """
-        if not self.lockfiles:
+        if not self.depfiles:
             return "unknown"
-        first_changed_lockfile = self.lockfiles[0]
-        for lockfile in self.lockfiles:
-            if lockfile.is_lockfile_changed:
-                first_changed_lockfile = lockfile
+        first_changed_depfile = self.depfiles[0]
+        for depfile in self.depfiles:
+            if depfile.is_depfile_changed:
+                first_changed_depfile = depfile
                 break
-        lockfile_hash_object = git_hash_object(first_changed_lockfile.path)
-        return lockfile_hash_object[:7]
+        depfile_hash_object = git_hash_object(first_changed_depfile.path)
+        return depfile_hash_object[:7]
 
     @cached_property
     @abstractmethod
@@ -328,10 +329,10 @@ class CIBase(ABC):
 
     @property
     @abstractmethod
-    def is_any_lockfile_changed(self) -> bool:
-        """Get the lockfiles' collective modification status.
+    def is_any_depfile_changed(self) -> bool:
+        """Get the dependency files' collective modification status.
 
-        Implementations should return `True` if any lockfile has changed and `False` otherwise.
+        Implementations should return `True` if any dependency file has changed and `False` otherwise.
         """
         raise NotImplementedError
 
@@ -344,25 +345,25 @@ class CIBase(ABC):
         """
         raise NotImplementedError
 
-    def update_lockfiles_change_status(self, commit: str, err_msg: Optional[str] = None) -> None:
-        """Update each lockfile's change status.
+    def update_depfiles_change_status(self, commit: str, err_msg: Optional[str] = None) -> None:
+        """Update each dependency file's change status.
 
         The input `commit` is the one to use in a `git diff` command to view the changes relative to the working tree.
         The input `err_msg` is what will be printed when `git diff` fails. This is usually due to not having enough
         branch history...which can happen with shallow clones.
         """
-        for lockfile in self.lockfiles:
-            LOG.debug("Checking [code]%r[/] for changes ...", lockfile, extra={"markup": True})
+        for depfile in self.depfiles:
+            LOG.debug("Checking [code]%r[/] for changes ...", depfile, extra={"markup": True})
             # `--exit-code` will make git exit with 1 if there were differences while 0 means no differences.
             # Any other exit code is an error and a reason to re-raise.
-            cmd = ["git", "diff", "--exit-code", "--quiet", commit, "--", str(lockfile.path)]
+            cmd = ["git", "diff", "--exit-code", "--quiet", commit, "--", str(depfile.path)]
             ret = subprocess.run(cmd, check=False)  # noqa: S603
             if ret.returncode == 0:
-                LOG.debug("The dependency file [code]%r[/] has [b]NOT[/] changed", lockfile, extra={"markup": True})
-                lockfile.is_lockfile_changed = False
+                LOG.debug("The dependency file [code]%r[/] has [b]NOT[/] changed", depfile, extra={"markup": True})
+                depfile.is_depfile_changed = False
             elif ret.returncode == 1:
-                LOG.debug("The dependency file [code]%r[/] has changed", lockfile, extra={"markup": True})
-                lockfile.is_lockfile_changed = True
+                LOG.debug("The dependency file [code]%r[/] has changed", depfile, extra={"markup": True})
+                depfile.is_depfile_changed = True
             else:
                 if err_msg:
                     LOG.error("%s", textwrap.dedent(err_msg))
@@ -424,8 +425,9 @@ class CIBase(ABC):
     def post_output(self) -> None:
         """Post the output of the analysis as markdown rendered for output to the terminal/logs.
 
-        Each implementation that offers analysis output in the form of comments on a pull/merge request should
-        ensure those comments are unique and not added multiple times as the review changes but no lockfile does.
+        Each implementation that offers analysis output in the form of comments
+        on a pull/merge request should ensure those comments are unique and not
+        added multiple times as the review changes but no dependency file does.
         """
         # Post the markdown output, rendered for terminal/log output
         LOG.debug("Analysis output:\n")
@@ -434,7 +436,7 @@ class CIBase(ABC):
 
     @progress_spinner("Analyzing dependencies with Phylum")
     def analyze(self) -> None:
-        """Analyze the results gathered from passing the lockfile(s) to the CLI."""
+        """Analyze the results gathered from passing the dependency file(s) to the CLI."""
         # Build up the command based on the provided inputs.
         cmd = [
             str(self.cli_path),
@@ -452,24 +454,24 @@ class CIBase(ABC):
         if self.all_deps:
             LOG.info("Considering all current dependencies ...")
             base_pkgs = []
-            total_packages = {pkg for lockfile in self.lockfiles for pkg in lockfile.current_lockfile_packages()}
+            total_packages = {pkg for depfile in self.depfiles for pkg in depfile.current_depfile_packages()}
             LOG.debug("%s unique current dependencies", len(total_packages))
         else:
             LOG.info("Only considering newly added dependencies ...")
-            # When the `--force-analysis` flag is specified without the `--all-deps` flag, it is necessary
-            # to ensure the `is_lockfile_changed` property is set for each lockfile. Simply referencing
-            # the `is_any_lockfile_changed` property will ensure this happens.
-            if self.force_analysis and self.is_any_lockfile_changed:
+            # When the `--force-analysis` flag is specified without the `--all-deps` flag, it is
+            # necessary to ensure the `is_depfile_changed` property is set for each dependency file.
+            # Simply referencing the `is_any_depfile_changed` property will ensure this happens.
+            if self.force_analysis and self.is_any_depfile_changed:
                 LOG.debug("Updated each dependency file's change status")
-            base_pkgs = sorted({pkg for lockfile in self.lockfiles for pkg in lockfile.base_deps})
-            new_packages = sorted({pkg for lockfile in self.lockfiles for pkg in lockfile.new_deps})
+            base_pkgs = sorted({pkg for depfile in self.depfiles for pkg in depfile.base_deps})
+            new_packages = sorted({pkg for depfile in self.depfiles for pkg in depfile.new_deps})
             LOG.debug("%s unique newly added dependencies", len(new_packages))
 
         with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8", prefix="base_", suffix=".json") as base_fd:
             json.dump(base_pkgs, base_fd, cls=DataclassJSONEncoder)
             base_fd.flush()
             cmd.append(base_fd.name)
-            cmd.extend(f"{lockfile.path}:{lockfile.type}" for lockfile in self.lockfiles)
+            cmd.extend(f"{depfile.path}:{depfile.type}" for depfile in self.depfiles)
 
             LOG.info("Performing analysis. This may take a few seconds.")
             LOG.debug("Using analysis command: %s", shlex.join(cmd))

--- a/src/phylum/ci/ci_bitbucket.py
+++ b/src/phylum/ci/ci_bitbucket.py
@@ -51,8 +51,8 @@ def is_in_pr() -> bool:
       * For pull requests (e.g., pull request pipelines)
 
     Knowing when the context is within a pull request helps to ensure the logic used
-    to determine the lockfile changes is correct. It also helps to ensure output is not
-    attempted to be posted when NOT in the context of a review.
+    to determine the dependency file changes is correct. It also helps to ensure output
+    is not attempted to be posted when NOT in the context of a review.
     """
     # References:
     # https://github.com/watson/ci-info/blob/master/vendors.json
@@ -112,7 +112,7 @@ class CIBitbucket(CIBase):
             label = f"{self.ci_platform_name}_PR#{pr_id}_{pr_src_branch}"
         else:
             current_branch = os.getenv("BITBUCKET_BRANCH", "unknown-branch")
-            label = f"{self.ci_platform_name}_{current_branch}_{self.lockfile_hash_object}"
+            label = f"{self.ci_platform_name}_{current_branch}_{self.depfile_hash_object}"
 
         label = re.sub(r"\s+", "-", label)
         return label
@@ -154,8 +154,8 @@ class CIBitbucket(CIBase):
 
             # If the current commit is on the default branch, then the merge base will be the same
             # as the current commit and it won't be possible to provide a useful common ancestor
-            # commit. In this case, it is better to force analysis of the lockfile(s) and consider
-            # *all* dependencies in analysis results instead of just the newly added ones.
+            # commit. In this case, it is better to force analysis of the dependency file(s) and
+            # consider *all* dependencies in analysis results instead of just the newly added ones.
             if src_branch == git_default_branch_name(remote):
                 LOG.warning("Source branch is same as default branch. Proceeding with analysis of all dependencies ...")
                 self._force_analysis = True
@@ -188,8 +188,8 @@ class CIBitbucket(CIBase):
         return common_commit
 
     @property
-    def is_any_lockfile_changed(self) -> bool:
-        """Predicate for detecting if any lockfile has changed."""
+    def is_any_depfile_changed(self) -> bool:
+        """Predicate for detecting if any dependency file has changed."""
         diff_base_sha = self.common_ancestor_commit
         LOG.debug("The common ancestor commit: %s", diff_base_sha)
 
@@ -200,9 +200,9 @@ class CIBitbucket(CIBase):
         err_msg = """\
             Consider changing the `clone depth` variable in CI settings to clone/fetch more branch history.
             Reference: https://support.atlassian.com/bitbucket-cloud/docs/git-clone-behavior/"""
-        self.update_lockfiles_change_status(diff_base_sha, err_msg)
+        self.update_depfiles_change_status(diff_base_sha, err_msg)
 
-        return any(lockfile.is_lockfile_changed for lockfile in self.lockfiles)
+        return any(depfile.is_depfile_changed for depfile in self.depfiles)
 
     @property
     def phylum_comment_exists(self) -> bool:

--- a/src/phylum/ci/ci_github.py
+++ b/src/phylum/ci/ci_github.py
@@ -48,7 +48,7 @@ class CIGitHub(CIBase):
 
     def __init__(self, args: Namespace) -> None:  # noqa: D107 ; the base __init__ docstring is better here
         # This is the recommended workaround for container actions, to avoid the `unsafe repository` error.
-        # It is added before super().__init__(args) so that lockfile change detection will be set properly.
+        # It is added before super().__init__(args) so that dependency file change detection will be set properly.
         # See https://github.com/actions/checkout/issues/766 (git CVE-2022-24765) for more detail.
         github_workspace = os.getenv("GITHUB_WORKSPACE", "/github/workspace")
         cmd = ["git", "config", "--global", "--add", "safe.directory", github_workspace]
@@ -136,8 +136,8 @@ class CIGitHub(CIBase):
         return self.pr_event.get("pull_request", {}).get("base", {}).get("sha")
 
     @property
-    def is_any_lockfile_changed(self) -> bool:
-        """Predicate for detecting if any lockfile has changed."""
+    def is_any_depfile_changed(self) -> bool:
+        """Predicate for detecting if any dependency file has changed."""
         pr_src_branch = os.getenv("GITHUB_HEAD_REF")
         pr_tgt_branch = os.getenv("GITHUB_BASE_REF")
         pr_base_sha = self.common_ancestor_commit
@@ -152,9 +152,9 @@ class CIGitHub(CIBase):
         err_msg = """\
             Consider changing the `fetch-depth` input during checkout to fetch more branch history.
             Reference: https://github.com/actions/checkout"""
-        self.update_lockfiles_change_status(pr_base_sha, err_msg)
+        self.update_depfiles_change_status(pr_base_sha, err_msg)
 
-        return any(lockfile.is_lockfile_changed for lockfile in self.lockfiles)
+        return any(depfile.is_depfile_changed for depfile in self.depfiles)
 
     @property
     def phylum_comment_exists(self) -> bool:

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -35,8 +35,8 @@ def is_in_mr() -> bool:
       * For merge requests (e.g., merge request pipelines)
 
     Knowing when the context is within a merge request helps to ensure the logic used
-    to determine the lockfile changes is correct. It also helps to ensure output is not
-    attempted to be posted when NOT in the context of a review.
+    to determine the dependency file changes is correct. It also helps to ensure output
+    is not attempted to be posted when NOT in the context of a review.
     """
     # References:
     # https://github.com/watson/ci-info/blob/master/vendors.json
@@ -95,7 +95,7 @@ class CIGitLab(CIBase):
             label = f"{self.ci_platform_name}_MR#{mr_iid}_{mr_src_branch}"
         else:
             current_branch = os.getenv("CI_COMMIT_BRANCH", "unknown-branch")
-            label = f"{self.ci_platform_name}_{current_branch}_{self.lockfile_hash_object}"
+            label = f"{self.ci_platform_name}_{current_branch}_{self.depfile_hash_object}"
 
         label = re.sub(r"\s+", "-", label)
         return label
@@ -153,8 +153,8 @@ class CIGitLab(CIBase):
         return common_commit
 
     @property
-    def is_any_lockfile_changed(self) -> bool:
-        """Predicate for detecting if any lockfile has changed."""
+    def is_any_depfile_changed(self) -> bool:
+        """Predicate for detecting if any dependency file has changed."""
         diff_base_sha = self.common_ancestor_commit
         LOG.debug("The common ancestor commit: %s", diff_base_sha)
 
@@ -165,9 +165,9 @@ class CIGitLab(CIBase):
         err_msg = """\
             Consider changing the `GIT_DEPTH` variable in CI settings to clone/fetch more branch history.
             Reference: https://docs.gitlab.com/ee/ci/large_repositories/index.html#shallow-cloning"""
-        self.update_lockfiles_change_status(diff_base_sha, err_msg)
+        self.update_depfiles_change_status(diff_base_sha, err_msg)
 
-        return any(lockfile.is_lockfile_changed for lockfile in self.lockfiles)
+        return any(depfile.is_depfile_changed for depfile in self.depfiles)
 
     @property
     def phylum_comment_exists(self) -> bool:

--- a/src/phylum/ci/ci_none.py
+++ b/src/phylum/ci/ci_none.py
@@ -35,7 +35,7 @@ class CINone(CIBase):
     def phylum_label(self) -> str:
         """Get a custom label for use when submitting jobs for analysis."""
         current_branch = git_curent_branch_name()
-        label = f"{self.ci_platform_name}_{current_branch}_{self.lockfile_hash_object}"
+        label = f"{self.ci_platform_name}_{current_branch}_{self.depfile_hash_object}"
         label = re.sub(r"\s+", "-", label)
         return label
 
@@ -53,22 +53,23 @@ class CINone(CIBase):
         return common_commit
 
     @property
-    def is_any_lockfile_changed(self) -> bool:
-        """Predicate for detecting if any lockfile has changed.
+    def is_any_depfile_changed(self) -> bool:
+        """Predicate for detecting if any dependency file has changed.
 
         For the case of operating outside of a CI platform, some assumptions are made:
           * There is only one remote configured for the repository
           * The diff is comparing against the remote and not another ref
           * The diff is comparing by using the files at the current HEAD
 
-        The usefulness of this approach is limited in that lockfile changes must already be committed to be detected.
+        The usefulness of this approach is limited in that dependency file changes
+        must already be committed to be detected.
 
         References:
         https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-emgitdiffemltoptionsgtltcommitgtltcommitgt--ltpathgt82308203
         """
         remote = git_remote()
-        self.update_lockfiles_change_status(f"refs/remotes/{remote}/HEAD...")
-        return any(lockfile.is_lockfile_changed for lockfile in self.lockfiles)
+        self.update_depfiles_change_status(f"refs/remotes/{remote}/HEAD...")
+        return any(depfile.is_depfile_changed for depfile in self.depfiles)
 
     @property
     def phylum_comment_exists(self) -> bool:

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -198,10 +198,10 @@ def main(args: Optional[Sequence[str]] = None) -> int:
     ci_env = detect_ci_platform(parsed_args, remainder_args)
 
     # Bail early when possible
-    LOG.debug("Dependency files in use: %s", ci_env.lockfiles)
+    LOG.debug("Dependency files in use: %s", ci_env.depfiles)
     if ci_env.force_analysis:
         LOG.info("Forced analysis specified with flag or otherwise set. Proceeding with analysis ...")
-    elif ci_env.is_any_lockfile_changed:
+    elif ci_env.is_any_depfile_changed:
         LOG.info("A dependency file has changed. Proceeding with analysis ...")
     elif ci_env.phylum_comment_exists:
         LOG.info("Existing Phylum comment found. Proceeding with analysis ...")
@@ -218,7 +218,7 @@ def main(args: Optional[Sequence[str]] = None) -> int:
     # Generate a label to use for analysis and report it
     LOG.info("Label to use for analysis: %s", ci_env.phylum_label)
 
-    # Analyze current project lockfile(s) with Phylum CLI
+    # Analyze current project dependency file(s) with Phylum CLI
     ci_env.analyze()
 
     # Output the results of the analysis

--- a/src/phylum/ci/common.py
+++ b/src/phylum/ci/common.py
@@ -42,9 +42,9 @@ class LockfileEntry:
     def __post_init__(self, _path):
         """Ensure the `path` field is actually a `Path` object."""
         if isinstance(_path, str):
-            self.path = Path(_path)
+            self.path = Path(_path).resolve()
         elif isinstance(_path, Path):
-            self.path = _path
+            self.path = _path.resolve()
         else:
             msg = "Provided lockfile path is not PathLike"
             raise TypeError(msg)

--- a/src/phylum/ci/common.py
+++ b/src/phylum/ci/common.py
@@ -33,7 +33,7 @@ class JobPolicyEvalResult:
 
 @dataclasses.dataclass()
 class LockfileEntry:
-    """Class for keeping track of an individual lockfile entry returned by the `phylum status` command."""
+    """Class for keeping track of an individual "lockfile" entry returned by the `phylum status` command."""
 
     _path: dataclasses.InitVar[os.PathLike]
     type: str = "auto"  # noqa: A003 ; shadowing built-in `type` is okay since renaming here would be more confusing
@@ -46,7 +46,7 @@ class LockfileEntry:
         elif isinstance(_path, Path):
             self.path = _path.resolve()
         else:
-            msg = "Provided lockfile path is not PathLike"
+            msg = "Provided dependency file path is not PathLike"
             raise TypeError(msg)
 
     def __repr__(self) -> str:
@@ -66,7 +66,7 @@ class ReturnCode(IntEnum):
     FAILURE = 1
     INCOMPLETE = 5
     FAILURE_INCOMPLETE = 6
-    LOCKFILE_FILTER = 10
+    DEPFILE_FILTER = 10
 
 
 # Reference: https://stackoverflow.com/questions/51286748/make-the-python-json-encoder-support-pythons-new-dataclasses

--- a/src/phylum/ci/depfile.py
+++ b/src/phylum/ci/depfile.py
@@ -1,12 +1,8 @@
-"""Define a lockfile implementation.
+"""Define a dependency file implementation.
 
-A Phylum project can consist of multiple lockfiles.
-This module/class represents a single lockfile.
-
-For historical purposes, this module uses "lockfile" language instead of the
-more general "dependency file" term. Both lockfiles and manifests are supported
-and the language has been changed where it is externally visible (e.g., log and
-help output) but kept as "lockfile" internally (e.g., code/variable names).
+A Phylum project can consist of multiple dependency files.
+Dependency files can be either lockfiles or manifests.
+This module/class represents a single dependency file.
 """
 from functools import cache, cached_property, lru_cache
 import json
@@ -25,37 +21,37 @@ from phylum.logger import LOG
 
 # Starting with Python 3.11, the `typing.Self` type was introduced to do this same thing.
 # Reference: https://peps.python.org/pep-0673/
-Self = TypeVar("Self", bound="Lockfile")
+Self = TypeVar("Self", bound="Depfile")
 
 
-class Lockfile:
-    """Provide methods for an instance of a lockfile."""
+class Depfile:
+    """Provide methods for an instance of a dependency file."""
 
-    def __init__(self, provided_lockfile: LockfileEntry, cli_path: Path, common_ancestor_commit: Optional[str]) -> None:
-        """Initialize a lockfile object."""
-        self._path = provided_lockfile.path.resolve()
-        self._type = provided_lockfile.type
+    def __init__(self, provided_depfile: LockfileEntry, cli_path: Path, common_ancestor_commit: Optional[str]) -> None:
+        """Initialize a `Depfile` object."""
+        self._path = provided_depfile.path.resolve()
+        self._type = provided_depfile.type
         self.cli_path = cli_path
         self._common_ancestor_commit = common_ancestor_commit
-        self._is_lockfile_changed: Optional[bool] = None
+        self._is_depfile_changed: Optional[bool] = None
 
         if not shutil.which("git"):
             msg = "`git` is required to be installed and available on the PATH"
             raise SystemExit(msg)
 
     def __repr__(self) -> str:
-        """Return a debug printable string representation of the `Lockfile` object."""
+        """Return a debug printable string representation of the `Depfile` object."""
         # `PurePath.relative_to()` requires `self` to be the subpath of the argument, but `os.path.relpath()` does not.
         # NOTE: Any change from this format should be made carefully as caller's
-        #       may be relying on `repr(lockfile)` to provide the relative path.
-        #       Example: print(f"Relative path to lockfile: `{lockfile!r}`")    # noqa: ERA001 ; commented code intended
+        #       may be relying on `repr(depfile)` to provide the relative path.
+        # Example: print(f"Relative path to dependency file: `{depfile!r}`")    # noqa: ERA001 ; commented code intended
         return os.path.relpath(self.path)
 
     def __str__(self) -> str:
-        """Return the nicely printable string representation of the `Lockfile` object."""
+        """Return the nicely printable string representation of the `Depfile` object."""
         # NOTE: Any change from this format should be made carefully as caller's
-        #       may be relying on `str(lockfile)` to provide the path.
-        #       Example: print(f"Path to lockfile: `{lockfile}`")   # noqa: ERA001 ; commented code intended
+        #       may be relying on `str(depfile)` to provide the path.
+        # Example: print(f"Path to dependency file: `{depfile}`")   # noqa: ERA001 ; commented code intended
         return str(self.path)
 
     def __lt__(self: Self, other: Self) -> bool:
@@ -64,23 +60,23 @@ class Lockfile:
 
     @property
     def path(self) -> Path:
-        """Get the lockfile path."""
+        """Get the dependency file path."""
         return self._path
 
     @property
     def type(self) -> str:  # noqa: A003 ; shadowing built-in `type` is okay since renaming here would be more confusing
-        """Get the lockfile type."""
+        """Get the dependency file type."""
         return self._type
 
     @property
-    def is_lockfile_changed(self) -> Optional[bool]:
-        """Predicate for detecting if the lockfile has changed."""
-        return self._is_lockfile_changed
+    def is_depfile_changed(self) -> Optional[bool]:
+        """Predicate for detecting if the dependency file has changed."""
+        return self._is_depfile_changed
 
-    @is_lockfile_changed.setter
-    def is_lockfile_changed(self, value: bool) -> None:
-        """Set the value for whether the lockfile has changed."""
-        self._is_lockfile_changed = value
+    @is_depfile_changed.setter
+    def is_depfile_changed(self, value: bool) -> None:
+        """Set the value for whether the dependency file has changed."""
+        self._is_depfile_changed = value
 
     @property
     def common_ancestor_commit(self) -> Optional[str]:
@@ -93,39 +89,39 @@ class Lockfile:
 
     @cached_property
     def base_deps(self) -> Packages:
-        """Get the dependencies from the base iteration of the lockfile and return them in sorted order.
+        """Get the dependencies from the base iteration of the dependency file and return them in sorted order.
 
         The base iteration is determined by the common ancestor commit.
         """
-        prev_lockfile_object = self.previous_lockfile_object()
-        if not prev_lockfile_object:
+        prev_depfile_object = self.previous_depfile_object()
+        if not prev_depfile_object:
             LOG.info("No previous dependency file object found for `%r`. Assuming no base dependencies.", self)
             return []
-        prev_lockfile_packages = sorted(set(self.get_previous_lockfile_packages(prev_lockfile_object)))
-        return prev_lockfile_packages
+        prev_depfile_packages = sorted(set(self.get_previous_depfile_packages(prev_depfile_object)))
+        return prev_depfile_packages
 
     @cached_property
     def new_deps(self) -> Packages:
-        """Get the new dependencies added to the lockfile and return them in sorted order."""
+        """Get the new dependencies added to the dependency file and return them in sorted order."""
         # Only consider newly added dependencies
-        if self.is_lockfile_changed is None:
-            LOG.warning("The `is_lockfile_changed` property has not been set yet")
-        if not self.is_lockfile_changed:
+        if self.is_depfile_changed is None:
+            LOG.warning("The `is_depfile_changed` property has not been set yet")
+        if not self.is_depfile_changed:
             return []
 
-        curr_lockfile_packages = self.current_lockfile_packages()
+        curr_depfile_packages = self.current_depfile_packages()
 
-        prev_lockfile_object = self.previous_lockfile_object()
-        if not prev_lockfile_object:
+        prev_depfile_object = self.previous_depfile_object()
+        if not prev_depfile_object:
             LOG.debug("No previous dependency file object found for `%r`. Assuming all current packages are new.", self)
-            return curr_lockfile_packages
+            return curr_depfile_packages
 
-        prev_lockfile_packages = self.get_previous_lockfile_packages(prev_lockfile_object)
+        prev_depfile_packages = self.get_previous_depfile_packages(prev_depfile_object)
 
-        prev_pkg_set = set(prev_lockfile_packages)
-        curr_pkg_set = set(curr_lockfile_packages)
+        prev_pkg_set = set(prev_depfile_packages)
+        curr_pkg_set = set(curr_depfile_packages)
 
-        # TODO(maxrake): Consider using these new dependencies to track the output findings...as mapped to a lockfile.
+        # TODO(maxrake): Consider using these new dependencies to track the output findings...as mapped to a depfile.
         #                https://github.com/phylum-dev/roadmap/issues/263
         new_deps_set = curr_pkg_set.difference(prev_pkg_set)
         new_deps_list = sorted(new_deps_set)
@@ -133,10 +129,10 @@ class Lockfile:
         return new_deps_list
 
     @lru_cache(maxsize=1)
-    def current_lockfile_packages(self) -> Packages:
-        """Get the current lockfile packages."""
+    def current_depfile_packages(self) -> Packages:
+        """Get the current dependency file packages."""
         try:
-            curr_lockfile_packages = parse_current_depfile(self.cli_path, self.type, self.path)
+            curr_depfile_packages = parse_current_depfile(self.cli_path, self.type, self.path)
         except subprocess.CalledProcessError as err:
             msg = f"""\
                 If this is a manifest, consider supplying lockfile type explicitly in the `.phylum_project` file.
@@ -144,21 +140,21 @@ class Lockfile:
                 Please report this as a bug if you believe [code]{self!r}[/] is a
                 valid [code]{self.type}[/] dependency file."""
             raise PhylumCalledProcessError(err, textwrap.dedent(msg)) from err
-        return curr_lockfile_packages
+        return curr_depfile_packages
 
     @lru_cache(maxsize=1)
-    def previous_lockfile_object(self) -> Optional[str]:
-        """Get the previous git object for the lockfile.
+    def previous_depfile_object(self) -> Optional[str]:
+        """Get the previous git object for the dependency file.
 
-        Return None when no previous lockfile object can be found.
+        Return None when no previous dependency file object can be found.
         """
         if not self.common_ancestor_commit:
             return None
         try:
-            # Use the `repr` form to get the relative path to the lockfile
+            # Use the `repr` form to get the relative path to the dependency file
             cmd = ["git", "rev-parse", "--verify", f"{self.common_ancestor_commit}:{self!r}"]
-            prev_lockfile_object = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout  # noqa: S603
-            prev_lockfile_object = prev_lockfile_object.strip()
+            prev_depfile_object = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout  # noqa: S603
+            prev_depfile_object = prev_depfile_object.strip()
         except subprocess.CalledProcessError as err:
             # There could be a true error, but the working assumption when here is a previous version does not exist
             msg = """\
@@ -166,29 +162,34 @@ class Lockfile:
                 Continuing with the assumption a previous dependency file version does not exist ..."""
             pprint_subprocess_error(err)
             LOG.warning(textwrap.dedent(msg), extra={"markup": True})
-            prev_lockfile_object = None
-        return prev_lockfile_object
+            prev_depfile_object = None
+        return prev_depfile_object
 
     @lru_cache(maxsize=1)
-    def get_previous_lockfile_packages(self, prev_lockfile_object: str) -> Packages:
-        """Get the previous lockfile packages from the corresponding git object and return them."""
+    def get_previous_depfile_packages(self, prev_depfile_object: str) -> Packages:
+        """Get the previous dependency file packages from the corresponding git object and return them."""
         with tempfile.TemporaryDirectory(prefix="phylum_") as temp_dir:
-            prev_lockfile_path = Path(temp_dir) / self.path.name
-            cmd = ["git", "cat-file", "blob", prev_lockfile_object]
+            prev_depfile_path = Path(temp_dir) / self.path.name
+            cmd = ["git", "cat-file", "blob", prev_depfile_object]
             try:
-                prev_lockfile_contents = subprocess.run(
+                prev_depfile_contents = subprocess.run(
                     cmd,  # noqa: S603
                     check=True,
                     capture_output=True,
                     text=True,
                 ).stdout
-                prev_lockfile_path.write_text(prev_lockfile_contents, encoding="utf-8")
+                prev_depfile_path.write_text(prev_depfile_contents, encoding="utf-8")
             except subprocess.CalledProcessError as err:
                 pprint_subprocess_error(err)
                 LOG.error("Due to error, assuming no previous dependency file packages. Please report this as a bug.")
                 return []
-            cmd = [str(self.cli_path), "parse", "--lockfile-type", self.type, str(prev_lockfile_path)]
-            LOG.info("Attempting to parse %s as previous lockfile. Manifest files may take a while.", self.path)
+            cmd = [str(self.cli_path), "parse", "--lockfile-type", self.type, str(prev_depfile_path)]
+            LOG.info(
+                "Attempting to parse [code]%s[/] as previous [code]%s[/] dependency file. Manifests may take a while.",
+                self.path,
+                self.type,
+                extra={"markup": True},
+            )
             LOG.debug("Using parse command: %s", shlex.join(cmd))
             try:
                 parse_result = subprocess.run(
@@ -209,12 +210,12 @@ class Lockfile:
                 return []
 
         parsed_pkgs = json.loads(parse_result)
-        prev_lockfile_packages = [PackageDescriptor(**pkg) for pkg in parsed_pkgs]
-        return prev_lockfile_packages
+        prev_depfile_packages = [PackageDescriptor(**pkg) for pkg in parsed_pkgs]
+        return prev_depfile_packages
 
 
 # Type alias
-Lockfiles = list[Lockfile]
+Depfiles = list[Depfile]
 
 
 @cache
@@ -224,7 +225,7 @@ def parse_current_depfile(cli_path: Path, lockfile_type: str, depfile_path: Path
     Callers of this function must catch `subprocess.CalledProcessError` exceptions and handle them.
     """
     LOG.info(
-        "Attempting to parse [code]%s[/] as a [code]%s[/] dependency file. Manifest files may take a while.",
+        "Attempting to parse [code]%s[/] as a [code]%s[/] dependency file. Manifests may take a while.",
         os.path.relpath(depfile_path),
         lockfile_type,
         extra={"markup": True},

--- a/src/phylum/exts/ci/main.ts
+++ b/src/phylum/exts/ci/main.ts
@@ -4,7 +4,7 @@ import { Package, PhylumApi } from "phylum";
 const args = Deno.args.slice(0);
 if (args.length < 4) {
     console.error(
-        "Usage: phylum ci <PROJECT> <LABEL> [--group <GROUP>] <BASE> <LOCKFILE:TYPE...>",
+        "Usage: phylum ci <PROJECT> <LABEL> [--group <GROUP>] <BASE> <DEPFILE:TYPE...>",
     );
     Deno.exit(1);
 }
@@ -21,15 +21,15 @@ if (groupArgsIndex != -1) {
 const project = args[0];
 const label = args[1];
 const base = args[2];
-const lockfiles = args.splice(3);
+const depfiles = args.splice(3);
 
-// Parse new lockfiles.
+// Parse new dependency files.
 let packages: Package[] = [];
-for (const lockfile of lockfiles) {
-    const lockfile_path = lockfile.substring(0, lockfile.lastIndexOf(":"));
-    const lockfile_type = lockfile.substring(lockfile.lastIndexOf(":") + 1, lockfile.length);
-    const lockfileDeps = await PhylumApi.parseLockfile(lockfile_path, lockfile_type);
-    packages = packages.concat(lockfileDeps.packages);
+for (const depfile of depfiles) {
+    const depfile_path = depfile.substring(0, depfile.lastIndexOf(":"));
+    const depfile_type = depfile.substring(depfile.lastIndexOf(":") + 1, depfile.length);
+    const depfileDeps = await PhylumApi.parseLockfile(depfile_path, depfile_type);
+    packages = packages.concat(depfileDeps.packages);
 }
 
 // Deserialize base dependencies.

--- a/tests/unit/test_lockfile_parse.py
+++ b/tests/unit/test_lockfile_parse.py
@@ -1,17 +1,17 @@
-"""Test the lockfile current_lockfile_packages function."""
+"""Test the `current_depfile_packages` method from the `Depfile` class."""
 
 from pathlib import Path
 from unittest.mock import patch
 
 from phylum.ci.common import LockfileEntry, PackageDescriptor
-from phylum.ci.lockfile import Lockfile
+from phylum.ci.depfile import Depfile
 
 EXPECTED_NUM_PACKAGES = 2
 
 
 @patch("subprocess.run")
-def test_current_lockfile_packages(mock_run):
-    """Test the `current_lockfile_packages` function of the Lockfile class."""
+def test_current_depfile_packages(mock_run):
+    """Test the `current_depfile_packages` method of the `Depfile` class."""
     # Prepare the mock
     mock_run.return_value.stdout = """
     [
@@ -29,14 +29,14 @@ def test_current_lockfile_packages(mock_run):
     ]
     """
 
-    lockfile_path = Path("Cargo.lock")
+    depfile_path = Path("Cargo.lock")
     provided_lockfile_type = "cargo"
     cli_path = Path("dummy_cli_path")
-    lockfile_entry = LockfileEntry(lockfile_path, provided_lockfile_type)
-    lockfile = Lockfile(lockfile_entry, cli_path, None)
+    lockfile_entry = LockfileEntry(depfile_path, provided_lockfile_type)
+    depfile = Depfile(lockfile_entry, cli_path, None)
 
-    # Test the current_lockfile_packages method
-    packages = lockfile.current_lockfile_packages()
+    # Test the `current_depfile_packages` method
+    packages = depfile.current_depfile_packages()
     expected_cargo_package = PackageDescriptor("quote", "1.0.21", "cargo", "Cargo.lock")
     expected_npm_package = PackageDescriptor("example", "0.1.0", "npm")
 
@@ -46,7 +46,7 @@ def test_current_lockfile_packages(mock_run):
 
     # Ensure the mock was called correctly
     mock_run.assert_called_once_with(
-        [str(lockfile.cli_path), "parse", "--lockfile-type", provided_lockfile_type, str(lockfile.path)],
+        [str(depfile.cli_path), "parse", "--lockfile-type", provided_lockfile_type, str(depfile.path)],
         check=True,
         capture_output=True,
         text=True,


### PR DESCRIPTION
This change speeds up overall execution time, especially for manifests.
It does this by caching the results of parsing dependency files from the
current (HEAD) location under analysis. This reduces the instances of
parsing the same file from three to two. Previously, it would happen:

* When filtering files supplied as input
* When calculating the new dependencies
  * File has changed (or `--force-analysis` provided) and `--all-deps`
    not supplied
  * This one is eliminated via caching
* When submitting the files for Phylum analysis
  * During the `PhylumApi.parseLockfile` extension API call
  * This one remains since the extension API does not recognize the
    Python cache

There is also large change to rename internal uses of `lockfile` term.
This was done in a separate commit and includes the following basic
changes:

* Rename the `phylum.ci.lockfile` module to `phylum.ci.depfile`
* Rename the `Lockfile` class to `Depfile`
* Change internal naming uses of "lockfile" to "depfile"
* Change text/comment uses of "lockfile" to "dependency file"
* Keep the instances where Phylum CLI still uses "lockfile" naming
  * Related names are similarly unchanged, to stay consistent
  * These may be changed if/when the CLI changes to "depfile" language
* Keep the `--lockfile` argument for the `phylum-ci` command
  * Changing this would be a breaking change
  * It would need to happen in coordination with documentation updates
  * It may happen separately at a later time

## Testing

Changes from this PR have been built in Docker images and hosted [on Docker Hub for my account](https://hub.docker.com/r/maxrake/phylum-ci/tags), as the `cache_current_parsing` tag.

Testing was completed with the private `isildurs_bane` repo, where it saved ~40s (2m40s --> 2m).
It was also completed with the public deepcausality-rs/deep_causality repo, where it saved ~3s (23s --> 20s).