### PR TITLE
feat: implement audit mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
         args: [--no-update, --no-cache]
 
   # NOTE: Don't use this config for your own repositories. Instead, see
-  #       "Git pre-commit Integration" at https://docs.phylum.io/integrations/git_precommit
+  #       "Git pre-commit Integration" at https://docs.phylum.io/phylum-ci/git_precommit
   - repo: local
     hooks:
       - id: phylum-ci

--- a/README.md
+++ b/README.md
@@ -160,11 +160,11 @@ The options for `phylum-ci`, automatically updated to be current for the latest 
 
 ![phylum-ci options](https://raw.githubusercontent.com/phylum-dev/phylum-ci/main/docs/img/phylum-ci_options.svg)
 
-[github_docs]: https://docs.phylum.io/integrations/github_actions
-[gitlab_docs]: https://docs.phylum.io/integrations/gitlab_ci
-[azure_docs]: https://docs.phylum.io/integrations/azure_pipelines
-[bb_pipelines_docs]: https://docs.phylum.io/integrations/bitbucket_pipelines
-[precommit_docs]: https://docs.phylum.io/integrations/git_precommit
+[github_docs]: https://docs.phylum.io/phylum-ci/github_actions
+[gitlab_docs]: https://docs.phylum.io/phylum-ci/gitlab_ci
+[azure_docs]: https://docs.phylum.io/phylum-ci/azure_pipelines
+[bb_pipelines_docs]: https://docs.phylum.io/phylum-ci/bitbucket_pipelines
+[precommit_docs]: https://docs.phylum.io/phylum-ci/git_precommit
 
 ## License
 

--- a/docs/integrations/git_precommit.md
+++ b/docs/integrations/git_precommit.md
@@ -132,7 +132,7 @@ with `--help` output as specified in the [Usage section of the top-level README.
         # casting the widest net for strict adherence to Quality Assurance (QA) standards.
         args: [--all-deps]
 
-        # Provide debug level output
+        # Provide debug level output.
         args: [-vv]
 
         # Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in that
@@ -141,18 +141,13 @@ with `--help` output as specified in the [Usage section of the top-level README.
         # an explicit path to them.
         args: [--depfile=requirements-prod.txt]
 
-        # Specify multiple explicit dependency file paths
+        # Specify multiple explicit dependency file paths.
         args:
           - --depfile=requirements-prod.txt
           - --depfile=package-lock.json
           - --depfile=poetry.lock
           - --depfile=Cargo.toml
           - --depfile=path/to/dependency.file
-
-        # Force analysis, even when no dependency file has changed. This can be useful for
-        # manifests, where the loosely specified dependencies may not change often but the
-        # completely resolved set of strict dependencies does.
-        args: [--force-analysis]
 
         # Force analysis for all dependencies in a manifest file. This is especially useful
         # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).

--- a/docs/integrations/gitlab_ci.md
+++ b/docs/integrations/gitlab_ci.md
@@ -11,8 +11,9 @@ For MR pipelines, analyzed dependencies will include any that are added/modified
 For branch pipelines, the analyzed dependencies will be determined by comparing dependency files in the branch to
 the default branch. **All** dependencies will be analyzed when the branch pipeline is run on the default branch.
 
-The results will be provided in the pipeline logs and provided as a note (comment) on the MR. The CI job will
-return an error (i.e., fail the build) if any of the analyzed dependencies fail to meet the established policy.
+The results will be provided in the pipeline logs and provided as a note (comment) on the MR unless the option to skip
+comments is provided. The CI job will return an error (i.e., fail the build) if any of the analyzed dependencies fail
+to meet the established policy unless audit mode is specified.
 
 There will be no note if no dependencies were added or modified for a given MR.
 If one or more dependencies are still processing (no results available), then the note will make that clear and
@@ -28,7 +29,9 @@ The pre-requisites for using this image are:
 
 * Access to the [phylumio/phylum-ci Docker image][docker_image]
 * A [GitLab token][gitlab_tokens] with API access
-  * This is only required when using the integration in merge request pipelines
+  * This is only required when:
+    * Using the integration in merge request pipelines
+    * Comment generation has not been skipped
   * The token needs the `api` scope
   * Tokens that specify a role will work with any role _other than_ `Guest`
 * A [Phylum token][phylum_tokens] with API access
@@ -126,7 +129,7 @@ See the [GitLab CI/CD Job Control][job_control] documentation for more detail.
 
 Choose the Docker image tag to match your comfort level with image dependencies. `latest` is a "rolling" tag that
 will point to the image created for the latest released `phylum-ci` Python package. A particular version tag
-(e.g., `0.23.1-CLIv4.4.0`) is created for each release of the `phylum-ci` Python package and _should_ not change
+(e.g., `0.42.4-CLIv6.1.2`) is created for each release of the `phylum-ci` Python package and _should_ not change
 once published.
 
 However, to be certain that the image does not change...or be warned when it does because it won't be available
@@ -135,8 +138,8 @@ anymore...use the SHA256 digest of the tag. The digest can be found by looking a
 
 ```sh
 # NOTE: The command-line JSON processor `jq` is used here for the sake of a one line example. It is not required.
-❯ docker manifest inspect --verbose phylumio/phylum-ci:0.23.1-CLIv4.4.0 | jq .Descriptor.digest
-"sha256:f2840ad448278e26b69a076a93f2c90cb083803243a614f5efb518f032626578"
+❯ docker manifest inspect --verbose phylumio/phylum-ci:0.42.4-CLIv6.1.2 | jq .Descriptor.digest
+"sha256:77b761ccef10edc28b0f009a40fbeab240bf004522edaaea05572dc3728b6ca6"
 ```
 
 For instance, at the time of this writing, all of these tag references pointed to the same image:
@@ -151,10 +154,10 @@ For instance, at the time of this writing, all of these tag references pointed t
   image: phylumio/phylum-ci:latest
 
   # Use a specific release version of the `phylum-ci` package
-  image: phylumio/phylum-ci:0.23.1-CLIv4.4.0
+  image: phylumio/phylum-ci:0.42.4-CLIv6.1.2
 
   # Use a specific image with it's SHA256 digest
-  image: phylumio/phylum-ci@sha256:f2840ad448278e26b69a076a93f2c90cb083803243a614f5efb518f032626578
+  image: phylumio/phylum-ci@sha256:77b761ccef10edc28b0f009a40fbeab240bf004522edaaea05572dc3728b6ca6
 ```
 
 Only the last tag reference, by SHA256 digest, is guaranteed to not have the underlying image it points to change.
@@ -180,7 +183,7 @@ Here are examples of using the slim image tags:
   image: phylumio/phylum-ci:slim
 
   # Use the `slim` image with a specific release version of `phylum-ci` and Phylum CLI
-  image: phylumio/phylum-ci:0.36.0-CLIv5.7.1-slim
+  image: phylumio/phylum-ci:0.42.4-CLIv6.1.2-slim
 ```
 
 [lockfile_generation]: ../cli/lockfile_generation.md
@@ -200,8 +203,8 @@ notes/comments on the MR. Therefore, it might be worth looking into using a bot 
 project and group access tokens. See the [GitLab Token Overview][gitlab_tokens] documentation for more info.
 The token needs the `api` scope. Project or Group access tokens should specify a role _other than_ `Guest`.
 
-Note, the GitLab token is only required when this Phylum integration is used in [merge request pipelines][mr_pipelines].
-It is not required when used in branch pipelines.
+Note, the GitLab token is only required when this Phylum integration is used in [merge request pipelines][mr_pipelines]
+where comment generation is not skipped. It is not required when used in branch pipelines.
 
 Note, using `$CI_JOB_TOKEN` as the value will work in some situations because "API authentication uses the job token,
 by using the authorization of the user triggering the job." This is not recommended for anything other than temporary
@@ -258,7 +261,7 @@ view the [script options output][script_options] for the latest release.
     # against the active policy set at the Phylum project level.
     - phylum-ci
 
-    # Provide debug level output
+    # Provide debug level output.
     - phylum-ci -vv
 
     # Consider all dependencies in analysis results instead of just the newly added ones.
@@ -276,17 +279,15 @@ view the [script options output][script_options] for the latest release.
     # and committing the generated `.phylum_project` file.
     - phylum-ci --depfile requirements-prod.txt
 
-    # Specify multiple explicit dependency file paths
+    # Specify multiple explicit dependency file paths.
     - phylum-ci --depfile requirements-prod.txt Cargo.toml path/to/dependency.file
-
-    # Force analysis, even when no dependency file has changed. This can be useful for
-    # manifests, where the loosely specified dependencies may not change often but the
-    # completely resolved set of strict dependencies does.
-    - phylum-ci --force-analysis
 
     # Force analysis for all dependencies in a manifest file. This is especially useful
     # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
     - phylum-ci --force-analysis --all-deps --depfile Cargo.toml
+
+    # Analyze all dependencies in audit mode, to gain insight without failing builds.
+    - phylum-ci --all-deps --audit
 
     # Ensure the latest Phylum CLI is installed.
     - phylum-ci --force-install

--- a/src/phylum/ci/ci_azure.py
+++ b/src/phylum/ci/ci_azure.py
@@ -19,11 +19,11 @@ Azure References:
 from argparse import Namespace
 import base64
 from functools import cached_property, lru_cache
+from inspect import cleandoc
 import os
 import re
 import shlex
 import subprocess
-import textwrap
 from typing import Optional
 import urllib.parse
 
@@ -230,12 +230,12 @@ class CIAzure(CIBase):
         try:
             common_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()  # noqa: S603
         except subprocess.CalledProcessError as err:
-            msg = """\
+            msg = """
                 The common ancestor commit could not be found.
                 Ensure shallow fetch is disabled for repo checkouts:
                 https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/steps-checkout#shallow-fetch"""
             pprint_subprocess_error(err)
-            LOG.warning(textwrap.dedent(msg))
+            LOG.warning(cleandoc(msg))
             common_commit = None
 
         return common_commit
@@ -250,7 +250,7 @@ class CIAzure(CIBase):
         if diff_base_sha is None:
             return False
 
-        err_msg = """\
+        err_msg = """
             Consider changing the `fetchDepth` property in CI settings to
             clone/fetch more branch history. For more info, reference:
             https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/steps-checkout"""

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -65,6 +65,8 @@ class CIBase(ABC):
         self.ci_platform_name = "Unknown"
         self.disable_lockfile_generation = False
 
+        self._skip_comments = args.skip_comments
+
         # Ensure all pre-requisites are met and bail at the earliest opportunity when they aren't
         self._check_prerequisites()
         LOG.info("All pre-requisites met")
@@ -290,6 +292,11 @@ class CIBase(ABC):
     def force_analysis(self) -> bool:
         """Get the status of forcing an analysis."""
         return self._force_analysis
+
+    @property
+    def skip_comments(self) -> bool:
+        """Get the status of skipping comments."""
+        return self._skip_comments
 
     @cached_property
     def phylum_project(self) -> str:

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -65,7 +65,9 @@ class CIBase(ABC):
         self.ci_platform_name = "Unknown"
         self.disable_lockfile_generation = False
 
-        self._skip_comments = args.skip_comments
+        # Disable comments when in audit mode
+        self.audit_mode = args.audit
+        self._skip_comments = True if self.audit_mode else args.skip_comments
 
         # Ensure all pre-requisites are met and bail at the earliest opportunity when they aren't
         self._check_prerequisites()

--- a/src/phylum/ci/ci_bitbucket.py
+++ b/src/phylum/ci/ci_bitbucket.py
@@ -19,11 +19,11 @@ Bitbucket References:
 
 from argparse import Namespace
 from functools import cached_property, lru_cache
+from inspect import cleandoc
 import os
 import re
 import shlex
 import subprocess
-import textwrap
 from typing import Optional
 import urllib.parse
 
@@ -180,12 +180,12 @@ class CIBitbucket(CIBase):
         try:
             common_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()  # noqa: S603
         except subprocess.CalledProcessError as err:
-            msg = """\
+            msg = """
                 The common ancestor commit could not be found.
                 Ensure git strategy is set to `full clone depth` for repo checkouts:
                 https://support.atlassian.com/bitbucket-cloud/docs/git-clone-behavior/"""
             pprint_subprocess_error(err)
-            LOG.warning(textwrap.dedent(msg))
+            LOG.warning(cleandoc(msg))
             common_commit = None
 
         return common_commit
@@ -200,7 +200,7 @@ class CIBitbucket(CIBase):
         if diff_base_sha is None:
             return False
 
-        err_msg = """\
+        err_msg = """
             Consider changing the `clone depth` variable in CI settings to
             clone/fetch more branch history. For more info, reference:
             https://support.atlassian.com/bitbucket-cloud/docs/git-clone-behavior/"""

--- a/src/phylum/ci/ci_github.py
+++ b/src/phylum/ci/ci_github.py
@@ -13,12 +13,12 @@ GitHub References:
 
 from argparse import Namespace
 from functools import cached_property, lru_cache
+from inspect import cleandoc
 import json
 import os
 from pathlib import Path
 import re
 import subprocess
-import textwrap
 from typing import Optional
 
 import requests
@@ -64,24 +64,24 @@ class CIGitHub(CIBase):
         try:
             subprocess.run(cmd, check=True, capture_output=True, text=True)  # noqa: S603
         except subprocess.CalledProcessError as err:
-            msg = f"""\
+            msg = f"""
                 Adding the GitHub workspace `{github_workspace}` as a safe
                 directory in the git config failed. This is the recommended workaround
                 for container actions, to avoid the `unsafe repository` error.
                 See https://github.com/actions/checkout/issues/766 (git CVE-2022-24765)
                 for more detail."""
-            raise PhylumCalledProcessError(err, textwrap.dedent(msg)) from err
+            raise PhylumCalledProcessError(err, cleandoc(msg)) from err
 
         super().__init__(args)
         self.ci_platform_name = "GitHub Actions"
 
         if os.getenv("GITHUB_EVENT_NAME") == "pull_request_target":
-            msg = """\
+            msg = """
                 Using `pull_request_target` events for forked repositories has security
                 implications if done improperly. Lockfile generation has been disabled
                 to prevent arbitrary code execution in an untrusted context.
                 See https://docs.phylum.io/integrations/github_actions for more detail."""
-            LOG.warning(textwrap.dedent(msg))
+            LOG.warning(cleandoc(msg))
             self.disable_lockfile_generation = True
 
     def _check_prerequisites(self) -> None:
@@ -174,7 +174,7 @@ class CIGitHub(CIBase):
         if pr_base_sha is None:
             return False
 
-        err_msg = """\
+        err_msg = """
             Consider changing the `fetch-depth` input during checkout to fetch more
             branch history. For more info: https://github.com/actions/checkout"""
         self.update_depfiles_change_status(pr_base_sha, err_msg)

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -63,6 +63,7 @@ class CIGitLab(CIBase):
         These are the current pre-requisites for operating within a GitLab CI Environment:
           * The environment must actually be within GitLab CI
           * A GitLab token providing API access is available when operating in an MR pipeline
+            * Unless comment generation is skipped
         """
         super()._check_prerequisites()
 
@@ -77,7 +78,7 @@ class CIGitLab(CIBase):
         # This can be a personal, project, or group access token...and possibly some other types as well.
         # See the GitLab Token Overview Documentation for info: https://docs.gitlab.com/ee/security/token_overview.html
         gitlab_token = os.getenv("GITLAB_TOKEN", "")
-        if not gitlab_token and is_in_mr():
+        if not gitlab_token and is_in_mr() and not self.skip_comments:
             msg = "A GitLab token with API access must be set at `GITLAB_TOKEN`"
             raise SystemExit(msg)
         self._gitlab_token = gitlab_token
@@ -186,12 +187,17 @@ class CIGitLab(CIBase):
         """Post the output of the analysis.
 
         Post output directly in the logs regardless of the pipeline context.
-        Post output as a note (comment) on the GitLab CI Merge Request (MR) when operating in a merge request pipeline.
+        Optionally post output as a note (comment) on the GitLab CI Merge
+        Request (MR) when operating in a merge request pipeline.
         """
         super().post_output()
 
         if not is_in_mr():
             # Can't post the output to the MR when there is no MR
+            return
+
+        if self.skip_comments:
+            LOG.debug("Posting analysis output as notes on the merge request was disabled.")
             return
 
         LOG.info("Checking merge request notes for existing content to avoid duplication ...")
@@ -230,6 +236,13 @@ class CIGitLab(CIBase):
         if not is_in_mr():
             # It only makes sense to reference this property in the context of an MR
             return None
+
+        if self.skip_comments:
+            LOG.debug("Posting analysis output as notes on the merge request was disabled.")
+            if not self.gitlab_token:
+                LOG.debug("GitLab API token not available. Unable to look for notes.")
+                return None
+            LOG.debug("GitLab API token available but possibly invalid. Attempting use ...")
 
         url = get_notes_url()
         LOG.info("Getting all current merge request notes with GET URL: %s ...", url)

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -10,12 +10,12 @@ GitLab References:
 
 from argparse import Namespace
 from functools import cached_property, lru_cache
+from inspect import cleandoc
 import os
 from pathlib import Path
 import re
 import shlex
 import subprocess
-import textwrap
 from typing import Optional
 
 import requests
@@ -143,12 +143,12 @@ class CIGitLab(CIBase):
         try:
             common_commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()  # noqa: S603
         except subprocess.CalledProcessError as err:
-            msg = """\
+            msg = """
                 The common ancestor commit could not be found.
                 Ensure the git strategy is set to `clone` for repo checkouts:
                 https://docs.gitlab.com/ee/ci/runners/configure_runners.html#git-strategy"""
             pprint_subprocess_error(err)
-            LOG.warning(textwrap.dedent(msg))
+            LOG.warning(cleandoc(msg))
             common_commit = None
 
         return common_commit
@@ -163,7 +163,7 @@ class CIGitLab(CIBase):
         if diff_base_sha is None:
             return False
 
-        err_msg = """\
+        err_msg = """
             Consider changing the `GIT_DEPTH` variable in CI settings to
             clone/fetch more branch history. For more info, reference:
             https://docs.gitlab.com/ee/ci/large_repositories/index.html#shallow-cloning"""

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -147,6 +147,13 @@ def get_args(args: Optional[Sequence[str]] = None) -> tuple[argparse.Namespace, 
         "--group",
         help="Optional group name, which will be the owner of the project. Only used when a project is also specified.",
     )
+    analysis_group.add_argument(
+        "-s",
+        "--skip-comments",
+        action="store_true",
+        help="""Specify this flag to disable posting comments/notes on pull/merge requests. This flag is implicitly
+            set when audit mode is enabled.""",
+    )
 
     cli_group = parser.add_argument_group(
         title="Phylum CLI Options",

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -154,6 +154,11 @@ def get_args(args: Optional[Sequence[str]] = None) -> tuple[argparse.Namespace, 
         help="""Specify this flag to disable posting comments/notes on pull/merge requests. This flag is implicitly
             set when audit mode is enabled.""",
     )
+    analysis_group.add_argument(
+        "--audit",
+        action="store_true",
+        help="Specify this flag to enable audit mode: analysis is performed but results do not affect the exit code.",
+    )
 
     cli_group = parser.add_argument_group(
         title="Phylum CLI Options",
@@ -226,8 +231,11 @@ def main(args: Optional[Sequence[str]] = None) -> int:
     # Output the results of the analysis
     ci_env.post_output()
 
-    # Don't return a failure code if the only reason is that analysis results are unknown at this point
+    # Don't return a failure code in audit mode or if analysis results are unknown at this point
     returncode = 0 if ci_env.returncode == ReturnCode.INCOMPLETE else ci_env.returncode.value
+    if ci_env.audit_mode:
+        LOG.info("Audit mode enabled. Original return code: %s", returncode)
+        returncode = 0
     LOG.debug("Return code: %s", returncode)
     return returncode
 

--- a/src/phylum/ci/depfile.py
+++ b/src/phylum/ci/depfile.py
@@ -7,13 +7,13 @@ This module/class represents a single dependency file.
 
 from enum import Enum
 from functools import cache, cached_property
+from inspect import cleandoc
 import json
 import os
 from pathlib import Path
 import shlex
 import shutil
 import subprocess
-import textwrap
 from typing import Optional
 
 from phylum.ci.common import CLIExitCode, DepfileEntry, Package, Packages
@@ -132,24 +132,24 @@ class Depfile:
             )
         except subprocess.CalledProcessError as err:
             if err.returncode == CLIExitCode.MANIFEST_WITHOUT_GENERATION.value:
-                msg = f"""\
+                msg = f"""
                     Provided manifest [code]{self!r}[/] requires lockfile
                     generation to parse but it was disabled to prevent running arbitrary
                     code in untrusted contexts, like PRs from forks. Consider adding a
                     lockfile instead of or along with the manifest, even for libraries."""
-                LOG.warning(textwrap.dedent(msg), extra=MARKUP)
+                LOG.warning(cleandoc(msg), extra=MARKUP)
                 return []
             if self.is_lockfile:
-                msg = f"""\
+                msg = f"""
                     Please report this as a bug if you believe [code]{self!r}[/]
                     is a valid [code]{self.type}[/] lockfile."""
             else:
-                msg = f"""\
+                msg = f"""
                     Consider supplying dependency file type explicitly in `.phylum_project`
                     file. For more info: https://docs.phylum.io/cli/lockfile_generation
                     Please report this as a bug if you believe [code]{self!r}[/]
                     is a valid [code]{self.type}[/] manifest file."""
-            raise PhylumCalledProcessError(err, textwrap.dedent(msg)) from err
+            raise PhylumCalledProcessError(err, cleandoc(msg)) from err
         return sorted(set(curr_depfile_packages))
 
 
@@ -208,11 +208,11 @@ def _is_sandbox_possible(cli_path: Path) -> bool:
     LOG.debug("Executing command: %s", shlex.join(cmd))
     # We want the return code here and don't want to raise when non-zero.
     if bool(subprocess.run(cmd, check=False, capture_output=True).returncode):  # noqa: S603
-        msg = """\
+        msg = """
             Phylum sandbox does not work in this environment and will be disabled.
             This is common and expected for container environments, such as Docker.
             Carefully scrutinize other environments where sandboxing is expected."""
-        LOG.warning(textwrap.dedent(msg))
+        LOG.warning(cleandoc(msg))
         return False
     LOG.info("The Phylum sandbox works in this environment and will be enabled")
     return True

--- a/src/phylum/ci/git.py
+++ b/src/phylum/ci/git.py
@@ -2,11 +2,11 @@
 
 from collections.abc import Generator, Mapping
 import contextlib
+from inspect import cleandoc
 from pathlib import Path
 import shlex
 import subprocess
 import tempfile
-import textwrap
 from typing import Optional
 
 from phylum.exceptions import PhylumCalledProcessError, pprint_subprocess_error
@@ -204,13 +204,13 @@ def git_repo_name(git_c_path: Optional[Path] = None) -> str:
     try:
         full_repo_name = subprocess.run(cmd, check=True, text=True, capture_output=True).stdout.strip()  # noqa: S603
     except subprocess.CalledProcessError as err:
-        msg = """\
+        msg = """
             Getting the git repository name failed. Are all assumptions met:
               * Only a single remote is in use if remotes are used
               * When a remote exists, it points to a URL and not another local repo
               * Cloned local repos without a remote defined have a name that does
                 not end in `.git`"""
-        raise PhylumCalledProcessError(err, textwrap.dedent(msg)) from err
+        raise PhylumCalledProcessError(err, cleandoc(msg)) from err
 
     full_repo_path = Path(full_repo_name)
     repo_name = full_repo_path.name

--- a/src/phylum/github.py
+++ b/src/phylum/github.py
@@ -1,7 +1,7 @@
 """Provide methods for interacting with the GitHub API."""
 
+from inspect import cleandoc
 import os
-import textwrap
 import time
 from typing import Any, Optional
 
@@ -89,7 +89,7 @@ def github_request(
     # The other possible forbidden cases are not common enough to check for here.
     # Reference: https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting
     if resp.status_code == requests.codes.forbidden and rate_limit_remaining == "0":
-        msg = f"""\
+        msg = f"""
             GitHub API rate limit of {rate_limit} requests/hour was exceeded for
             URL: {api_url}
             The current time is:  {current_time}
@@ -98,7 +98,7 @@ def github_request(
             or to make authenticated requests by providing a GitHub token in
             the `GITHUB_TOKEN` environment variable. Reference:
             {PAT_REF}"""
-        raise SystemExit(textwrap.dedent(msg))
+        raise SystemExit(cleandoc(msg))
 
     LOG.debug("%s GitHub API requests remaining until window resets at: %s", rate_limit_remaining, reset_time)
 
@@ -106,11 +106,11 @@ def github_request(
     try:
         resp.raise_for_status()
     except requests.HTTPError as err:
-        msg = f"""\
+        msg = f"""
             A bad request was made to the GitHub API:
             {err}
             Response text: {resp.text.strip()}"""
-        raise SystemExit(textwrap.dedent(msg)) from err
+        raise SystemExit(cleandoc(msg)) from err
 
     resp_json = resp.json()
 

--- a/src/phylum/init/sig.py
+++ b/src/phylum/init/sig.py
@@ -24,8 +24,8 @@ https://raw.githubusercontent.com/phylum-dev/cli/main/scripts/signing-key.pub si
 documentation directs CLI users.
 """
 
+from inspect import cleandoc
 from pathlib import Path
-from textwrap import dedent
 
 from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
 from cryptography.hazmat.backends.openssl import backend
@@ -36,8 +36,8 @@ from phylum.logger import LOG, progress_spinner
 
 # This is the RSA Public Key for Phylum, Inc. The matching private key was used to sign the software releases
 PHYLUM_RSA_PUBKEY = bytes(
-    dedent(
-        """\
+    cleandoc(
+        """
         -----BEGIN PUBLIC KEY-----
         MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyGgvuy6CWSgJuhKY8oVz
         42udH1F2yIlaBoxAdQFuY2zxPSSpK9zv34B7m0JekuC5WCYfW0gS2Z8Ryu2RVdQh

--- a/tests/functional/test_init.py
+++ b/tests/functional/test_init.py
@@ -50,7 +50,7 @@ def test_phylum_pubkey_is_constant(tmp_path):
     phylum_pubkey_url = "https://raw.githubusercontent.com/phylum-dev/cli/main/scripts/signing-key.pub"
     downloaded_key_path: Path = tmp_path / "signing-key.pub"
     save_file_from_url(phylum_pubkey_url, downloaded_key_path)
-    assert downloaded_key_path.read_bytes() == sig.PHYLUM_RSA_PUBKEY, "The key should not be changing"
+    assert downloaded_key_path.read_bytes().strip() == sig.PHYLUM_RSA_PUBKEY, "The key should not be changing"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_sig.py
+++ b/tests/unit/test_sig.py
@@ -1,6 +1,6 @@
 """Test the signature verification module."""
 
-from textwrap import dedent
+from inspect import cleandoc
 
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import load_pem_public_key
@@ -15,7 +15,7 @@ def test_phylum_pubkey_is_bytes():
 
 def test_phylum_pubkey_is_constant():
     """Ensure the RSA public key in use by Phylum has not changed."""
-    key_text = """\
+    key_text = """
         -----BEGIN PUBLIC KEY-----
         MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyGgvuy6CWSgJuhKY8oVz
         42udH1F2yIlaBoxAdQFuY2zxPSSpK9zv34B7m0JekuC5WCYfW0gS2Z8Ryu2RVdQh
@@ -26,7 +26,7 @@ def test_phylum_pubkey_is_constant():
         sQIDAQAB
         -----END PUBLIC KEY-----
         """
-    expected_key = bytes(dedent(key_text), encoding="ASCII")
+    expected_key = bytes(cleandoc(key_text), encoding="ASCII")
     assert expected_key == sig.PHYLUM_RSA_PUBKEY, "The key should not be changing"
 
 


### PR DESCRIPTION
This change introduces audit mode in the form of an `--audit` flag. It also adds a `--skip-comments`/`-s` flag to disable posting comments/notes on pull/merge requests. This flag is implicitly set when audit mode is enabled. The documentation was updated to match. Additionally, a change was made to use `inspect.cleandoc` instead of `textwrap.dedent` everywhere. Using `cleandoc` is preferred since it allows for removing the ugly line continuation character from multiline strings.

Closes #396
Closes #311

## Testing

A Docker image was created with the changes in this PR and hosted [under my account](https://hub.docker.com/repository/docker/maxrake/phylum-ci/tags) as the `audit_mode` tag. It was used to test the CI environments. Results were good.