### PR TITLE
fix: image failures for non-root uses of `yarn` and `pnpm`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -280,9 +280,10 @@ RUN \
     # Create a git config file in a location accessible for $HOME-less users
     # Ref: https://git-scm.com/docs/git-config#FILES
     mkdir -vp "${XDG_CONFIG_HOME}/git" && touch "${XDG_CONFIG_HOME}/git/config"; \
-    # Ensure the XDG directories have permissions for non-root users
+    # Ensure the XDG and Corepack directories have permissions for non-root users
     mkdir -vp "${XDG_DATA_HOME}" "${XDG_CONFIG_HOME}" "${XDG_STATE_HOME}" "${XDG_CACHE_HOME}"; \
     chmod -vR 777 "${XDG_DATA_HOME}" "${XDG_CONFIG_HOME}" "${XDG_STATE_HOME}" "${XDG_CACHE_HOME}"; \
+    chmod -v 666 "${COREPACK_HOME}/lastKnownGood.json"; \
     #
     # Final cleanup
     apt-get remove --yes --auto-remove \

--- a/Dockerfile
+++ b/Dockerfile
@@ -280,7 +280,7 @@ RUN \
     # Create a git config file in a location accessible for $HOME-less users
     # Ref: https://git-scm.com/docs/git-config#FILES
     mkdir -vp "${XDG_CONFIG_HOME}/git" && touch "${XDG_CONFIG_HOME}/git/config"; \
-    # Ensure the XDG and Corepack directories have permissions for non-root users
+    # Ensure non-root users have necessary permissions
     mkdir -vp "${XDG_DATA_HOME}" "${XDG_CONFIG_HOME}" "${XDG_STATE_HOME}" "${XDG_CACHE_HOME}"; \
     chmod -vR 777 "${XDG_DATA_HOME}" "${XDG_CONFIG_HOME}" "${XDG_STATE_HOME}" "${XDG_CACHE_HOME}"; \
     chmod -v 666 "${COREPACK_HOME}/lastKnownGood.json"; \


### PR DESCRIPTION
The lockfile generation tool `yarn` fails when used in the `phylum-ci` Docker image as a non-root user. An example of the failure can be seen from the output of the "smoke test," which is using `scripts/docker_tests.sh` to ensure basic functionality:

```
yarn --version
Internal Error: EACCES: permission denied, open '/usr/local/corepack/lastKnownGood.json'
Error: EACCES: permission denied, open '/usr/local/corepack/lastKnownGood.json'
```

The same behavior happens for `pnpm`. These are the tools installed by `corepack`, which changed recently to "Bump Known Good Release when downloading new version" (https://github.com/nodejs/corepack/pull/364). Part of that change was to make use of the `COREPACK_DEFAULT_TO_LATEST` environment variable to *not* update the last known good version, but setting that to `0` does not appear to prevent *all* writes (or creating a file handle with write permission) to the `lastKnownGood.json` file.

This fix simply modifies the file permissions for `lastKnownGood.json` so that non-root users can read and write to it. This approach may seem specific to a file that may change name or location in the future, but the alternative method of adding `${COREPACK_HOME}` to the list of directories that get updated with a `chmod -vR 777` was deemed to be too blunt and therefore less desirable.
