### PR TITLE
docs: update docs based on user feedback

### DIFF
--- a/docs/integrations/azure_pipelines.md
+++ b/docs/integrations/azure_pipelines.md
@@ -99,7 +99,7 @@ jobs:
       - checkout: self
         fetchDepth: 0
         persistCredentials: true
-      - script: phylum-ci
+      - script: phylum-ci -vv
         displayName: Analyze dependencies with Phylum
         env:
           PHYLUM_API_KEY: $(PHYLUM_TOKEN)
@@ -108,8 +108,8 @@ jobs:
 ```
 
 This single stage pipeline configuration contains a single container job named `Phylum`, triggered to run on pushes
-or PRs targeting the `main` branch. It does not override any of the `phylum-ci` arguments, which are all either
-optional or default to secure values.
+or PRs targeting the `main` branch. It provides debug output but otherwise does not override any of the `phylum-ci`
+arguments, which are all either optional or default to secure values.
 
 Let's take a deeper dive into each part of the configuration:
 
@@ -290,7 +290,7 @@ view the [script options output][script_options] for the latest release.
       # against the active policy set at the Phylum project level.
       - script: phylum-ci
 
-      # Provide debug level output.
+      # Provide debug level output. Highly recommended.
       - script: phylum-ci -vv
 
       # Consider all dependencies in analysis results instead of just the newly added ones.

--- a/docs/integrations/bitbucket_pipelines.md
+++ b/docs/integrations/bitbucket_pipelines.md
@@ -18,7 +18,7 @@ conditions:
         clone:
           depth: full
         script:
-          - phylum-ci
+          - phylum-ci -vv
 ```
 
 ## Overview
@@ -88,7 +88,7 @@ pipelines:
           clone:
             depth: full
           script:
-            - phylum-ci
+            - phylum-ci -vv
   default:
     - step:
         name: Phylum Analyze branch
@@ -96,12 +96,13 @@ pipelines:
         clone:
           depth: full
         script:
-          - phylum-ci
+          - phylum-ci -vv
 ```
 
 This configuration contains pipeline definitions for the `pull-requests` and `default` start conditions. It will
-run for _all_ pull requests and pushes to _any_ branch. It does not override any of the `phylum-ci` arguments, which
-are all either optional or default to secure values. Let's take a deeper dive into each part of the configuration:
+run for _all_ pull requests and pushes to _any_ branch. It provides debug output but otherwise does not override any of
+the `phylum-ci` arguments, which are all either optional or default to secure values. Let's take a deeper dive into
+each part of the configuration:
 
 ### User-defined variables
 
@@ -287,7 +288,7 @@ view the [script options output][script_options] for the latest release.
     # against the active policy set at the Phylum project level.
     - phylum-ci
 
-    # Provide debug level output.
+    # Provide debug level output. Highly recommended.
     - phylum-ci -vv
 
     # Consider all dependencies in analysis results instead of just the newly added ones.

--- a/docs/integrations/git_precommit.md
+++ b/docs/integrations/git_precommit.md
@@ -168,3 +168,23 @@ with `--help` output as specified in the [Usage section of the top-level README.
           - --force-analysis
           - --all-deps
 ```
+
+### Audit Mode
+
+It is possible to use the Phylum hook in an audit mode, where analysis is performed but results do not affect the exit
+code. To do so, update the `args` to include the `--audit` flag and add the `verbose: true` mapping to the hook
+configuration. That will ensure the output of the hook is printed every time so it can be examined during the audit
+period.
+
+```yaml
+repos:
+  - repo: https://github.com/phylum-dev/phylum-ci
+    rev: main
+    hooks:
+      - id: phylum
+        # Additional args are possible, but `--audit` is the new one.
+        args: [--audit]
+        # Since the hook will always pass in audit mode, forcing the output of the
+        # hook to be printed will ensure failures have a chance of being noticed.
+        verbose: true
+```

