### PR TITLE
docs: restore integration documentation

### DIFF
--- a/docs/integrations/azure_pipelines.md
+++ b/docs/integrations/azure_pipelines.md
@@ -1,0 +1,430 @@
+# Azure Pipelines Integration
+
+## Overview
+
+Azure Pipelines [supports several different source repositories][supported_repos]. This integration works with repos
+hosted on [Azure Repos Git][azure_repos_git] and [GitHub][github_repos].
+
+Once configured for a repository, the Azure Pipelines integration will provide analysis of project dependencies from
+manifests and lockfiles. This can happen in a branch pipeline run from a CI trigger or in a Pull Request (PR)
+pipeline run from a PR trigger.
+
+For PR triggered pipelines, analyzed dependencies will include any that are added/modified in the PR.
+
+For CI triggered pipelines, the analyzed dependencies will be determined by comparing dependency files in the branch
+to the default branch. **All** dependencies will be analyzed when the CI triggered pipeline is run on the default
+branch.
+
+The results will be provided in the pipeline logs and provided as a comment in a thread on the PR. The CI job will
+return an error (i.e., fail the build) if any of the analyzed dependencies fail to meet the established policy.
+
+There will be no comment if no dependencies were added or modified for a given PR.
+If one or more dependencies are still processing (no results available), then the comment will make that clear and
+the CI pipeline job will only fail if dependencies that have _completed analysis results_ do not meet the active policy.
+
+[supported_repos]: https://learn.microsoft.com/azure/devops/pipelines/repos
+[azure_repos_git]: https://learn.microsoft.com/azure/devops/pipelines/repos/azure-repos-git
+[github_repos]: https://learn.microsoft.com/azure/devops/pipelines/repos/github
+
+## Prerequisites
+
+The Azure Pipelines environment is primarily supported through the use of a Docker image.
+The pre-requisites for using this image are:
+
+* Access to the [phylumio/phylum-ci Docker image][docker_image]
+* Azure DevOps Services is used with an [Azure Repos Git][azure_repos_git] or [GitHub][github_repos] repository type
+  * Azure DevOps Server versions are not guaranteed to work at this time
+  * Bitbucket Cloud hosted repositories are not supported at this time
+* An [Azure token][azure_auth] with API access
+  * This is only required when the build repository is [Azure Repos Git][azure_repos_git] and PR triggers are enabled
+  * Can be the default `System.AccessToken` provided automatically at the start of each pipeline build
+    * The [scoped build identity][build_scope] using this token needs the `Contribute to pull requests` permission
+    * See documentation for using the [token][access_token] and setting it's [job authorization scope][auth_scope]
+  * Can be a personal access token (PAT) - see [documentation][AZP_PAT]
+    * Needs at least the `Pull Request Threads` scope (read & write)
+    * Consider using a service account for this token
+* A [GitHub PAT][GH_PAT] with API access
+  * This is only required when the build repository is [GitHub][github_repos] and PR triggers are enabled
+  * Can be a fine-grained PAT
+    * Needs repository access and permissions: read access to `metadata` and read/write access to `pull requests`
+    * See [permissions required for fine-grained PATs][fine_pats]
+  * Can be a classic PAT
+    * Needs the `repo` scope or minimally the `public_repo` scope if private repositories are not used
+    * See [documentation][scopes]
+* A [Phylum token][phylum_tokens] with API access
+  * [Contact Phylum][phylum_contact] or [register][app_register] to gain access
+    * See also [`phylum auth register`][phylum_register] command documentation
+  * Consider using a bot or group account for this token
+* Access to the Phylum API endpoints
+  * That usually means a connection to the internet, optionally via a proxy
+  * Support for on-premises installs are not available at this time
+
+[docker_image]: https://hub.docker.com/r/phylumio/phylum-ci/tags
+[azure_auth]: https://learn.microsoft.com/azure/devops/integrate/get-started/authentication/authentication-guidance
+[build_scope]: https://learn.microsoft.com/azure/devops/pipelines/process/access-tokens#scoped-build-identities
+[access_token]: https://learn.microsoft.com/azure/devops/pipelines/build/variables#systemaccesstoken
+[auth_scope]: https://learn.microsoft.com/azure/devops/pipelines/process/access-tokens#job-authorization-scope
+[AZP_PAT]: https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate
+[GH_PAT]: https://docs.github.com/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+[fine_pats]: https://docs.github.com/rest/overview/permissions-required-for-fine-grained-personal-access-tokens
+[scopes]: https://docs.github.com/developers/apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes
+[phylum_tokens]: ../knowledge_base/api-keys.md
+[phylum_contact]: https://phylum.io/contact-us/
+[app_register]: https://app.phylum.io/register
+[phylum_register]: ../cli/commands/phylum_auth_register.md
+
+## Configure `azure-pipelines.yml`
+
+Phylum analysis of dependencies can be added to existing pipelines or on it's own with this minimal configuration:
+
+```yaml
+trigger:
+  - main
+pr:
+  - main
+
+jobs:
+  - job: Phylum
+    pool:
+      vmImage: ubuntu-latest
+    container: phylumio/phylum-ci:latest
+    steps:
+      - checkout: self
+        fetchDepth: 0
+        persistCredentials: true
+      - script: phylum-ci
+        displayName: Analyze dependencies with Phylum
+        env:
+          PHYLUM_API_KEY: $(PHYLUM_TOKEN)
+          AZURE_TOKEN: $(AZURE_PAT)     # For Azure repos only
+          GITHUB_TOKEN: $(GITHUB_PAT)   # For GitHub repos only
+```
+
+This single stage pipeline configuration contains a single container job named `Phylum`, triggered to run on pushes
+or PRs targeting the `main` branch. It does not override any of the `phylum-ci` arguments, which are all either
+optional or default to secure values.
+
+Let's take a deeper dive into each part of the configuration:
+
+### Pipeline control
+
+Choose when to run the pipeline. See the YAML schema [trigger definition][yaml_trigger] and [pr definition][yaml_pr]
+documentation for more detail.
+
+```yaml
+# This is a CI trigger that will cause the
+# pipeline to run on pushes to the `main` branch
+trigger:
+  - main
+```
+
+It is recommended to also enable PR validation for the target trigger branch(es). To do so for GitHub repos, use
+the `pr` keyword. See the YAML schema [pr definition][yaml_pr] documentation for more detail.
+
+```yaml
+# This is a PR trigger that will cause the pipeline to run when
+# a pull request is opened with `main` as the target branch.
+# NOTE: This has no affect for Azure Repos Git based repositories
+pr:
+  - main
+```
+
+To enable PR validation for Azure Repos Git, navigate to the branch policies for the desired branch
+(`main` in this example), and configure the [Build validation policy][build_validation] for that branch.
+For more information, see the documentation on [PR triggers for Azure Repos Git][az_pr_triggers] hosted repositories,
+[PR triggers for GitHub][gh_pr_triggers], or more broadly [events that trigger pipelines][triggers].
+
+[yaml_trigger]: https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/trigger
+[yaml_pr]: https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/pr
+[build_validation]: https://learn.microsoft.com/azure/devops/repos/git/branch-policies#build-validation
+[az_pr_triggers]: https://learn.microsoft.com/azure/devops/pipelines/repos/azure-repos-git#pr-triggers
+[gh_pr_triggers]: https://learn.microsoft.com/azure/devops/pipelines/repos/github#pr-triggers
+[triggers]: https://learn.microsoft.com/azure/devops/pipelines/build/triggers
+
+### Job names
+
+The job name can be named differently or included in an existing stage/job.
+
+```yaml
+jobs:
+  - job: Phylum  # Name this what you like
+```
+
+### Pool selection
+
+The pool is specified at the job level here because this is a [container job][container_job]. While Azure Pipelines
+allows container jobs for `windows-2019` and `ubuntu-*` base `vmImage` images, only `ubuntu-*` is supported by
+Phylum at this time. Keeping that restriction in mind, the pool can be specified at the pipeline or stage level
+instead. See the [YAML schema pool definition][yaml_pool] documentation for more detail.
+
+[container_job]: https://learn.microsoft.com/azure/devops/pipelines/process/container-phases
+[yaml_pool]: https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/pool
+
+```yaml
+    pool:
+      vmImage: ubuntu-latest
+```
+
+### Docker image selection
+
+The container is specified at the job level here because this is a [container job][container_job] where all steps
+in the job are meant to run with the same image. The container can also be specified as a
+[resource at the pipeline level][resource_container] and then
+[referenced by name in individual steps of a job][step_target] instead.
+See the YAML schema [jobs.job.container definition][yaml_job_container] and [resource definition][yaml_resources]
+documentation for more detail.
+
+Choose the Docker image tag to match your comfort level with image dependencies. `latest` is a "rolling" tag that
+will point to the image created for the latest released `phylum-ci` Python package. A particular version tag
+(e.g., `0.21.0-CLIv4.0.1`) is created for each release of the `phylum-ci` Python package and _should_ not change
+once published.
+
+However, to be certain that the image does not change...or be warned when it does because it won't be available
+anymore...use the SHA256 digest of the tag. The digest can be found by looking at the `phylumio/phylum-ci`
+[tags on Docker Hub][docker_image] or with the command:
+
+```sh
+# The command-line JSON processor `jq` is used here for the sake of a one line example. It is not required.
+❯ docker manifest inspect --verbose phylumio/phylum-ci:0.21.0-CLIv4.0.1 | jq .Descriptor.digest
+"sha256:7ddeb98897cd7af9dacae2e1474e8574dcf74b2e2e41e47327519d12242601cc"
+```
+
+For instance, at the time of this writing, all of these tag references pointed to the same image:
+
+```yaml
+    # NOTE: These are examples. Only one container line for `phylum-ci` is expected.
+
+    # Be explicit about wanting the `latest` tag
+    container: phylumio/phylum-ci:latest
+
+    # Use a specific release version of the `phylum-ci` package
+    container: phylumio/phylum-ci:0.21.0-CLIv4.0.1
+
+    # Use a specific image with it's SHA256 digest
+    container: phylumio/phylum-ci@sha256:7ddeb98897cd7af9dacae2e1474e8574dcf74b2e2e41e47327519d12242601cc
+```
+
+Only the last tag reference, by SHA256 digest, is guaranteed to not have the underlying image it points to change.
+
+The default `phylum-ci` Docker image contains `git` and the installed `phylum` Python package. It also contains an
+installed version of the Phylum CLI and all required tools needed for [lockfile generation][lockfile_generation].
+An advantage of using the default Docker image is that the complete environment is packaged and made available
+with components that are known to work together.
+
+One disadvantage to the default image is it's size. It can take a while to download and may provide more
+tools than required for your specific use case. Special `slim` tags of the `phylum-ci` image are provided as
+an alternative. These tags differ from the default image in that they do not contain the required tools needed
+for [lockfile generation][lockfile_generation] (with the exception of the `pip` tool). The `slim` tags are
+significantly smaller and allow for faster action run times. They are useful for those instances where **no**
+manifest files are present and/or **only** lockfiles are used.
+
+Here are examples of using the slim image tags:
+
+```yaml
+    # NOTE: These are examples. Only one container line for `phylum-ci` is expected.
+
+    # Use the most current release of *both* `phylum-ci` and the Phylum CLI
+    container: phylumio/phylum-ci:slim
+
+    # Use the `slim` image with a specific release version of `phylum-ci` and Phylum CLI
+    container: phylumio/phylum-ci:0.36.0-CLIv5.7.1-slim
+```
+
+[resource_container]: https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/resources-containers-container
+[step_target]: https://learn.microsoft.com/azure/devops/pipelines/process/tasks#step-target
+[yaml_job_container]: https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/jobs-job-container
+[yaml_resources]: https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/resources
+[lockfile_generation]: ../cli/lockfile_generation.md
+
+### Repository checkout
+
+The `phylum-ci` logic for determining changes in dependency files requires git history beyond what is available in a
+shallow clone/checkout/fetch. To ensure the shallow fetch option is disabled for the pipeline, an explicit checkout
+step is specified here, with `fetchDepth` set to `0`. It is also possible to disable the shallow fetch option in the
+[pipeline settings UI][pipeline_settings]. See the [YAML schema steps.checkout definition][yaml_checkout] documentation
+for more detail.
+
+In order to support CI triggers, certain git operations are needed to determine the default branch name and set the
+remote HEAD ref for it since Azure Pipelines does not do so during repository checkout. These operations require git
+credentials to be available after the initial fetch, which is done with the `persistCredentials` property. This property
+is not required if CI triggers are disabled (e.g., via `trigger: none`).
+
+```yaml
+      # Reference: https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/steps-checkout
+      - checkout: self
+        fetchDepth: 0
+        persistCredentials: true    # Needed only for CI triggers
+```
+
+[pipeline_settings]: https://learn.microsoft.com/azure/devops/pipelines/repos/azure-repos-git#shallow-fetch
+[yaml_checkout]: https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/steps-checkout
+
+### Script arguments
+
+The arguments to the script step are the way to exert control over the execution of the Phylum analysis.
+The entry here will run as a script in the `phylum-ci` based container job.
+See the [YAML schema steps.script definition][yaml_script] and [container job][container_job] documentation for
+more detail.
+
+The `phylum-ci` script entry point is expected to be called. It has a number of arguments that are all optional
+and defaulted to secure values. To view the arguments, their description, and default values,
+run the script with `--help` output as specified in the [Usage section of the top-level README.md][usage] or
+view the [script options output][script_options] for the latest release.
+
+[yaml_script]: https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/steps-script
+[script_options]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/script_options.md
+
+```yaml
+      # NOTE: These are examples. Only one script entry line for `phylum-ci` is expected.
+
+      # Use the defaults for all the arguments.
+      # The default behavior is to only analyze newly added dependencies
+      # against the active policy set at the Phylum project level.
+      - script: phylum-ci
+
+      # Provide debug level output
+      - script: phylum-ci -vv
+
+      # Consider all dependencies in analysis results instead of just the newly added ones.
+      # The default is to only analyze newly added dependencies, which can be useful for
+      # existing code bases that may not meet established policy rules yet,
+      # but don't want to make things worse. Specifying `--all-deps` can be useful for
+      # casting the widest net for strict adherence to Quality Assurance (QA) standards.
+      - script: phylum-ci --all-deps
+
+      # Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in that
+      # they can be named differently and may or may not contain strict dependencies.
+      # In these cases it is best to specify an explicit path, either with the `--depfile`
+      # option or in a `.phylum_project` file. The easiest way to do that is with the
+      # Phylum CLI, using `phylum init` command (docs.phylum.io/cli/commands/phylum_init)
+      # and committing the generated `.phylum_project` file.
+      - script: phylum-ci --depfile requirements-prod.txt
+
+      # Specify multiple explicit dependency file paths
+      - script: phylum-ci --depfile requirements-prod.txt Cargo.toml path/to/dependency.file
+
+      # Force analysis, even when no dependency file has changed. This can be useful for
+      # manifests, where the loosely specified dependencies may not change often but the
+      # completely resolved set of strict dependencies does.
+      - script: phylum-ci --force-analysis
+
+      # Force analysis for all dependencies in a manifest file. This is especially useful
+      # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
+      - script: phylum-ci --force-analysis --all-deps --depfile Cargo.toml
+
+      # Ensure the latest Phylum CLI is installed.
+      - script: phylum-ci --force-install
+
+      # Install a specific version of the Phylum CLI.
+      - script: phylum-ci --phylum-release 4.8.0 --force-install
+
+      # Mix and match for your specific use case.
+      - script: |
+        phylum-ci \
+          -vv \
+          --depfile requirements-dev.txt \
+          --depfile requirements-prod.txt path/to/dependency.file \
+          --depfile Cargo.toml \
+          --force-analysis \
+          --all-deps
+```
+
+### Script Variables
+
+The script step environment variables are used to ensure the `phylum-ci` tool is able to perform it's job.
+
+A [Phylum token][phylum_tokens] with API access is required to perform analysis on project dependencies.
+[Contact Phylum][phylum_contact] or [register][app_register] to gain access.
+See also [`phylum auth register`][phylum_register] command documentation and consider using a bot or group account
+for this token.
+
+#### Azure Repos Git Build Repositories
+
+An Azure DevOps token with API access is required to use the API (e.g., to post notes/comments) when the build
+repository is [Azure Repos Git][azure_repos_git] and PR triggers are enabled.
+This can be the default `System.AccessToken` provided automatically at the start of each pipeline build for the
+[scoped build identity][build_scope] or a personal access token (PAT).
+
+If using a PAT, it will need at least the `Pull Request Threads` scope (read & write).
+The account used to create the PAT will be the one that appears to post the comments on the pull request.
+Therefore, it might be worth using a bot or service account.
+See the Azure DevOps [documentation for using PATs to authenticate][azure_pat] for more info.
+
+If using the `System.AccessToken`, the [scoped build identity][build_scope] it attaches to needs at least the
+`Contribute to pull requests` permission. For example, to use the `System.AccessToken` on a project-scoped
+identity, follow these steps:
+
+* Go to project settings
+* Select the `Repos --> Repositories` menu
+* Select the `Security` tab
+* Select the user `{Project Name} Build Service ({Org Name})`
+  * NOTE: This user will only exist after the first time the pipeline has run
+* Ensure the `Contribute to pull requests` permission is set to `Allow`
+
+See the Azure DevOps documentation for [using the `System.AccessToken`][access_token] and setting it's
+[job authorization scope][auth_scope].
+
+#### GitHub Build Repositories
+
+A [GitHub PAT][GH_PAT] with API access is required to use the API (e.g., to post notes/comments) when the build
+repository is [GitHub][github_repos] and PR triggers are enabled.
+This can be a fine-grained or classic PAT.
+
+If using a fine-grained PAT, it will need repository access and permissions for read access to `metadata` and
+read/write access to `pull requests`. See [permissions required for fine-grained PATs][fine_pats] for more info.
+
+If using a classic PAT, it will need the `repo` scope or minimally the `public_repo` scope if private
+repositories are not used. See [documentation for scopes][scopes] for more info.
+
+#### Setting Values
+
+Values for the `PHYLUM_API_KEY` and either `AZURE_TOKEN` or `GITHUB_TOKEN` environment variable (e.g., `PHYLUM_TOKEN`
+and one of either `AZURE_PAT` or `GITHUB_PAT` in the example here) can come from the pipeline UI, a variable group,
+or an Azure Key Vault. View the full [documentation for how to set secret variables][secret_variables] for more
+information. Since these tokens are sensitive, **care should be taken to protect them appropriately**.
+
+[azure_pat]: https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate
+[secret_variables]: https://learn.microsoft.com/azure/devops/pipelines/process/set-secret-variables
+
+```yaml
+        env:
+          # Contact Phylum (phylum.io/contact-us) or register (app.phylum.io/register)
+          # to gain access. See also `phylum auth register`
+          # (docs.phylum.io/cli/commands/phylum_auth_register) command documentation.
+          # Consider using a bot or group account for this token.
+          # This value (`PHYLUM_TOKEN`) will need to be set as a secret variable:
+          # https://learn.microsoft.com/azure/devops/pipelines/process/set-secret-variables
+          PHYLUM_API_KEY: $(PHYLUM_TOKEN)
+
+          # NOTE: These are examples. Only one `AZURE_TOKEN` entry line is expected, and only
+          #       when the build repository is hosted in Azure Repos Git with PR triggers enabled.
+          #
+          # Use the `System.AccessToken` provided automatically at the start of each pipeline build.
+          # This value does not have to be set as a secret variable since it is provided by default.
+          AZURE_TOKEN: $(System.AccessToken)
+          #
+          # Use a personal access token (PAT).
+          # This value (`AZURE_PAT`) will need to be set as a secret variable:
+          # https://learn.microsoft.com/azure/devops/pipelines/process/set-secret-variables
+          AZURE_TOKEN: $(AZURE_PAT)
+
+          # NOTE: A `GITHUB_TOKEN` entry is only needed for GitHub hosted build repositories
+          #       with PR triggers enabled.
+          #
+          # Use a personal access token (PAT).
+          # This value (`GITHUB_PAT`) will need to be set as a secret variable:
+          # https://learn.microsoft.com/azure/devops/pipelines/process/set-secret-variables
+          GITHUB_TOKEN: $(GITHUB_PAT)
+```
+
+## Alternatives
+
+It is also possible to make direct use of the [`phylum` Python package][pypi] within CI.
+This may be necessary if the Docker image is unavailable or undesirable for some reason.
+To use the `phylum` package, install it and call the desired entry points from a script under your control.
+See the [Installation][installation] and [Usage][usage] sections of the [README file][readme] for more detail.
+
+[pypi]: https://pypi.org/project/phylum/
+[readme]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md
+[installation]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md#installation
+[usage]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md#usage

