### PR TITLE
docs: recommend triggering scans for default branch

### DIFF
--- a/docs/integrations/azure_pipelines.md
+++ b/docs/integrations/azure_pipelines.md
@@ -116,7 +116,8 @@ Let's take a deeper dive into each part of the configuration:
 ### Pipeline control
 
 Choose when to run the pipeline. See the YAML schema [trigger definition][yaml_trigger] and [pr definition][yaml_pr]
-documentation for more detail.
+documentation for more detail. It is recommended to enable CI triggered branch pipelines for pushes to the default
+branch, to ensure the Phylum analysis results for that branch are current.
 
 ```yaml
 # This is a CI trigger that will cause the

--- a/docs/integrations/bitbucket_pipelines.md
+++ b/docs/integrations/bitbucket_pipelines.md
@@ -151,6 +151,19 @@ pipelines:
         # Add the Phylum Analyze step here
 ```
 
+If the `default` pipeline start condition is not used, it is recommended to at least enable the `branches` pipeline
+start condition for the default branch. That way, Phylum analysis results will stay current with updates to the default
+branch.
+
+```yaml
+pipelines:
+  # Pipeline definition for specific branches
+  branches:
+    main:   # The name of the default branch
+      - step:
+          # Add the Phylum Analyze step here
+```
+
 [start_conditions]: https://support.atlassian.com/bitbucket-cloud/docs/pipeline-start-conditions/
 
 ### Step name

--- a/docs/integrations/gitlab_ci.md
+++ b/docs/integrations/gitlab_ci.md
@@ -115,7 +115,22 @@ workflow:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS
       when: never
+      # This next rule will trigger for pushes to any branch
     - if: $CI_COMMIT_BRANCH
+```
+
+It is recommended to allow branch pipelines for pushes to the default branch, to ensure the Phylum analysis results for
+that branch are current. This modification to the previous example will allow for merge request pipelines and pushes
+specifically to the default branch:
+
+```yaml
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS
+      when: never
+      # This next rule will trigger for pushes only to the default branch
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 ```
 
 See the [GitLab CI/CD Job Control][job_control] documentation for more detail.


### PR DESCRIPTION
This change updates the docs for the integrations that allow for triggering Phylum analysis upon pushes to the default branch: GitLab CI, Azure Pipelines, and Bitbucket Pipelines (GitHub Actions currently only runs in the context of `pull_request` webhook events).

The change is made to coincide with the upcoming platform feature enabling default labels. It is meant to ensure the Phylum analysis results for the branch associated with that label are current.
