### PR TITLE
ci: update to latest Phylum GitHub action

### DIFF
--- a/.github/workflows/phylum_analyze_pr.yml
+++ b/.github/workflows/phylum_analyze_pr.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           fetch-depth: 0
       - name: Analyze poetry.lock file
-        uses: phylum-dev/phylum-analyze-pr-action@53d203dd18c41350a673bcc236aa05337eb6edf3 # v2.1.1
+        uses: phylum-dev/phylum-analyze-pr-action@f428af5c1ee8a705740d51b67424106012740f38 # v2.2.0
         with:
           phylum_token: ${{ secrets.PHYLUM_TOKEN }}
-          cmd: phylum-ci -vv


### PR DESCRIPTION
The `phylum-analyze-pr-action` was recently updated to make debug output the default. A new tag and release was created for that action to include the change. This PR updates the action to that version and removes the custom `cmd` entry since it is no longer different than the default.