--- a/docs/integrations/github_actions.md
+++ b/docs/integrations/github_actions.md
@@ -33,6 +33,10 @@ GitHub Action. That is possible with either [container jobs](#container-jobs) or
 
 ### Container Jobs
 
+> ⚠️ **NOTE:** The alternative configuration offered here is only meant to be used if the default `phylum-ci` Docker
+> image is not acceptable for any reason. Otherwise, use the [GitHub action][marketplace] directly and view it's
+> documentation for configuration instead.
+
 GitHub Actions allows for workflows to run a job within a container, using the `container:` statement in the
 workflow file. These are known as container jobs. More information can be found in GitHub documentation:
 ["Running jobs in a container"][container_job]. To use a `slim` tag in a container job, use this minimal
@@ -49,6 +53,10 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     container:
+      # This `slim` tag is smaller than the `latest` tag
+      # but does not contain all the required tools for
+      # lockfile generation. If that is desired, use the
+      # `phylum-dev/phylum-analyze-pr-action` action instead.
       image: docker://ghcr.io/phylum-dev/phylum-ci:slim
       env:
         GITHUB_TOKEN: ${{ github.token }}
@@ -76,6 +84,10 @@ Those environment variables and the rest of the options are more fully documente
 
 ### Container Steps
 
+> ⚠️ **NOTE:** The alternative configuration offered here is only meant to be used if the default `phylum-ci` Docker
+> image is not acceptable for any reason. Otherwise, use the [GitHub action][marketplace] directly and view it's
+> documentation for configuration instead.
+
 GitHub Actions allows for workflows to run a step within a container, by specifying that container image in
 the `uses:` statement of the workflow step. These are known as container steps. More information can be found
 in [GitHub workflow syntax documentation][container_step]. To use a `slim` tag in a container step, use this
@@ -97,6 +109,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Analyze dependencies
+        # This `slim` tag is smaller than the `latest` tag
+        # but does not contain all the required tools for
+        # lockfile generation. If that is desired, use the
+        # `phylum-dev/phylum-analyze-pr-action` action instead.
         uses: docker://ghcr.io/phylum-dev/phylum-ci:slim
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/docs/integrations/gitlab_ci.md
+++ b/docs/integrations/gitlab_ci.md
@@ -68,12 +68,12 @@ analyze_MR_with_Phylum:
     GITLAB_TOKEN: $GITLAB_TOKEN_VARIABLE_OR_SECRET_HERE
     PHYLUM_API_KEY: $PHYLUM_TOKEN_VARIABLE_OR_SECRET_HERE
   script:
-    - phylum-ci
+    - phylum-ci -vv
 ```
 
 This configuration contains a single Quality Assurance stage named QA and will only run in merge request pipelines.
-It does not override any of the `phylum-ci` arguments, which are all either optional or default to secure values.
-Let's take a deeper dive into each part of the configuration:
+It provides debug output but otherwise does not override any of the `phylum-ci` arguments, which are all either
+optional or default to secure values. Let's take a deeper dive into each part of the configuration:
 
 ### Stage and Job names
 
@@ -276,7 +276,7 @@ view the [script options output][script_options] for the latest release.
     # against the active policy set at the Phylum project level.
     - phylum-ci
 
-    # Provide debug level output.
+    # Provide debug level output. Highly recommended.
     - phylum-ci -vv
 
     # Consider all dependencies in analysis results instead of just the newly added ones.


### PR DESCRIPTION
This change seeks to improve the integration documentation by acting on user feedback. In particular, the following suggestions were taken:

* Add detail on how to use audit mode with the `pre-commit` hook
* Make debug/verbose output the default in recommended CI configurations
* Be more explicit about the GitHub Action options
  * The default action uses the `latest` tag from the `phylum-ci` Docker image and should be used unless there is a good reason not to
  * The alternative options have callouts and notes now making it more clear that their configurations should only be used if the default action does not suffice

A separate PR will be made in the `phylum-analyze-pr-action` repo, to include the same changes here.