### PR TITLE
fix: `pre-commit` hook failures

### DIFF
--- a/.github/workflows/auto_updates.yml
+++ b/.github/workflows/auto_updates.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Update Python dependencies
         run: |
-          poetry update -vv --lock
+          poetry update -vv --lock --no-cache
           poetry check --lock
 
       - name: Commit changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,7 @@ Here's how to set up `phylum-ci` for local development.
     #   new-dependency-name = "*"
 
     # Update the lockfile and the local environment to get the latest versions of dependencies
-    poetry update
+    poetry update --no-cache
 
     # Dependencies will be checked automatically in CI during a PR. They will also be checked
     # with the local pre-commit hook, if enabled. Manually checking locally is also possible:

--- a/poetry.lock
+++ b/poetry.lock
@@ -32,13 +32,13 @@ tests-no-zope = ["attrs[tests-mypy]", "cloudpickle", "hypothesis", "pympler", "p
 
 [[package]]
 name = "cachetools"
-version = "5.3.2"
+version = "5.3.3"
 description = "Extensible memoizing collections and decorators"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "cachetools-5.3.2-py3-none-any.whl", hash = "sha256:861f35a13a451f94e301ce2bec7cac63e881232ccce7ed67fab9b5df4d3beaa1"},
-    {file = "cachetools-5.3.2.tar.gz", hash = "sha256:086ee420196f7b2ab9ca2db2520aca326318b68fe5ba8bc4d49cca91add450f2"},
+    {file = "cachetools-5.3.3-py3-none-any.whl", hash = "sha256:0abad1021d3f8325b2fc1d2e9c8b9c9d57b04c3932657a72465447332c24d945"},
+    {file = "cachetools-5.3.3.tar.gz", hash = "sha256:ba29e2dfa0b8b556606f097407ed1aa62080ee108ab0dc5ec9d6a723a007d105"},
 ]
 
 [[package]]
@@ -884,13 +884,13 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "2.6.2"
+version = "2.6.3"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic-2.6.2-py3-none-any.whl", hash = "sha256:37a5432e54b12fecaa1049c5195f3d860a10e01bdfd24f1840ef14bd0d3aeab3"},
-    {file = "pydantic-2.6.2.tar.gz", hash = "sha256:a09be1c3d28f3abe37f8a78af58284b236a92ce520105ddc91a6d29ea1176ba7"},
+    {file = "pydantic-2.6.3-py3-none-any.whl", hash = "sha256:72c6034df47f46ccdf81869fddb81aade68056003900a8724a4f160700016a2a"},
+    {file = "pydantic-2.6.3.tar.gz", hash = "sha256:e07805c4c7f5c6826e33a1d4c9d47950d7eaf34868e2690f8594d2e30241f11f"},
 ]
 
 [package.dependencies]
@@ -1325,13 +1325,13 @@ requests = ">=2.0.1,<3.0.0"
 
 [[package]]
 name = "rich"
-version = "13.7.0"
+version = "13.7.1"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "rich-13.7.0-py3-none-any.whl", hash = "sha256:6da14c108c4866ee9520bbffa71f6fe3962e193b7da68720583850cd4548e235"},
-    {file = "rich-13.7.0.tar.gz", hash = "sha256:5cb5123b5cf9ee70584244246816e9114227e0b98ad9176eede6ad54bf5403fa"},
+    {file = "rich-13.7.1-py3-none-any.whl", hash = "sha256:4edbae314f59eb482f54e9e30bf00d33350aaa94f4bfcd4e9e3110e64d0d7222"},
+    {file = "rich-13.7.1.tar.gz", hash = "sha256:9be308cb1fe2f1f57d67ce99e95af38a1e2bc71ad9813b0e247cf7ffbcc3a432"},
 ]
 
 [package.dependencies]
@@ -1619,13 +1619,13 @@ files = [
 
 [[package]]
 name = "tomlkit"
-version = "0.12.3"
+version = "0.12.4"
 description = "Style preserving TOML library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "tomlkit-0.12.3-py3-none-any.whl", hash = "sha256:b0a645a9156dc7cb5d3a1f0d4bab66db287fcb8e0430bdd4664a095ea16414ba"},
-    {file = "tomlkit-0.12.3.tar.gz", hash = "sha256:75baf5012d06501f07bee5bf8e801b9f343e7aac5a92581f20f80ce632e6b5a4"},
+    {file = "tomlkit-0.12.4-py3-none-any.whl", hash = "sha256:5cd82d48a3dd89dee1f9d64420aa20ae65cfbd00668d6f094d7578a78efbb77b"},
+    {file = "tomlkit-0.12.4.tar.gz", hash = "sha256:7ca1cfc12232806517a8515047ba66a19369e71edf2439d0f5824f91032b6cc3"},
 ]
 
 [[package]]

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -8,6 +8,7 @@ designated as abstract methods to be defined in specific CI environments.
 from abc import ABC, abstractmethod
 from argparse import Namespace
 from collections import OrderedDict
