### PR TITLE
ci: ensure forced patch releases are possible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Set to next version for build
         run: |
           next_ver=$(poetry run semantic-release -vv version --print)
+          echo "PSR_EXPECTED_NEXT_VER=${next_ver}" >> "${GITHUB_ENV}"
           if [ "${{ env.PHYLUM_ORIGINAL_VER }}" = "${next_ver}" ]; then
             if [ "${{ inputs.prerelease }}" = "true" ]; then
               next_ver=$(poetry run semantic-release -vv --strict version --print --as-prerelease --patch)
@@ -103,7 +104,6 @@ jobs:
             fi
           fi
           poetry version "${next_ver}"
-          echo "PHYLUM_NEXT_VER=${next_ver}" >> "${GITHUB_ENV}"
 
       - name: Set PHYLUM_REL_VER value
         run: echo "PHYLUM_REL_VER=$(poetry version --short)" >> "${GITHUB_ENV}"
@@ -150,7 +150,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         run: |
-          if [ "${{ env.PHYLUM_ORIGINAL_VER }}" = "${{ env.PHYLUM_NEXT_VER }}" ]; then
+          if [ "${{ env.PHYLUM_ORIGINAL_VER }}" = "${{ env.PSR_EXPECTED_NEXT_VER }}" ]; then
             if [ "${{ inputs.prerelease }}" = "true" ]; then
               poetry run semantic-release -vv --strict version --as-prerelease --patch
             else


### PR DESCRIPTION
This change fixes a small logic error in the release process. The value used to compare whether a release needs to be forced as a patch release (due to no bump-worthy changes found by Python Semantic Release) was overwritten before it was saved off. That is no longer the case. The environment variable name was also changed to make the difference between what Python Semantic Release thinks the next release version should be and what the actual next release version will be more obvious.
