### PR TITLE
perf: reduce `phylum` binary size for slim images

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -180,11 +180,12 @@ RUN set -eux; \
     # Install pre-requisites
     apt-get update; \
     apt-get upgrade --yes; \
-    apt-get install --yes --no-install-recommends git; \
+    apt-get install --yes --no-install-recommends git binutils; \
     # Make ENTRYPOINT alternative script available
     chmod +x "${PHYLUM_VENV}/bin/entrypoint.sh"; \
     # Install Phylum CLI
     phylum-init -vvv --phylum-release "${CLI_VER:-latest}" --global-install; \
+    strip "$(which phylum)"; \
     # Create a git config file in a location accessible for $HOME-less users
     # Ref: https://git-scm.com/docs/git-config#FILES
     mkdir -vp "${XDG_CONFIG_HOME}/git" && touch "${XDG_CONFIG_HOME}/git/config"; \
@@ -192,6 +193,7 @@ RUN set -eux; \
     mkdir -vp "${XDG_DATA_HOME}" "${XDG_CONFIG_HOME}" "${XDG_STATE_HOME}" "${XDG_CACHE_HOME}"; \
     chmod -vR 777 "${XDG_DATA_HOME}" "${XDG_CONFIG_HOME}" "${XDG_STATE_HOME}" "${XDG_CACHE_HOME}"; \
     # Cleanup
+    apt-get remove --yes --auto-remove binutils; \
     apt-get purge --yes --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*; \
     rm -rf /tmp/*; \


### PR DESCRIPTION
This change uses `strip` to reduce the `phylum` binary size. This idea comes from a blog post about making Rust release binaries smaller:

https://kobzol.github.io/rust/cargo/2024/01/23/making-rust-binaries-smaller-by-default.html

Instead of making the change in the release workflow of the Phylum CLI, the binary stripping is limited to the `slim` Docker images here in an effort to reduce the size for performance-oriented applications. The benefit is a smaller image and therefore faster download times.

Benchmarks from this change on my local system:

* Image generation duration increased by a few seconds
  * This is due to installing and then removing the `binutils` package
* The `phylum` binary size went from 124MB --> 90MB
* Uncompressed image size went from 380MB --> 344MB
* Compressed image size went from 126.66MB --> 116.96MB

## Testing

Local testing with the `scripts/docker_tests.sh -i maxrake/phylum-ci:new_slim --slim` command resulted in a success.

Generating lockfiles still works (`--skip-sandbox` is used due to Docker not playing well with the sandbox):

```
❯ docker run -it --rm -e PHYLUM_API_KEY=$(phylum auth token) --mount type=bind,src=$(pwd),dst=/phylum -w /phylum maxrake/phylum-ci:orig_slim phylum parse -t pip --skip-sandbox dev-requirements.txt
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
Generating lockfile for manifest "dev-requirements.txt" using Pip…
[
  {
    "name": "PyYAML",
    "version": "6.0.1",
    "type": "pypi",
    "lockfile": "dev-requirements.txt"
  }
]

❯ docker run -it --rm -e PHYLUM_API_KEY=$(phylum auth token) --mount type=bind,src=$(pwd),dst=/phylum -w /phylum maxrake/phylum-ci:new_slim phylum parse -t pip --skip-sandbox dev-requirements.txt
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
Generating lockfile for manifest "dev-requirements.txt" using Pip…
[
  {
    "name": "PyYAML",
    "version": "6.0.1",
    "type": "pypi",
    "lockfile": "dev-requirements.txt"
  }
]
```