+from collections.abc import Mapping
 from functools import cached_property, lru_cache
 from itertools import starmap
 import json
@@ -60,6 +61,7 @@ class CIBase(ABC):
         self._force_analysis = args.force_analysis
         self._returncode = ReturnCode.SUCCESS
         self._analysis_report = "No analysis output yet"
+        self._env: Optional[Mapping[str, str]] = None
         self.ci_platform_name = "Unknown"
         self.disable_lockfile_generation = False
 
@@ -700,7 +702,7 @@ class CIBase(ABC):
             return []
 
         base_packages: set[Package] = set()
-        with git_worktree(self.common_ancestor_commit) as temp_dir:
+        with git_worktree(self.common_ancestor_commit, env=self._env) as temp_dir:
             for depfile in self.depfiles:
                 prev_depfile_path = temp_dir / depfile.path.relative_to(Path.cwd())
                 try:

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -655,6 +655,7 @@ class CIBase(ABC):
         # TODO(maxrake): Better formatting with parenthesized context managers is available in Python 3.10+
         #     https://github.com/phylum-dev/phylum-ci/issues/357
         #     https://docs.python.org/3.10/whatsnew/3.10.html#parenthesized-context-managers
+        #     https://stackoverflow.com/q/67808977
         with tempfile.NamedTemporaryFile(
             mode="w+",
             encoding="utf-8",

--- a/src/phylum/ci/git.py
+++ b/src/phylum/ci/git.py
@@ -1,6 +1,6 @@
 """Provide common git functions."""
 
-from collections.abc import Generator
+from collections.abc import Generator, Mapping
 import contextlib
 from pathlib import Path
 import shlex
@@ -221,7 +221,11 @@ def git_repo_name(git_c_path: Optional[Path] = None) -> str:
 
 
 @contextlib.contextmanager
-def git_worktree(commit: str, git_c_path: Optional[Path] = None) -> Generator[Path, None, None]:
+def git_worktree(
+    commit: str,
+    env: Optional[Mapping[str, str]] = None,
+    git_c_path: Optional[Path] = None,
+) -> Generator[Path, None, None]:
     """Create a git worktree at the given commit.
 
     This is a context manager that yields a `Path` to the worktree, created in a temporary directory.
@@ -242,7 +246,7 @@ def git_worktree(commit: str, git_c_path: Optional[Path] = None) -> Generator[Pa
         LOG.debug("Adding git worktree for base iteration in a temporary directory ...")
         LOG.debug("Using command: %s", shlex.join(cmd))
         try:
-            subprocess.run(cmd, check=True, capture_output=True, text=True)  # noqa: S603
+            subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)  # noqa: S603
         except subprocess.CalledProcessError as err:
             msg = f"Unable to create a git worktree at commit: {commit}"
             raise PhylumCalledProcessError(err, msg) from err

--- a/tests/functional/test_ci.py
+++ b/tests/functional/test_ci.py
@@ -1,4 +1,4 @@
-""""Test the phylum-ci command line interface (CLI)."""
+"""Test the phylum-ci command line interface (CLI)."""
 
 import logging
 import subprocess

--- a/tests/functional/test_init.py
+++ b/tests/functional/test_init.py
@@ -1,4 +1,4 @@
-""""Test the phylum-init command line interface (CLI)."""
+"""Test the phylum-init command line interface (CLI)."""
 
 import logging
 from pathlib import Path


### PR DESCRIPTION
Testing was performed locally and bug free functionality confirmed by updating `poetry.lock` with the latest dependencies and ensuring it passed the `pre-commit` hooks while submitting this change. Some small formatting changes were applied here. Guidance and implementation was updated to specify `--no-cache` when updating dependencies with Poetry. That way, the results will be the same regardless of where it happens (e.g., locally vs. CI).

Closes #394