### PR TITLE
refactor: trim log messages and remove walrus operators

### DIFF
--- a/src/phylum/ci/ci_azure.py
+++ b/src/phylum/ci/ci_azure.py
@@ -250,8 +250,9 @@ class CIAzure(CIBase):
             return False
 
         err_msg = """\
-            Consider changing the `fetchDepth` property in CI settings to clone/fetch more branch history.
-            Reference: https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/steps-checkout"""
+            Consider changing the `fetchDepth` property in CI settings to
+            clone/fetch more branch history. For more info, reference:
+            https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/steps-checkout"""
         self.update_depfiles_change_status(diff_base_sha, err_msg)
 
         return any(depfile.is_depfile_changed for depfile in self.depfiles)
@@ -276,9 +277,11 @@ class CIAzure(CIBase):
         if self.triggering_repo == "TfsGit":
             # SYSTEM_TEAMPROJECT provides the name that corresponds to SYSTEM_TEAMPROJECTID.
             # Even though the ID will never change while the name might, the name is used for better human consumption.
-            if (team_project_id := os.getenv("SYSTEM_TEAMPROJECT")) is None:
+            team_project_id = os.getenv("SYSTEM_TEAMPROJECT")
+            if team_project_id is None:
                 LOG.debug("`SYSTEM_TEAMPROJECT` missing. Can't get repository URL.")
-            if (instance := os.getenv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI")) is None:
+            instance = os.getenv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI")
+            if instance is None:
                 LOG.debug("`SYSTEM_TEAMFOUNDATIONCOLLECTIONURI` missing. Can't get repository URL.")
             if team_project_id is None or instance is None:
                 return None
@@ -286,7 +289,10 @@ class CIAzure(CIBase):
             return f"{instance}{team_project_id}"
         if self.triggering_repo == "GitHub":
             # BUILD_REPOSITORY_URI will have the correct format regardless of the pipeline context
-            return os.getenv("BUILD_REPOSITORY_URI")
+            build_repo_uri = os.getenv("BUILD_REPOSITORY_URI")
+            if build_repo_uri is None:
+                LOG.debug("`BUILD_REPOSITORY_URI` missing. Can't get repository URL.")
+            return build_repo_uri
         return None
 
     def post_output(self) -> None:

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -209,15 +209,15 @@ class CIBase(ABC):
                         generation to parse but it was disabled to prevent running arbitrary
                         code in untrusted contexts, like PRs from forks. The resolved
                         dependencies from the manifest have NOT been analyzed by Phylum. Care
-                        should be taken to inspect changes manually before allowing the manifest
-                        to be used in a trusted context. For automatic analysis, consider adding
+                        should be taken to inspect changes manually before allowing a manifest
+                        to be used in a trusted context. For Phylum analysis, consider adding
                         a lockfile instead of or along with the manifest, even for libraries."""
                     self.returncode = ReturnCode.MANIFEST_WITHOUT_GENERATION
                 else:
                     msg = f"""\
                         Provided dependency file [code]{provided_depfile!r}[/] failed to parse
                         as lockfile type [code]{provided_depfile.type}[/]. If this is a manifest,
-                        consider supplying lockfile type explicitly in a `.phylum_project` file.
+                        consider supplying lockfile type explicitly in `.phylum_project` file.
                         For more info, see: https://docs.phylum.io/docs/lockfile_generation
                         Please report this as a bug if you believe [code]{provided_depfile!r}[/]
                         is a valid [code]{provided_depfile.type}[/] dependency file."""

--- a/src/phylum/ci/ci_bitbucket.py
+++ b/src/phylum/ci/ci_bitbucket.py
@@ -181,7 +181,7 @@ class CIBitbucket(CIBase):
         except subprocess.CalledProcessError as err:
             msg = """\
                 The common ancestor commit could not be found.
-                Ensure the git strategy is set to `full clone depth` for repo checkouts:
+                Ensure git strategy is set to `full clone depth` for repo checkouts:
                 https://support.atlassian.com/bitbucket-cloud/docs/git-clone-behavior/"""
             pprint_subprocess_error(err)
             LOG.warning(textwrap.dedent(msg))
