### PR TITLE
docs: update documentation links

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
         args: [--no-update, --no-cache]
 
   # NOTE: Don't use this config for your own repositories. Instead, see
-  #       "Git pre-commit Integration" at https://docs.phylum.io/docs/git_precommit
+  #       "Git pre-commit Integration" at https://docs.phylum.io/integrations/git_precommit
   - repo: local
     hooks:
       - id: phylum-ci

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -4,7 +4,7 @@
 # NOTE:
 # This Dockerfile is used to build the `slim` tags for the `phylum-ci` images. It differs
 # from the primary Dockerfile in that it does not install the required tools needed for
-# lockfile generation: https://docs.phylum.io/docs/lockfile_generation (with the exception
+# lockfile generation: https://docs.phylum.io/cli/lockfile_generation (with the exception
 # of the `pip` tool). The image created from this Dockerfile is significantly smaller and
 # will allow the integrations relying on it to complete faster. It is useful for those
 # instances where *no* manifest files are present and/or *only* lockfiles are used.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ docker pull phylumio/phylum-ci:0.35.2-CLIv5.7.1
 docker pull phylumio/phylum-ci:0.36.0-CLIv5.7.1-slim
 ```
 
-[lockfile generation]: https://docs.phylum.io/docs/lockfile_generation
+[lockfile generation]: https://docs.phylum.io/cli/lockfile_generation
 
 #### `phylum-init` Script Entry Point
 
@@ -160,11 +160,11 @@ The options for `phylum-ci`, automatically updated to be current for the latest 
 
 ![phylum-ci options](https://raw.githubusercontent.com/phylum-dev/phylum-ci/main/docs/img/phylum-ci_options.svg)
 
-[github_docs]: https://docs.phylum.io/docs/github_actions
-[gitlab_docs]: https://docs.phylum.io/docs/gitlab_ci
-[azure_docs]: https://docs.phylum.io/docs/azure_pipelines
-[bb_pipelines_docs]: https://docs.phylum.io/docs/bitbucket_pipelines
-[precommit_docs]: https://docs.phylum.io/docs/git_precommit
+[github_docs]: https://docs.phylum.io/integrations/github_actions
+[gitlab_docs]: https://docs.phylum.io/integrations/gitlab_ci
+[azure_docs]: https://docs.phylum.io/integrations/azure_pipelines
+[bb_pipelines_docs]: https://docs.phylum.io/integrations/bitbucket_pipelines
+[precommit_docs]: https://docs.phylum.io/integrations/git_precommit
 
 ## License
 

--- a/scripts/docker_tests.sh
+++ b/scripts/docker_tests.sh
@@ -77,7 +77,7 @@ EOF
 )
 
 # These are the commands to ensure lockfile generation is available by checking
-# for each required tool: https://docs.phylum.io/docs/lockfile_generation
+# for each required tool: https://docs.phylum.io/cli/lockfile_generation
 MANIFEST_COMMANDS=$(cat <<EOF
 set -eux
 type npm && npm --version || false

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -219,7 +219,7 @@ class CIBase(ABC):
                         Provided dependency file [code]{provided_depfile!r}[/] failed to parse
                         as type [code]{provided_depfile.type}[/]. If this is a manifest, consider
                         supplying dependency file type explicitly in `.phylum_project` file.
-                        For more info, see: https://docs.phylum.io/docs/lockfile_generation
+                        For more info, see: https://docs.phylum.io/cli/lockfile_generation
                         Please report this as a bug if you believe [code]{provided_depfile!r}[/]
                         is a valid [code]{provided_depfile.type}[/] dependency file."""
                     self.returncode = ReturnCode.DEPFILE_FILTER
@@ -231,7 +231,7 @@ class CIBase(ABC):
                 msg = f"""\
                     Provided dependency file [code]{provided_depfile!r}[/] is a [b]lockifest[/].
                     It will be treated as a [b]manifest[/].
-                    For more info, see: https://docs.phylum.io/docs/lockfile_generation"""
+                    For more info, see: https://docs.phylum.io/cli/lockfile_generation"""
                 LOG.warning(textwrap.dedent(msg), extra=MARKUP)
                 depfile = Depfile(
                     provided_depfile,
@@ -564,8 +564,9 @@ class CIBase(ABC):
         except subprocess.CalledProcessError as err:
             pprint_subprocess_error(err)
             msg = """\
-                Phylum project status failed. Skipping repository URL check. Use CLI
-                to manually set it: https://docs.phylum.io/docs/phylum_project_update"""
+                Phylum project status failed. Skipping repository URL check.
+                Use CLI to manually set it:
+                https://docs.phylum.io/cli/commands/phylum_project_update"""
             LOG.warning(textwrap.dedent(msg))
             return
         project_status: dict = json.loads(cmd_output)
@@ -573,8 +574,9 @@ class CIBase(ABC):
         repo_url = project_status.get("repository_url")
         if not project_id:
             msg = """\
-                Could not find the project ID. Skipping repository URL check. Use CLI
-                to manually set it: https://docs.phylum.io/docs/phylum_project_update"""
+                Could not find the project ID. Skipping repository URL check.
+                Use CLI to manually set it:
+                https://docs.phylum.io/cli/commands/phylum_project_update"""
             LOG.warning(textwrap.dedent(msg))
             return
         LOG.debug("Found project ID: %s", project_id)
@@ -586,7 +588,7 @@ class CIBase(ABC):
                     Repository URL differs from what would be set! Keeping existing value.
                     Existing: {repo_url}
                     Proposed: {self.repo_url}
-                    Use CLI to override: https://docs.phylum.io/docs/phylum_project_update"""
+                    To override: https://docs.phylum.io/cli/commands/phylum_project_update"""
                 LOG.warning(textwrap.dedent(msg))
                 return
             LOG.info("Repository URL matches what would be set. Nothing to do.")
@@ -602,8 +604,9 @@ class CIBase(ABC):
         except subprocess.CalledProcessError as err:
             pprint_subprocess_error(err)
             msg = """\
-                Phylum project update failed. Skipping repository URL check. Use CLI
-                to manually set it: https://docs.phylum.io/docs/phylum_project_update"""
+                Phylum project update failed. Skipping repository URL check.
+                Use CLI to manually set it:
+                https://docs.phylum.io/cli/commands/phylum_project_update"""
             LOG.warning(textwrap.dedent(msg))
             return
         LOG.info("Repository URL successfully set")
@@ -721,7 +724,7 @@ class CIBase(ABC):
                         msg = f"""\
                             Due to error, assuming no previous packages in [code]{depfile!r}[/].
                             Consider supplying dependency file type explicitly in `.phylum_project`
-                            file. For more info: https://docs.phylum.io/docs/lockfile_generation
+                            file. For more info: https://docs.phylum.io/cli/lockfile_generation
                             Please report this as a bug if you believe [code]{depfile!r}[/]
                             is a valid [code]{depfile.type}[/] [b]{depfile.depfile_type.value}[/] at revision
                             [code]{self.common_ancestor_commit}[/]."""

--- a/src/phylum/ci/ci_github.py
+++ b/src/phylum/ci/ci_github.py
@@ -79,7 +79,7 @@ class CIGitHub(CIBase):
                 Using `pull_request_target` events for forked repositories has security
                 implications if done improperly. Lockfile generation has been disabled
                 to prevent arbitrary code execution in an untrusted context.
-                See https://docs.phylum.io/docs/github_actions for more detail."""
+                See https://docs.phylum.io/integrations/github_actions for more detail."""
             LOG.warning(textwrap.dedent(msg))
             self.disable_lockfile_generation = True
 

--- a/src/phylum/ci/depfile.py
+++ b/src/phylum/ci/depfile.py
@@ -145,7 +145,7 @@ class Depfile:
             else:
                 msg = f"""\
                     Consider supplying dependency file type explicitly in `.phylum_project`
-                    file. For more info: https://docs.phylum.io/docs/lockfile_generation
+                    file. For more info: https://docs.phylum.io/cli/lockfile_generation
                     Please report this as a bug if you believe [code]{self!r}[/]
                     is a valid [code]{self.type}[/] manifest file."""
             raise PhylumCalledProcessError(err, textwrap.dedent(msg)) from err


### PR DESCRIPTION
NOTE: This PR is not meant to be merged until after the docs.phylum.io page is cutover from being hosted on README.com to GitHub Pages.
