### PR TITLE
feat: ensure remote `HEAD` set for `CINone` implementation

### DIFF
--- a/src/phylum/ci/ci_none.py
+++ b/src/phylum/ci/ci_none.py
@@ -11,8 +11,8 @@ import subprocess
 from typing import Optional
 
 from phylum.ci.ci_base import CIBase
-from phylum.ci.git import git_curent_branch_name, git_remote
-from phylum.exceptions import pprint_subprocess_error
+from phylum.ci.git import git_curent_branch_name, git_remote, git_set_remote_head
+from phylum.exceptions import PhylumCalledProcessError, pprint_subprocess_error
 from phylum.logger import LOG
 
 
@@ -45,12 +45,20 @@ class CINone(CIBase):
         remote = git_remote()
         cmd = ["git", "merge-base", "HEAD", f"refs/remotes/{remote}/HEAD"]
         try:
-            common_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()  # noqa: S603
-        except subprocess.CalledProcessError as err:
-            pprint_subprocess_error(err)
-            LOG.warning("The common ancestor commit could not be found")
-            common_commit = None
-        return common_commit
+            commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()  # noqa: S603
+        except subprocess.CalledProcessError as outer_err:
+            # The most likely problem is that the remote HEAD ref is not set. The attempt to set it here, inside
+            # the except block, is due to wanting to minimize calling commands that require git credentials.
+            pprint_subprocess_error(outer_err)
+            LOG.warning("Failed to get commit. Remote HEAD ref likely not set. Attempting to set it and try again ...")
+            git_set_remote_head(remote)
+            try:
+                commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()  # noqa: S603
+            except subprocess.CalledProcessError as inner_err:
+                pprint_subprocess_error(inner_err)
+                LOG.warning("The common ancestor commit could not be found")
+                commit = None
+        return commit
 
     @property
     def is_any_depfile_changed(self) -> bool:
@@ -68,7 +76,20 @@ class CINone(CIBase):
         https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-emgitdiffemltoptionsgtltcommitgtltcommitgt--ltpathgt82308203
         """
         remote = git_remote()
-        self.update_depfiles_change_status(f"refs/remotes/{remote}/HEAD...")
+        try:
+            self.update_depfiles_change_status(f"refs/remotes/{remote}/HEAD...")
+        except subprocess.CalledProcessError as outer_err:
+            # The most likely problem is that the remote HEAD ref is not set. The attempt to set it here, inside
+            # the except block, is due to wanting to minimize calling commands that require git credentials.
+            pprint_subprocess_error(outer_err)
+            LOG.warning("Failed to get diff. Remote HEAD ref likely not set. Attempting to set it and try again ...")
+            git_set_remote_head(remote)
+            try:
+                self.update_depfiles_change_status(f"refs/remotes/{remote}/HEAD...")
+            except subprocess.CalledProcessError as inner_err:
+                msg = "Failed to get diff with remote HEAD ref even after setting it."
+                raise PhylumCalledProcessError(inner_err, msg) from outer_err
+
         return any(depfile.is_depfile_changed for depfile in self.depfiles)
 
     @property


### PR DESCRIPTION
This change uses the `git_set_remote_head` helper function in the `CINone` implementation to ensure the remote `HEAD` ref is set for the cases where it is used. This happens in the `common_ancestor_commit` and `is_any_depfile_changed` properties. In each case, the function is used as a fall back instead of pre-emptively to minimize calling commands that require git credentials.

This change initially came from a request from @louislang, who noticed a hard failure when running `phylum-ci` locally, for an integration that does not have it's own customized implementation. It also occurred for @cd-work, while using `phylum-ci` in a Circle CI orb.


## Screenshots / Testing

Here is what it looks like in action:

<details><summary>Details (click to expand)</summary>
<p>

```
../phylum-ci  10  17 on  more_head_checks [!] via 🐳 desktop-linux is 📦 v0.38.0 via 🐍 v3.12.0
❯ rm .git/refs/remotes/origin/HEAD

../phylum-ci  10  17 on  more_head_checks [!] via 🐳 desktop-linux is 📦 v0.38.0 via 🐍 v3.12.0
❯ poetry run phylum-ci -vv
DEBUG    Logging initialized to level 10 (DEBUG)
DEBUG    Phylum CLI version not specified
DEBUG    Found installed Phylum CLI version: v5.8.1
DEBUG    Minimum supported Phylum CLI version required for install: v5.8.0
DEBUG    Making request to GitHub API URL: https://api.github.com/repos/phylum-dev/cli/releases
DEBUG    59 GitHub API requests remaining until window resets at: Wed Nov 15 15:56:07 2023
INFO     Using Phylum CLI version: v5.8.1
DEBUG    No CI environment detected
INFO     Confirming pre-requisites ...
DEBUG    `git` binary found on the PATH
INFO     All pre-requisites met
DEBUG    Existing Phylum CLI instance found: v5.8.1 at /Users/maxrake/.local/bin/phylum
INFO     Using Phylum CLI instance: v5.8.1 at /Users/maxrake/.local/bin/phylum
INFO     Project name not provided as argument. Checking the `.phylum_project` file ...
DEBUG    Project name provided in `.phylum_project` file: phylum-ci
INFO     Attempting to create a Phylum project with the name: phylum-ci ...
DEBUG    Using Phylum group: phylum_bot
INFO     Project phylum-ci already exists. Continuing with it ...
INFO     No valid dependency files were provided as arguments. An attempt will be made to detect them.
DEBUG    Dependency files provided in `.phylum_project` file: [poetry.lock]
INFO     Parsing poetry.lock as poetry dependency file. Manifests take longer.
DEBUG    Using parse command: /Users/maxrake/.local/bin/phylum parse --lockfile-type poetry /Users/maxrake/dev/phylum/phylum-ci/poetry.lock
DEBUG    Running command from: /Users/maxrake/dev/phylum/phylum-ci
INFO     Provided dependency file poetry.lock is a lockfile
DEBUG    Valid detected dependency files: [poetry.lock]
DEBUG    Dependency files in use: [poetry.lock]
DEBUG    Checking poetry.lock for changes ...
fatal: bad revision 'refs/remotes/origin/HEAD...'

╭────────────────────────────────────────────────── Subprocess Error ──────────────────────────────────────────────────╮
│ COMMAND: git diff --exit-code --quiet refs/remotes/origin/HEAD... -- /Users/maxrake/dev/phylum/phylum-ci/poetry.lock │
│ RETURN CODE: 128                                                                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
WARNING  Failed to get diff. Remote HEAD ref likely not set. Attempting to set it and try again ...
INFO     Automatically setting the remote HEAD ref ...
DEBUG    Checking poetry.lock for changes ...
DEBUG    The dependency file poetry.lock has NOT changed
WARNING  No lockfile has changed. Nothing to do.

../phylum-ci  10  17 on  more_head_checks [!] via 🐳 desktop-linux is 📦 v0.38.0 via 🐍 v3.12.0 took 4s
❯ l .git/refs/remotes/origin
total 32
drwxr-xr-x  6 maxrake  staff   192B Nov 15 14:56 .
drwxr-xr-x  3 maxrake  staff    96B Mar 23  2022 ..
-rw-r--r--  1 maxrake  staff    30B Nov 15 14:56 HEAD
-rw-r--r--  1 maxrake  staff    41B Oct 27 16:33 gh_pr_target
-rw-r--r--  1 maxrake  staff    41B Nov 15 13:55 main
-rw-r--r--  1 maxrake  staff    41B Nov 15 13:56 more_head_checks
```

</p>
</details> 