### PR TITLE
feat: ensure Bitbucket repo URLs use HTTPS scheme

### DIFF
--- a/src/phylum/ci/ci_bitbucket.py
+++ b/src/phylum/ci/ci_bitbucket.py
@@ -220,7 +220,16 @@ class CIBitbucket(CIBase):
         # This is the "URL for the origin", which uses `HTTP:` instead of
         # `HTTPS:`, even though the value redirects to the `HTTPS:` site.
         # Ref: https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
-        return os.getenv("BITBUCKET_GIT_HTTP_ORIGIN")
+        origin_url = os.getenv("BITBUCKET_GIT_HTTP_ORIGIN")
+        if origin_url is None:
+            LOG.warning("Repository URL not found at `BITBUCKET_GIT_HTTP_ORIGIN`")
+            return None
+
+        # Ensure the repository URL uses the HTTPS scheme
+        parsed_url = urllib.parse.urlparse(origin_url)
+        if parsed_url.scheme == "http":
+            parsed_url = parsed_url._replace(scheme="https")
+        return parsed_url.geturl()
 
     def post_output(self) -> None:
         """Post the output of the analysis.

--- a/src/phylum/init/cli.py
+++ b/src/phylum/init/cli.py
@@ -249,7 +249,7 @@ def get_archive_url(tag_name: str, archive_name: str) -> str:
     return archive_url
 
 
-def is_token_set(phylum_settings_path, token=None):
+def is_token_set(phylum_settings_path: Path, token: Optional[str] = None) -> bool:
     """Check if any token is already set in the given CLI configuration file.
 
     Optionally, check if a specific given `token` is set.
@@ -260,13 +260,14 @@ def is_token_set(phylum_settings_path, token=None):
         return False
 
     yaml = YAML()
-    settings_dict = yaml.load(settings_data)
-    configured_token = settings_dict.get("auth_info", {}).get("offline_access")
+    settings_dict: dict = yaml.load(settings_data)
+    auth_info_dict: dict = settings_dict.get("auth_info", {})
+    configured_token = auth_info_dict.get("offline_access")
 
     if configured_token is None:
         return False
-    if token is not None and token != configured_token:
-        return False
+    if token is not None:
+        return token == configured_token
 
     return True
 


### PR DESCRIPTION
This change was made after discovering that Atlassian Compass components
recognize Bitbucket repository URLs only when they are `HTTPS:` and not
when they are `HTTP:`, even though that is how the URL is provided when
obtained by getting the `BITBUCKET_GIT_HTTP_ORIGIN` environment variable
value.

Additionally, the `is_token_set` function was refactored to adhere to
the new `ruff` preview rule `SIM103`. The latest release of `ruff`
introduced the new linting rule [SIM103: needless-bool](https://docs.astral.sh/ruff/rules/needless-bool),
which causes the code in question to fail when run in preview mode. This
change was made now to get ahead of the rule, for when it enforces the
implicit `else` cases by default. The change was made in a way that
seeks to maintain readability and intent. Type annotations were added to
the affected function as well.

## Testing / Screenshots

What a Bitbucket pipeline looks like when run with the changes from this PR:

<img width="1336" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/eb942f46-6a21-40c9-9630-88eea1735b56">

---

Updating the repo URL manually:

```
❯ phylum project list -g integrations
Project Name  Project ID                            Repository URL
---TRIMMED---
TestBB        935bdc06-13e8-4ead-a2b7-e679c69b8970  http://bitbucket.org/phylum-maxrake/testbb
---TRIMMED

❯ phylum project update -i 935bdc06-13e8-4ead-a2b7-e679c69b8970 -g integrations -r https://bitbucket.org/phylum-maxrake/testbb
✅ Successfully updated project "935bdc06-13e8-4ead-a2b7-e679c69b8970" (group "integrations"):
      Name: "TestBB" -> "TestBB"
      Repository URL: "http://bitbucket.org/phylum-maxrake/testbb" -> "https://bitbucket.org/phylum-maxrake/testbb"

❯ phylum project list -g integrations
Project Name  Project ID                            Repository URL
---TRIMMED---
TestBB        935bdc06-13e8-4ead-a2b7-e679c69b8970  https://bitbucket.org/phylum-maxrake/testbb
---TRIMMED---
```

---

Re-running the pipeline:

<img width="1336" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/5bbf2d04-b81a-43b8-b893-2d2e01b521d1">
