### PR TITLE
fix: account for `cargo_suffix` in CLI version

### DIFF
--- a/src/phylum/init/cli.py
+++ b/src/phylum/init/cli.py
@@ -68,7 +68,7 @@ def get_phylum_cli_version(cli_path: Path) -> str:
     except subprocess.CalledProcessError as err:
         msg = "There was an error retrieving the Phylum CLI version"
         raise PhylumCalledProcessError(err, msg) from err
-    version = version.removeprefix("phylum ")
+    version = version.removeprefix("phylum ").removesuffix("+")
     return version
 
 


### PR DESCRIPTION
This fix accounts for the possibility of the Phylum CLI version reporting with a trailing `+` character. This is the `cargo_suffix` and indicates when the version was obtained by Cargo instead of git, which happens for homebrew installed instances of the Phylum CLI.

The fix here simply removes any trailing `+` character when obtaining the version from a `phylum --version` command. This approach allows the rest of the version checking/handling code to remain intact.

References:

* [Phylum CLI code](https://github.com/phylum-dev/cli/blob/a9c29420322f866880d11df48c9c324fbe7911b9/cli/src/app.rs#L8)
* [`git_version` crate docs](https://docs.rs/git-version/0.3.9/git_version/macro.git_version.html)
* [`CARGO_PKG_VERSION` envvar docs](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates)

Fixes #432
