### PR TITLE
fix: repository URL sometimes formatted with `False`

### DIFF
--- a/src/phylum/ci/ci_azure.py
+++ b/src/phylum/ci/ci_azure.py
@@ -276,9 +276,9 @@ class CIAzure(CIBase):
         if self.triggering_repo == "TfsGit":
             # SYSTEM_TEAMPROJECT provides the name that corresponds to SYSTEM_TEAMPROJECTID.
             # Even though the ID will never change while the name might, the name is used for better human consumption.
-            if team_project_id := os.getenv("SYSTEM_TEAMPROJECT") is None:
+            if (team_project_id := os.getenv("SYSTEM_TEAMPROJECT")) is None:
                 LOG.debug("`SYSTEM_TEAMPROJECT` missing. Can't get repository URL.")
-            if instance := os.getenv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI") is None:
+            if (instance := os.getenv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI")) is None:
                 LOG.debug("`SYSTEM_TEAMFOUNDATIONCOLLECTIONURI` missing. Can't get repository URL.")
             if team_project_id is None or instance is None:
                 return None

--- a/src/phylum/ci/ci_github.py
+++ b/src/phylum/ci/ci_github.py
@@ -175,9 +175,9 @@ class CIGitHub(CIBase):
     def repo_url(self) -> Optional[str]:
         """Get the repository URL for reference in Phylum project metadata."""
         # Ref: https://docs.github.com/actions/learn-github-actions/variables#default-environment-variables
-        if server_url := os.getenv("GITHUB_SERVER_URL") is None:
+        if (server_url := os.getenv("GITHUB_SERVER_URL")) is None:
             LOG.debug("`GITHUB_SERVER_URL` missing. Can't get repository URL.")
-        if repo := os.getenv("GITHUB_REPOSITORY") is None:
+        if (repo := os.getenv("GITHUB_REPOSITORY")) is None:
             LOG.debug("`GITHUB_REPOSITORY` missing. Can't get repository URL.")
         if server_url is None or repo is None:
             return None


### PR DESCRIPTION
The repository URL is sometimes incorrectly formatted with `False` values instead of the correct environment variable. This happens because the walrus operator assignment is not properly delimited. For instance, the GitHub CI environment would incorrectly report the repo URL:

```
WARNING  Repository URL differs from what would be set! Keeping existing value.
         Existing: https://github.com/maxrake/delme
         Proposed: False/False
         Use CLI to override: https://docs.phylum.io/docs/phylum_project_update
```

This change ensures the walrus operator assignment is parsed as intended.