@@ -200,8 +200,9 @@ class CIBitbucket(CIBase):
             return False
 
         err_msg = """\
-            Consider changing the `clone depth` variable in CI settings to clone/fetch more branch history.
-            Reference: https://support.atlassian.com/bitbucket-cloud/docs/git-clone-behavior/"""
+            Consider changing the `clone depth` variable in CI settings to
+            clone/fetch more branch history. For more info, reference:
+            https://support.atlassian.com/bitbucket-cloud/docs/git-clone-behavior/"""
         self.update_depfiles_change_status(diff_base_sha, err_msg)
 
         return any(depfile.is_depfile_changed for depfile in self.depfiles)

--- a/src/phylum/ci/ci_github.py
+++ b/src/phylum/ci/ci_github.py
@@ -174,8 +174,8 @@ class CIGitHub(CIBase):
             return False
 
         err_msg = """\
-            Consider changing the `fetch-depth` input during checkout to fetch more branch history.
-            Reference: https://github.com/actions/checkout"""
+            Consider changing the `fetch-depth` input during checkout to fetch more
+            branch history. For more info: https://github.com/actions/checkout"""
         self.update_depfiles_change_status(pr_base_sha, err_msg)
 
         return any(depfile.is_depfile_changed for depfile in self.depfiles)
@@ -189,9 +189,11 @@ class CIGitHub(CIBase):
     def repo_url(self) -> Optional[str]:
         """Get the repository URL for reference in Phylum project metadata."""
         # Ref: https://docs.github.com/actions/learn-github-actions/variables#default-environment-variables
-        if (server_url := os.getenv("GITHUB_SERVER_URL")) is None:
+        server_url = os.getenv("GITHUB_SERVER_URL")
+        if server_url is None:
             LOG.debug("`GITHUB_SERVER_URL` missing. Can't get repository URL.")
-        if (repo := os.getenv("GITHUB_REPOSITORY")) is None:
+        repo = os.getenv("GITHUB_REPOSITORY")
+        if repo is None:
             LOG.debug("`GITHUB_REPOSITORY` missing. Can't get repository URL.")
         if server_url is None or repo is None:
             return None

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -163,8 +163,9 @@ class CIGitLab(CIBase):
             return False
 
         err_msg = """\
-            Consider changing the `GIT_DEPTH` variable in CI settings to clone/fetch more branch history.
-            Reference: https://docs.gitlab.com/ee/ci/large_repositories/index.html#shallow-cloning"""
+            Consider changing the `GIT_DEPTH` variable in CI settings to
+            clone/fetch more branch history. For more info, reference:
+            https://docs.gitlab.com/ee/ci/large_repositories/index.html#shallow-cloning"""
         self.update_depfiles_change_status(diff_base_sha, err_msg)
 
         return any(depfile.is_depfile_changed for depfile in self.depfiles)

--- a/src/phylum/ci/depfile.py
+++ b/src/phylum/ci/depfile.py
@@ -144,7 +144,7 @@ class Depfile:
                     is a valid [code]{self.type}[/] lockfile."""
             else:
                 msg = f"""\
-                    Consider supplying lockfile type explicitly in the `.phylum_project` file.
+                    Consider supplying lockfile type explicitly in `.phylum_project` file.
                     For more info, see: https://docs.phylum.io/docs/lockfile_generation
                     Please report this as a bug if you believe [code]{self!r}[/]
                     is a valid [code]{self.type}[/] manifest file."""

--- a/src/phylum/ci/git.py
+++ b/src/phylum/ci/git.py
@@ -208,7 +208,8 @@ def git_repo_name(git_c_path: Optional[Path] = None) -> str:
             Getting the git repository name failed. Are all assumptions met:
               * Only a single remote is in use if remotes are used
               * When a remote exists, it points to a URL and not another local repo
-              * Cloned local repos without a remote defined have a name that does not end in `.git`"""
+              * Cloned local repos without a remote defined have a name that does
+                not end in `.git`"""
         raise PhylumCalledProcessError(err, textwrap.dedent(msg)) from err
 
     full_repo_path = Path(full_repo_name)


### PR DESCRIPTION
This change seeks to clean up a few things that were discovered during recent testing, and to do so before the next release. The use of walrus operators (i.e., `:=`) has been removed in favor of more, but simpler, code. Multiline log messages have been trimmed a bit after it was discovered that lines with >71 characters wrap in constrained environments where the WIDTH is fixed at 80 characters (e.g., GitHub Actions). This is due to the space between the log level (e.g., `WARNING`) and the message being two characters instead of the assumed one, allowing a max of 71 characters for each line of the message instead of 72 as previously assumed. There is likely a better way to programmatically account for this with something in the `textwrap` module, but these small changes will do for now.