--- a/docs/integrations/bitbucket_pipelines.md
+++ b/docs/integrations/bitbucket_pipelines.md
@@ -1,0 +1,327 @@
+# Bitbucket Pipelines Integration
+
+## Quickstart
+
+Add the following "Phylum Analyze" step to a `bitbucket-pipelines.yml` configuration, in one or more pipeline start
+conditions:
+
+```yaml
+# Ensure these variables are set at the repository or workspace level:
+#  - `PHYLUM_API_KEY`: Phylum authentication token
+#  - `BITBUCKET_TOKEN`: repository, project, or workspace access token with `pullrequest` (read) scope
+
+    - step:
+        name: Phylum Analyze
+        image: phylumio/phylum-ci:latest
+        clone:
+          depth: full
+        script:
+          - phylum-ci
+```
+
+## Overview
+
+Once configured for a repository, the Bitbucket Pipelines integration will provide analysis of project
+dependencies from manifests and lockfiles. This can happen in a branch or default pipeline as a result of a commit
+or in a pull request (PR) pipeline.
+
+For PR pipelines, analyzed dependencies will include any that are added/modified in the PR.
+
+For branch pipelines, the analyzed dependencies will be determined by comparing dependency files in the branch to
+the default branch. **All** dependencies will be analyzed when the branch pipeline is run on the default branch.
+
+The results will be provided in the pipeline logs and provided as a comment on the PR. The CI job will return an
+error (i.e., fail the build) if any of the analyzed dependencies fail to meet the established policy.
+
+There will be no comment if no dependencies were added or modified for a given PR.
+If one or more dependencies are still processing (no results available), then the comment will make that clear and
+the CI job will only fail if dependencies that have _completed analysis results_ do not meet the active policy.
+
+## Prerequisites
+
+Bitbucket Cloud is supported for repositories hosted on [https://bitbucket.org/](https://bitbucket.org/).
+Bitbucket Data Center is not currently supported.
+
+The Bitbucket Pipelines environment is primarily supported through the use of a Docker image. The pre-requisites
+for using this image are:
+
+* Access to the [phylumio/phylum-ci Docker image][docker_image]
+* A [Bitbucket access token][bb_tokens] with API access
+  * This is only required when using the integration in pull request pipelines
+  * The token needs the `pullrequest` (read) scope
+* A [Phylum token][phylum_tokens] with API access
+  * [Contact Phylum][phylum_contact] or [register][app_register] to gain access
+    * See also [`phylum auth register`][phylum_register] command documentation
+  * Consider using a bot or group account for this token
+* Access to the Phylum API endpoints
+  * That usually means a connection to the internet, optionally via a proxy
+
+[docker_image]: https://hub.docker.com/r/phylumio/phylum-ci/tags
+[bb_tokens]: https://developer.atlassian.com/cloud/bitbucket/rest/intro/#access-tokens
+[phylum_tokens]: ../knowledge_base/api-keys.md
+[phylum_contact]: https://phylum.io/contact-us/
+[app_register]: https://app.phylum.io/register
+[phylum_register]: ../cli/commands/phylum_auth_register.md
+
+## Configure `bitbucket-pipelines.yml`
+
+Phylum analysis of dependencies can be added to existing CI workflows or on it's own with this minimal configuration:
+
+```yaml
+# Ensure these variables are set at the repository or workspace level:
+#  - `PHYLUM_API_KEY`: Phylum authentication token
+#  - `BITBUCKET_TOKEN`: repository, project, or workspace access token with `pullrequest` (read) scope
+
+pipelines:
+  pull-requests:
+    '**':
+      - step:
+          name: Phylum Analyze PR
+          image: phylumio/phylum-ci:latest
+          clone:
+            depth: full
+          script:
+            - phylum-ci
+  default:
+    - step:
+        name: Phylum Analyze branch
+        image: phylumio/phylum-ci:latest
+        clone:
+          depth: full
+        script:
+          - phylum-ci
+```
+
+This configuration contains pipeline definitions for the `pull-requests` and `default` start conditions. It will
+run for _all_ pull requests and pushes to _any_ branch. It does not override any of the `phylum-ci` arguments, which
+are all either optional or default to secure values. Let's take a deeper dive into each part of the configuration:
+
+### User-defined variables
+
+There are several user-defined variables needed to ensure the `phylum-ci` tool is able to perform it's job. Ensure
+these variables are set at the repository or workspace level. See the [user-defined variables][user_vars] documentation
+for more info.
+
+A [Phylum token][phylum_tokens] with API access is required to perform analysis on project dependencies.
+[Contact Phylum][phylum_contact] or [register][app_register] to gain access.
+See also [`phylum auth register`][phylum_register] command documentation and consider using a bot or group account
+for this token. Provide the token value in a user-defined variable named `PHYLUM_API_KEY`.
+
+A Bitbucket token with API access is required to use the API (e.g., to post comments). This can be a repository,
+project, or workspace access token. The token needs the `pullrequest` (read) scope. The name given to the token
+will be the one that appears to post the comments on the PR. Therefore, it might be worth naming it something like
+`Phylum Analysis`. See the [Bitbucket Access Tokens][bb_tokens] documentation for more info.
+
+Note, the Bitbucket token is only required when this Phylum integration is used in
+[pull request pipelines][pr_pipelines]. It is not required when used in branch based pipelines. Provide the token
+value in a user-defined variable named `BITBUCKET_TOKEN`.
+
+Values for the `BITBUCKET_TOKEN` and `PHYLUM_API_KEY` variables are sensitive and should be set as a
+[secured variable][secured_var]. **Care should be taken to protect them appropriately**.
+
+[user_vars]: https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/#User-defined-variables
+[pr_pipelines]: https://support.atlassian.com/bitbucket-cloud/docs/pipeline-start-conditions/#Pull-Requests
+[secured_var]: https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/#Secured-variables
+
+### Pipeline start conditions
+
+There are a handful of different [pipeline start conditions][start_conditions] available to trigger CI. The Phylum
+analysis step can be included in most of these, or even multiple start conditions. The exceptions _may_ be `tags` and
+`custom` pipelines. The example configuration adds the step to both the `pull-requests` and `default` pipelines:
+
+```yaml
+pipelines:
+  # Pipeline definition for pull requests
+  pull-requests:
+    '**':   # Glob pattern to specify all branches
+      - step:
+          # Add the Phylum Analyze step here
+
+  # Pipeline definition for all branches that don't
+  # match a pipeline definition in other sections
+  default:
+    - step:
+        # Add the Phylum Analyze step here
+```
+
+[start_conditions]: https://support.atlassian.com/bitbucket-cloud/docs/pipeline-start-conditions/
+
+### Step name
+
+The step name is optional, can be named what you like, and have different names depending on the pipeline context.
+See the [`name` step option][step_option_name] documentation for more information.
+
+```yaml
+pipelines:
+  pull-requests:
+    '**':
+      - step:
+          name: Phylum Analyze PR    # Name this what you like
+
+  default:
+    - step:
+        name: Phylum Analyze branch  # Name this what you like
+```
+
+[step_option_name]: https://support.atlassian.com/bitbucket-cloud/docs/step-options/#Name
+
+### Docker image selection
+
+Choose the Docker image tag to match your comfort level with image dependencies. `latest` is a "rolling" tag that
+will point to the image created for the latest released `phylum-ci` Python package. A particular version tag
+(e.g., `0.23.1-CLIv4.4.0`) is created for each release of the `phylum-ci` Python package and _should_ not change
+once published.
+
+However, to be certain that the image does not change...or be warned when it does because it won't be available
+anymore...use the SHA256 digest of the tag. The digest can be found by looking at the `phylumio/phylum-ci`
+[tags on Docker Hub][docker_image] or with the command:
+
+```sh
+# NOTE: The command-line JSON processor `jq` is used here for the sake of a one line example. It is not required.
+❯ docker manifest inspect --verbose phylumio/phylum-ci:0.23.1-CLIv4.4.0 | jq .Descriptor.digest
+"sha256:f2840ad448278e26b69a076a93f2c90cb083803243a614f5efb518f032626578"
+```
+
+For instance, at the time of this writing, all of these tag references pointed to the same image:
+
+```yaml
+  # NOTE: These are examples. Only one image line for `phylum-ci` is expected.
+
+  # Not specifying a tag means a default of `latest`
+  image: phylumio/phylum-ci
+
+  # Be more explicit about wanting the `latest` tag
+  image: phylumio/phylum-ci:latest
+
+  # Use a specific release version of the `phylum-ci` package
+  image: phylumio/phylum-ci:0.23.1-CLIv4.4.0
+
+  # Use a specific image with it's SHA256 digest
+  image: phylumio/phylum-ci@sha256:f2840ad448278e26b69a076a93f2c90cb083803243a614f5efb518f032626578
+```
+
+Only the last tag reference, by SHA256 digest, is guaranteed to not have the underlying image it points to change.
+
+The default `phylum-ci` Docker image contains `git` and the installed `phylum` Python package. It also contains an
+installed version of the Phylum CLI and all required tools needed for [lockfile generation][lockfile_generation].
+An advantage of using the default Docker image is that the complete environment is packaged and made available
+with components that are known to work together.
+
+One disadvantage to the default image is it's size. It can take a while to download and may provide more
+tools than required for your specific use case. Special `slim` tags of the `phylum-ci` image are provided as
+an alternative. These tags differ from the default image in that they do not contain the required tools needed
+for [lockfile generation][lockfile_generation] (with the exception of the `pip` tool). The `slim` tags are
+significantly smaller and allow for faster action run times. They are useful for those instances where **no**
+manifest files are present and/or **only** lockfiles are used.
+
+Here are examples of using the slim image tags:
+
+```yaml
+  # NOTE: These are examples. Only one image line for `phylum-ci` is expected.
+
+  # Use the most current release of *both* `phylum-ci` and the Phylum CLI
+  image: phylumio/phylum-ci:slim
+
+  # Use the `slim` image with a specific release version of `phylum-ci` and Phylum CLI
+  image: phylumio/phylum-ci:0.36.0-CLIv5.7.1-slim
+```
+
+See the Docker [image option][image_option] and [build environment][docker_builds] documentation for more information.
+
+[lockfile_generation]: ../cli/lockfile_generation.md
+[image_option]: https://support.atlassian.com/bitbucket-cloud/docs/docker-image-options/
+[docker_builds]: https://support.atlassian.com/bitbucket-cloud/docs/use-docker-images-as-build-environments/
+
+### Git clone behavior
+
+The `git` version control system is used within the `phylum-ci` package to do things like determine if there was a
+dependency file change and, when specified, report on new dependencies only. Therefore, a full clone of the
+repository is required to ensure that the local working copy is always pristine and history is available to pull the
+requested information.
+
+```yaml
+    - step:
+        clone:
+          depth: full
+```
+
+See the [git clone behavior][clone_behavior] documentation for more information.
+
+[clone_behavior]: https://support.atlassian.com/bitbucket-cloud/docs/git-clone-behavior/
+
+### Script arguments
+
+The script arguments to the Docker image are the way to exert control over the execution of the Phylum analysis.
+The `phylum-ci` script entry point is expected to be called. It has a number of arguments that are all optional
+and defaulted to secure values. To view the arguments, their description, and default values,
+run the script with `--help` output as specified in the [Usage section of the top-level README.md][usage] or
+view the [script options output][script_options] for the latest release.
+
+[script_options]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/script_options.md
+
+```yaml
+  # NOTE: These are examples. Only one script entry line for `phylum-ci` is expected.
+  script:
+    # Use the defaults for all the arguments.
+    # The default behavior is to only analyze newly added dependencies
+    # against the active policy set at the Phylum project level.
+    - phylum-ci
+
+    # Provide debug level output
+    - phylum-ci -vv
+
+    # Consider all dependencies in analysis results instead of just the newly added ones.
+    # The default is to only analyze newly added dependencies, which can be useful for
+    # existing code bases that may not meet established policy rules yet,
+    # but don't want to make things worse. Specifying `--all-deps` can be useful for
+    # casting the widest net for strict adherence to Quality Assurance (QA) standards.
+    - phylum-ci --all-deps
+
+    # Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in that
+    # they can be named differently and may or may not contain strict dependencies.
+    # In these cases it is best to specify an explicit path, either with the `--depfile`
+    # option or in a `.phylum_project` file. The easiest way to do that is with the
+    # Phylum CLI, using `phylum init` command (docs.phylum.io/cli/commands/phylum_init)
+    # and committing the generated `.phylum_project` file.
+    - phylum-ci --depfile requirements-prod.txt
+
+    # Specify multiple explicit dependency file paths
+    - phylum-ci --depfile requirements-prod.txt Cargo.toml path/to/dependency.file
+
+    # Force analysis, even when no dependency file has changed. This can be useful for
+    # manifests, where the loosely specified dependencies may not change often but the
+    # completely resolved set of strict dependencies does.
+    - phylum-ci --force-analysis
+
+    # Force analysis for all dependencies in a manifest file. This is especially useful
+    # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
+    - phylum-ci --force-analysis --all-deps --depfile Cargo.toml
+
+    # Ensure the latest Phylum CLI is installed.
+    - phylum-ci --force-install
+
+    # Install a specific version of the Phylum CLI.
+    - phylum-ci --phylum-release 4.8.0 --force-install
+
+    # Mix and match for your specific use case.
+    - |
+      phylum-ci \
+        -vv \
+        --depfile requirements-dev.txt \
+        --depfile requirements-prod.txt path/to/dependency.file \
+        --depfile Cargo.toml \
+        --force-analysis \
+        --all-deps
+```
+
+## Alternatives
+
+It is also possible to make direct use of the [`phylum` Python package][pypi] within CI.
+This may be necessary if the Docker image is unavailable or undesirable for some reason.
+To use the `phylum` package, install it and call the desired entry points from a script under your control.
+See the [Installation][installation] and [Usage][usage] sections of the [README file][readme] for more detail.
+
+[pypi]: https://pypi.org/project/phylum/
+[readme]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md
+[installation]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md#installation
+[usage]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md#usage

--- a/docs/integrations/git_precommit.md
+++ b/docs/integrations/git_precommit.md
@@ -1,0 +1,175 @@
+# Git `pre-commit` Integration
+
+## Overview
+
+[pre-commit] is a framework for managing and maintaining multi-language Git pre-commit hooks.
+
+Phylum is available as a pre-commit hook.
+
+Once configured for a repository, the git `pre-commit` integration will provide analysis of project dependencies
+from manifests or lockfiles during a commit containing those dependency files. The hook will fail and provide
+a report if any of the newly added/modified dependencies from the commit fail to meet the established policy.
+
+The hook will be skipped if no dependencies were added or modified for a given commit.
+If one or more dependencies are still processing (no results available), then the hook will only fail if
+dependencies that have _completed analysis results_ do not meet the active policy.
+
+[pre-commit]: https://pre-commit.com/
+
+## Prerequisites
+
+The pre-requisites for using the git `pre-commit` hook are:
+
+* The [pre-commit] package manager installed
+* A [Phylum token][phylum_tokens] with API access
+  * [Contact Phylum][phylum_contact] or [register][app_register] to gain access
+    * See also [`phylum auth register`][phylum_register] command documentation
+  * Consider using a bot or group account for this token
+* Access to the Phylum API endpoints
+  * That usually means a connection to the internet, optionally via a proxy
+  * Support for on-premises installs are not available at this time
+
+[phylum_tokens]: ../knowledge_base/api-keys.md
+[phylum_contact]: https://phylum.io/contact-us/
+[app_register]: https://app.phylum.io/register
+[phylum_register]: ../cli/commands/phylum_auth_register.md
+
+**NOTE: If the `phylum` CLI binary is installed locally, it will be used. Otherwise, the hook will install it.**
+
+## Configure `.pre-commit-config.yaml`
+
+Phylum analysis of dependencies can be added to existing `pre-commit` configurations or
+on it's own with this minimal configuration:
+
+```yaml
+# This is the config for using `pre-commit` on this repository.
+#
+# See https://pre-commit.com for more information
+---
+repos:
+  - repo: https://github.com/phylum-dev/phylum-ci
+    rev: main
+    hooks:
+      - id: phylum
+        # Optional: Specify the dependency file pattern for your repository
+        files: ''
+        # Optional: Specify additional arguments to be passed to `phylum-ci`
+        args: []
+```
+
+**NOTE**: This example configuration uses a mutable reference for `rev`, which is a bad practice
+(and only done here to prevent old tags from being used through copy and paste implementations).
+A best practice is to ensure the `rev` key for all hooks is updated to a valid and current immutable reference:
+
+```sh
+pre-commit autoupdate --freeze
+```
+
+The hook can be customized with [optional keys][hook_config] in the config file.
+Two common customization keys for the `phylum` hook are `files` and `args`:
+
+[hook_config]: https://pre-commit.com/index.html#pre-commit-configyaml---hooks
+
+### File Control
+
+The `files` key in the hook configuration file is the way to ensure the hook only runs when specified
+dependency files have changed, saving execution time.
+
+The value for the `files` key is a [Python regular expression][re] and is matched with `re.search`.
+
+[re]: https://docs.python.org/3/library/re.html#regular-expression-syntax
+
+```yaml
+        # NOTE: These are examples. Only one `files` key for the hook is expected
+
+        # Specify `package-lock.json`
+        files: ^package-lock\.json$
+
+        # Specify `poetry.lock`
+        files: ^poetry\.lock$
+
+        # Specify `requirements-*.txt` files
+        files: ^requirements-.*\.txt$
+
+        # Specify both `package-lock.json` and `poetry.lock` on one line
+        files: ^(package-lock\.json|poetry\.lock)$
+
+        # Specify multiple files using the inline `re.VERBOSE` flag `(?x)`
+        files: |
+            (?x)^(
+                package-lock\.json|
+                poetry\.lock|
+                requirements-.*\.txt|
+                Cargo\.toml|
+                path/to/dependency\.file
+            )$
+```
+
+### Argument Control
+
+The `args` key is the way to exert control over the execution of the Phylum analysis.
+The `phylum-ci` script entry point is called by the hook. It has a number of arguments that are all optional
+and defaulted to secure values. To view the arguments, their description, and default values, run the script
+with `--help` output as specified in the [Usage section of the top-level README.md][usage] or view the
+[script options output][script_options] for the latest release.
+
+[usage]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md#usage
+[script_options]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/script_options.md
+
+```yaml
+        # NOTE: These are examples. Only one `args` key for the hook is expected
+
+        # Use the defaults for all the arguments.
+        # The default behavior is to only analyze newly added dependencies
+        # against the active policy set at the Phylum project level.
+        # The key can be removed if the defaults are used.
+        args: []
+
+        # Consider all dependencies in analysis results instead of just the newly added ones.
+        # The default is to only analyze newly added dependencies, which can be useful for
+        # existing code bases that may not meet established policy rules yet,
+        # but don't want to make things worse. Specifying `--all-deps` can be useful for
+        # casting the widest net for strict adherence to Quality Assurance (QA) standards.
+        args: [--all-deps]
+
+        # Provide debug level output
+        args: [-vv]
+
+        # Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in that
+        # they can be named differently and may be a manifest or a lockfile. In cases where
+        # only specific dependency files are meant to be analyzed, it is best to specify
+        # an explicit path to them.
+        args: [--depfile=requirements-prod.txt]
+
+        # Specify multiple explicit dependency file paths
+        args:
+          - --depfile=requirements-prod.txt
+          - --depfile=package-lock.json
+          - --depfile=poetry.lock
+          - --depfile=Cargo.toml
+          - --depfile=path/to/dependency.file
+
+        # Force analysis, even when no dependency file has changed. This can be useful for
+        # manifests, where the loosely specified dependencies may not change often but the
+        # completely resolved set of strict dependencies does.
+        args: [--force-analysis]
+
+        # Force analysis for all dependencies in a manifest file. This is especially useful
+        # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
+        args: [--force-analysis, --all-deps, --depfile=Cargo.toml]
+
+        # Ensure the latest Phylum CLI is installed.
+        args: [--force-install]
+
+        # Install a specific version of the Phylum CLI.
+        args: [--phylum-release=4.8.0, --force-install]
+
+        # Mix and match for your specific use case.
+        args:
+          - -vv
+          - --depfile=requirements-prod.txt
+          - --depfile=path/to/dependency.file
+          - --depfile=Cargo.toml
+          - --force-analysis
+          - --all-deps
+```

--- a/docs/integrations/github_actions.md
+++ b/docs/integrations/github_actions.md
@@ -1,0 +1,128 @@
+# GitHub Actions Integration
+
+## Overview
+
+Integrations with the GitHub Actions environment are available in several forms.
+The primary method is through the `phylum-dev/phylum-analyze-pr-action` action.
+This action is available in the [GitHub Actions Marketplace][marketplace].
+Full documentation can be found there or by viewing the [Phylum Analyze PR action repository][repo] directly.
+
+[marketplace]: https://github.com/marketplace/actions/phylum-analyze-pr
+[repo]: https://github.com/phylum-dev/phylum-analyze-pr-action
+
+## Alternatives
+
+The Phylum Analyze PR action is a [Docker container action][container_action]. The default `phylum-ci` Docker
+image it uses contains `git` and the installed `phylum` Python package. It also contains an installed version
+of the Phylum CLI and all required tools needed for [lockfile generation][lockfile_generation].
+An advantage of using the default Docker image is that the complete environment is packaged and made available
+with components that are known to work together.
+
+One disadvantage to the default image is it's size. It can take a while to download and may provide more
+tools than required for your specific use case. Special `slim` tags of the `phylum-ci` image are provided as
+an alternative. These tags differ from the default image in that they do not contain the required tools needed
+for [lockfile generation][lockfile_generation] (with the exception of the `pip` tool). The `slim` tags are
+significantly smaller and allow for faster action run times. They are useful for those instances where **no**
+manifest files are present and/or **only** lockfiles are used.
+
+Using the slim image tags is possible by altering your workflow to use the image directly instead of this
+GitHub Action. That is possible with either [container jobs](#container-jobs) or [container steps](#container-steps).
+
+[container_action]: https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action
+[lockfile_generation]: ../cli/lockfile_generation.md
+
+### Container Jobs
+
+GitHub Actions allows for workflows to run a job within a container, using the `container:` statement in the
+workflow file. These are known as container jobs. More information can be found in GitHub documentation:
+["Running jobs in a container"][container_job]. To use a `slim` tag in a container job, use this minimal
+configuration:
+
+```yaml
+name: Phylum_analyze
+on: pull_request
+jobs:
+  analyze_deps:
+    name: Analyze dependencies with Phylum
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    container:
+      image: docker://ghcr.io/phylum-dev/phylum-ci:slim
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        PHYLUM_API_KEY: ${{ secrets.PHYLUM_TOKEN }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Analyze dependencies
+        run: phylum-ci -vv
+```
+
+The `image:` value is set to the latest slim image, but other tags are available to ensure a specific release
+of the `phylum-ci` project and a specific version of the Phylum CLI. The full list of available `phylum-ci`
+image tags can be viewed on [GitHub Container Registry][ghcr_tags] (preferred) or [Docker Hub][docker_hub_tags].
+
+The `GITHUB_TOKEN` and `PHYLUM_API_KEY` environment variables are required to have those exact names.
+Those environment variables and the rest of the options are more fully documented in the
+[Phylum Analyze PR action repository][repo].
+
+[container_job]: https://docs.github.com/actions/using-jobs/running-jobs-in-a-container
+[ghcr_tags]: https://github.com/phylum-dev/phylum-ci/pkgs/container/phylum-ci
+[docker_hub_tags]: https://hub.docker.com/r/phylumio/phylum-ci/tags
+
+### Container Steps
+
+GitHub Actions allows for workflows to run a step within a container, by specifying that container image in
+the `uses:` statement of the workflow step. These are known as container steps. More information can be found
+in [GitHub workflow syntax documentation][container_step]. To use a `slim` tag in a container step, use this
+minimal configuration:
+
+```yaml
+name: Phylum_analyze
+on: pull_request
+jobs:
+  analyze_deps:
+    name: Analyze dependencies with Phylum
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Analyze dependencies
+        uses: docker://ghcr.io/phylum-dev/phylum-ci:slim
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PHYLUM_API_KEY: ${{ secrets.PHYLUM_TOKEN }}
+        with:
+          args: phylum-ci -vv
+```
+
+The `uses:` value is set to the latest slim image, but other tags are available to ensure a specific release
+of the `phylum-ci` project and a specific version of the Phylum CLI. The full list of available `phylum-ci`
+image tags can be viewed on [GitHub Container Registry][ghcr_tags] (preferred) or [Docker Hub][docker_hub_tags].
+
+The `GITHUB_TOKEN` and `PHYLUM_API_KEY` environment variables are required to have those exact names.
+Those environment variables and the rest of the options are more fully documented in the
+[Phylum Analyze PR action repository][repo].
+
+[container_step]: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses
+
+### Direct `phylum` Python Package Use
+
+It is also possible to make direct use of the [`phylum` Python package][pypi] within CI.
+This may be necessary if the Docker image is unavailable or undesirable for some reason.
+To use the `phylum` package, install it and call the desired entry points from a script under your control.
+See the [Installation][installation] and [Usage][usage] sections of the [README file][readme] for more detail.
+
+[pypi]: https://pypi.org/project/phylum/
+[readme]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md
+[installation]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md#installation
+[usage]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md#usage

--- a/docs/integrations/gitlab_ci.md
+++ b/docs/integrations/gitlab_ci.md
@@ -1,0 +1,319 @@
+# GitLab CI Integration
+
+## Overview
+
+Once configured for a repository, the GitLab CI integration will provide analysis of project dependencies from
+manifests and lockfiles. This can happen in a branch pipeline as a result of a commit or in a Merge Request (MR)
+pipeline.
+
+For MR pipelines, analyzed dependencies will include any that are added/modified in the MR.
+
+For branch pipelines, the analyzed dependencies will be determined by comparing dependency files in the branch to
+the default branch. **All** dependencies will be analyzed when the branch pipeline is run on the default branch.
+
+The results will be provided in the pipeline logs and provided as a note (comment) on the MR. The CI job will
+return an error (i.e., fail the build) if any of the analyzed dependencies fail to meet the established policy.
+
+There will be no note if no dependencies were added or modified for a given MR.
+If one or more dependencies are still processing (no results available), then the note will make that clear and
+the CI job will only fail if dependencies that have _completed analysis results_ do not meet the active policy.
+
+## Prerequisites
+
+The GitLab CI environment is primarily supported through the use of a Docker image. GitLab [SaaS subscriptions][gl_saas]
+hosted on [https://gitlab.com](https://gitlab.com) are supported. [Self-managed subscriptions][self_managed] are
+supported for "on-premises" installs which still have access to the internet. Self-hosted "offline" (e.g., air-gapped networks) installs of GitLab may work but have not been confirmed.
+
+The pre-requisites for using this image are:
+
+* Access to the [phylumio/phylum-ci Docker image][docker_image]
+* A [GitLab token][gitlab_tokens] with API access
+  * This is only required when using the integration in merge request pipelines
+  * The token needs the `api` scope
+  * Tokens that specify a role will work with any role _other than_ `Guest`
+* A [Phylum token][phylum_tokens] with API access
+  * [Contact Phylum][phylum_contact] or [register][app_register] to gain access
+    * See also [`phylum auth register`][phylum_register] command documentation
+  * Consider using a bot or group account for this token
+* Access to the Phylum API endpoints
+  * That usually means a connection to the internet, optionally via a proxy
+
+[gl_saas]: https://docs.gitlab.com/ee/subscriptions/gitlab_com/
+[self_managed]: https://docs.gitlab.com/ee/subscriptions/self_managed/
+[docker_image]: https://hub.docker.com/r/phylumio/phylum-ci/tags
+[gitlab_tokens]: https://docs.gitlab.com/ee/security/token_overview.html
+[phylum_tokens]: ../knowledge_base/api-keys.md
+[phylum_contact]: https://phylum.io/contact-us/
+[app_register]: https://app.phylum.io/register
+[phylum_register]: ../cli/commands/phylum_auth_register.md
+
+## Configure `.gitlab-ci.yml`
+
+Phylum analysis of dependencies can be added to existing CI workflows or on it's own with this minimal configuration:
+
+```yaml
+stages:
+  - QA
+
+analyze_MR_with_Phylum:
+  stage: QA
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  image: phylumio/phylum-ci:latest
+  variables:
+    GIT_STRATEGY: clone
+    GITLAB_TOKEN: $GITLAB_TOKEN_VARIABLE_OR_SECRET_HERE
+    PHYLUM_API_KEY: $PHYLUM_TOKEN_VARIABLE_OR_SECRET_HERE
+  script:
+    - phylum-ci
+```
+
+This configuration contains a single Quality Assurance stage named QA and will only run in merge request pipelines.
+It does not override any of the `phylum-ci` arguments, which are all either optional or default to secure values.
+Let's take a deeper dive into each part of the configuration:
+
+### Stage and Job names
+
+The stage and job names can be named differently or included in existing stages/jobs.
+
+```yaml
+stages:
+  - QA  # Name this what you like
+
+analyze_MR_with_Phylum:  # Name this what you like
+  stage: QA  # Change the stage where the job will run here
+```
+
+### Job control
+
+Choose when to run the job. The Phylum integration can run in the context of branch pipelines or merge request
+pipelines but [merge request pipelines][mr_pipelines] are given preferential treatment so care should be taken to
+[avoid duplicate pipelines][duplicate_pipelines].
+
+There are several ways to accomplish this goal. The first is to create a rule at the job level to specify that
+the job should only run for merge request pipelines. Branch pipelines are the default type and will run when new
+commits are pushed to a branch. If the desire is to only run the job for branch pipelines, then no rule limiting
+the pipeline source should be specified.
+
+```yaml
+  # This optional rule specifies to run the job for merge request pipelines only.
+  # Remove these lines entirely to run the job for branch pipelines instead.
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+```
+
+It is also possible to allow for both pipeline types while ensuring only one runs at a time by using workflow
+rules to automatically [switch between branch pipelines and merge request pipelines][switch]. To do so, remove
+any _job_ level rules related to pipeline sources and add the following _workflow_ level rules to the configuration:
+
+```yaml
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS
+      when: never
+    - if: $CI_COMMIT_BRANCH
+```
+
+See the [GitLab CI/CD Job Control][job_control] documentation for more detail.
+
+[mr_pipelines]: https://docs.gitlab.com/ee/ci/pipelines/merge_request_pipelines.html
+[duplicate_pipelines]: https://docs.gitlab.com/ee/ci/jobs/job_control.html#avoid-duplicate-pipelines
+[switch]: https://docs.gitlab.com/ee/ci/yaml/workflow.html#switch-between-branch-pipelines-and-merge-request-pipelines
+[job_control]: https://docs.gitlab.com/ee/ci/jobs/job_control.html
+
+### Docker image selection
+
+Choose the Docker image tag to match your comfort level with image dependencies. `latest` is a "rolling" tag that
+will point to the image created for the latest released `phylum-ci` Python package. A particular version tag
+(e.g., `0.23.1-CLIv4.4.0`) is created for each release of the `phylum-ci` Python package and _should_ not change
+once published.
+
+However, to be certain that the image does not change...or be warned when it does because it won't be available
+anymore...use the SHA256 digest of the tag. The digest can be found by looking at the `phylumio/phylum-ci`
+[tags on Docker Hub][docker_image] or with the command:
+
+```sh
+# NOTE: The command-line JSON processor `jq` is used here for the sake of a one line example. It is not required.
+❯ docker manifest inspect --verbose phylumio/phylum-ci:0.23.1-CLIv4.4.0 | jq .Descriptor.digest
+"sha256:f2840ad448278e26b69a076a93f2c90cb083803243a614f5efb518f032626578"
+```
+
+For instance, at the time of this writing, all of these tag references pointed to the same image:
+
+```yaml
+  # NOTE: These are examples. Only one image line for `phylum-ci` is expected.
+
+  # Not specifying a tag means a default of `latest`
+  image: phylumio/phylum-ci
+
+  # Be more explicit about wanting the `latest` tag
+  image: phylumio/phylum-ci:latest
+
+  # Use a specific release version of the `phylum-ci` package
+  image: phylumio/phylum-ci:0.23.1-CLIv4.4.0
+
+  # Use a specific image with it's SHA256 digest
+  image: phylumio/phylum-ci@sha256:f2840ad448278e26b69a076a93f2c90cb083803243a614f5efb518f032626578
+```
+
+Only the last tag reference, by SHA256 digest, is guaranteed to not have the underlying image it points to change.
+
+The default `phylum-ci` Docker image contains `git` and the installed `phylum` Python package. It also contains an
+installed version of the Phylum CLI and all required tools needed for [lockfile generation][lockfile_generation].
+An advantage of using the default Docker image is that the complete environment is packaged and made available
+with components that are known to work together.
+
+One disadvantage to the default image is it's size. It can take a while to download and may provide more
+tools than required for your specific use case. Special `slim` tags of the `phylum-ci` image are provided as
+an alternative. These tags differ from the default image in that they do not contain the required tools needed
+for [lockfile generation][lockfile_generation] (with the exception of the `pip` tool). The `slim` tags are
+significantly smaller and allow for faster action run times. They are useful for those instances where **no**
+manifest files are present and/or **only** lockfiles are used.
+
+Here are examples of using the slim image tags:
+
+```yaml
+  # NOTE: These are examples. Only one image line for `phylum-ci` is expected.
+
+  # Use the most current release of *both* `phylum-ci` and the Phylum CLI
+  image: phylumio/phylum-ci:slim
+
+  # Use the `slim` image with a specific release version of `phylum-ci` and Phylum CLI
+  image: phylumio/phylum-ci:0.36.0-CLIv5.7.1-slim
+```
+
+[lockfile_generation]: ../cli/lockfile_generation.md
+
+### Variables
+
+The job variables are used to ensure the `phylum-ci` tool is able to perform it's job.
+
+For instance, `git` is used within the `phylum-ci` package to do things like determine if there was a dependency file
+change and, when specified, report on new dependencies only. Therefore, a clone of the repository is required to
+ensure that the local working copy is always pristine and history is available to pull the requested information.
+It _may_ also be necessary to specify the depth of cloning if/when there is not enough info.
+
+A GitLab token with API access is required to use the API (e.g., to post notes/comments). This can be a personal,
+project, or group access token. The account used to create the token will be the one that appears to post the
+notes/comments on the MR. Therefore, it might be worth looking into using a bot account, which is available for
+project and group access tokens. See the [GitLab Token Overview][gitlab_tokens] documentation for more info.
+The token needs the `api` scope. Project or Group access tokens should specify a role _other than_ `Guest`.
+
+Note, the GitLab token is only required when this Phylum integration is used in [merge request pipelines][mr_pipelines].
+It is not required when used in branch pipelines.
+
+Note, using `$CI_JOB_TOKEN` as the value will work in some situations because "API authentication uses the job token,
+by using the authorization of the user triggering the job." This is not recommended for anything other than temporary
+personal use in private repositories as there is a chance that depending on it will cause failures when attempting to
+do the same thing in different scenarios.
+
+A [Phylum token][phylum_tokens] with API access is required to perform analysis on project dependencies.
+[Contact Phylum][phylum_contact] or [register][app_register] to gain access.
+See also [`phylum auth register`][phylum_register] command documentation and consider using a bot or group account
+for this token.
+
+Values for the `GITLAB_TOKEN` and `PHYLUM_API_KEY` variables can come from a [CI/CD Variable][ci_cd_variable] or an
+[External Secret][external_secret]. Since they are sensitive, **care should be taken to protect them appropriately**.
+
+[ci_cd_variable]: https://docs.gitlab.com/ee/ci/variables/index.html
+[external_secret]: https://docs.gitlab.com/ee/ci/secrets/index.html
+
+```yaml
+  variables:
+    # References:
+    # GIT_STRATEGY - https://docs.gitlab.com/ee/ci/runners/configure_runners.html#git-strategy
+    # GIT_DEPTH - https://docs.gitlab.com/ee/ci/runners/configure_runners.html#shallow-cloning
+    GIT_STRATEGY: clone
+    # GIT_DEPTH: "50"
+
+    # References for GitLab tokens:
+    # All tokens - https://docs.gitlab.com/ee/security/token_overview.html
+    # Personal - https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html
+    # Project - https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html
+    # Group - https://docs.gitlab.com/ee/user/group/settings/group_access_tokens.html
+    GITLAB_TOKEN: $GITLAB_TOKEN_VARIABLE_OR_SECRET_HERE
+
+    # Contact Phylum (phylum.io/contact-us) or register (app.phylum.io/register) to gain
+    # access. See also `phylum auth register` (docs.phylum.io/cli/commands/phylum_auth_register)
+    # command documentation. Consider using a bot or group account for this token.
+    PHYLUM_API_KEY: $PHYLUM_TOKEN_VARIABLE_OR_SECRET_HERE
+```
+
+### Script arguments
+
+The script arguments to the Docker image are the way to exert control over the execution of the Phylum analysis.
+The `phylum-ci` script entry point is expected to be called. It has a number of arguments that are all optional
+and defaulted to secure values. To view the arguments, their description, and default values,
+run the script with `--help` output as specified in the [Usage section of the top-level README.md][usage] or
+view the [script options output][script_options] for the latest release.
+
+[script_options]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/script_options.md
+
+```yaml
+  # NOTE: These are examples. Only one script entry line for `phylum-ci` is expected.
+  script:
+    # Use the defaults for all the arguments.
+    # The default behavior is to only analyze newly added dependencies
+    # against the active policy set at the Phylum project level.
+    - phylum-ci
+
+    # Provide debug level output
+    - phylum-ci -vv
+
+    # Consider all dependencies in analysis results instead of just the newly added ones.
+    # The default is to only analyze newly added dependencies, which can be useful for
+    # existing code bases that may not meet established policy rules yet,
+    # but don't want to make things worse. Specifying `--all-deps` can be useful for
+    # casting the widest net for strict adherence to Quality Assurance (QA) standards.
+    - phylum-ci --all-deps
+
+    # Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in that
+    # they can be named differently and may or may not contain strict dependencies.
+    # In these cases it is best to specify an explicit path, either with the `--depfile`
+    # option or in a `.phylum_project` file. The easiest way to do that is with the
+    # Phylum CLI, using the `phylum init` command (docs.phylum.io/cli/commands/phylum_init)
+    # and committing the generated `.phylum_project` file.
+    - phylum-ci --depfile requirements-prod.txt
+
+    # Specify multiple explicit dependency file paths
+    - phylum-ci --depfile requirements-prod.txt Cargo.toml path/to/dependency.file
+
+    # Force analysis, even when no dependency file has changed. This can be useful for
+    # manifests, where the loosely specified dependencies may not change often but the
+    # completely resolved set of strict dependencies does.
+    - phylum-ci --force-analysis
+
+    # Force analysis for all dependencies in a manifest file. This is especially useful
+    # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
+    - phylum-ci --force-analysis --all-deps --depfile Cargo.toml
+
+    # Ensure the latest Phylum CLI is installed.
+    - phylum-ci --force-install
+
+    # Install a specific version of the Phylum CLI.
+    - phylum-ci --phylum-release 4.8.0 --force-install
+
+    # Mix and match for your specific use case.
+    # Long commands: https://docs.gitlab.com/ee/ci/yaml/script.html#split-long-commands
+    - |
+      phylum-ci \
+        -vv \
+        --depfile requirements-dev.txt \
+        --depfile requirements-prod.txt path/to/dependency.file \
+        --depfile Cargo.toml \
+        --force-analysis \
+        --all-deps
+```
+
+## Alternatives
+
+It is also possible to make direct use of the [`phylum` Python package][pypi] within CI.
+This may be necessary if the Docker image is unavailable or undesirable for some reason.
+To use the `phylum` package, install it and call the desired entry points from a script under your control.
+See the [Installation][installation] and [Usage][usage] sections of the [README file][readme] for more detail.
+
+[pypi]: https://pypi.org/project/phylum/
+[readme]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md
+[installation]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md#installation
+[usage]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md#usage


### PR DESCRIPTION
This change restores the integration documentation that was previously stored in this repository by copying it from the `documentation` repo (no additional changes were made). That way, the code and docs will live together and be maintained more easily.

This is the first step in a three-step process. The second step is to update the `documentation` repo to include these integration docs as a git submodule, in the same way as is done for the `cli` repo. The third step is to ensure releases of `phylum-ci` trigger a sub-module update in the `documentation` repository.

This change is also acceptable because the `phylum-ci` repo is also public and therefore available to view and suggest/submit changes directly from the docs.phylum.io website.
