### PR TITLE
feat: add support for Jenkins Pipelines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -205,7 +205,7 @@ COPY --from=builder ${PHYLUM_VENV} ${PHYLUM_VENV}
 # Ref: https://github.com/hadolint/hadolint/wiki/DL4006
 SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
 RUN \
-    # Install pre-requisites and package manager versions for `npm`, `bundle`, and `mvn` tools
+    # Install prerequisites and package manager versions for `npm`, `bundle`, and `mvn` tools
     apt-get update; \
     apt-get upgrade --yes; \
     apt-get install --yes --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -277,9 +277,11 @@ RUN \
     rm ms-prod.deb; \
     apt-get update; \
     apt-get install --yes --no-install-recommends "dotnet-sdk-${DOTNET_SDK_LATEST_CHANNEL_VER}"; \
+    #
     # Create a git config file in a location accessible for $HOME-less users
     # Ref: https://git-scm.com/docs/git-config#FILES
     mkdir -vp "${XDG_CONFIG_HOME}/git" && touch "${XDG_CONFIG_HOME}/git/config"; \
+    #
     # Ensure non-root users have necessary permissions
     mkdir -vp "${XDG_DATA_HOME}" "${XDG_CONFIG_HOME}" "${XDG_STATE_HOME}" "${XDG_CACHE_HOME}"; \
     chmod -vR 777 "${XDG_DATA_HOME}" "${XDG_CONFIG_HOME}" "${XDG_STATE_HOME}" "${XDG_CACHE_HOME}"; \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -177,7 +177,7 @@ ENV XDG_CACHE_HOME="${INSTALL_DIR}/.cache"
 COPY --from=builder ${PHYLUM_VENV} ${PHYLUM_VENV}
 
 RUN set -eux; \
-    # Install pre-requisites
+    # Install prerequisites
     apt-get update; \
     apt-get upgrade --yes; \
     apt-get install --yes --no-install-recommends git binutils; \

--- a/docs/integrations/azure_pipelines.md
+++ b/docs/integrations/azure_pipelines.md
@@ -30,9 +30,9 @@ the CI pipeline job will only fail if dependencies that have _completed analysis
 ## Prerequisites
 
 The Azure Pipelines environment is primarily supported through the use of a Docker image.
-The pre-requisites for using this image are:
+The prerequisites for using this image are:
 
-* Access to the [phylumio/phylum-ci Docker image][docker_image]
+* Access to the [`phylumio/phylum-ci` Docker image][docker_image]
 * Azure DevOps Services is used with an [Azure Repos Git][azure_repos_git] or [GitHub][github_repos] repository type
   * Azure DevOps Server versions are not guaranteed to work at this time
   * Bitbucket Cloud hosted repositories are not supported at this time

--- a/docs/integrations/bitbucket_pipelines.md
+++ b/docs/integrations/bitbucket_pipelines.md
@@ -45,10 +45,10 @@ the CI job will only fail if dependencies that have _completed analysis results_
 Bitbucket Cloud is supported for repositories hosted on [https://bitbucket.org/](https://bitbucket.org/).
 Bitbucket Data Center is not currently supported.
 
-The Bitbucket Pipelines environment is primarily supported through the use of a Docker image. The pre-requisites
+The Bitbucket Pipelines environment is primarily supported through the use of a Docker image. The prerequisites
 for using this image are:
 
-* Access to the [phylumio/phylum-ci Docker image][docker_image]
+* Access to the [`phylumio/phylum-ci` Docker image][docker_image]
 * A [Bitbucket access token][bb_tokens] with API access
   * This is only required when:
     * Using the integration in pull request pipelines

--- a/docs/integrations/git_precommit.md
+++ b/docs/integrations/git_precommit.md
@@ -18,7 +18,7 @@ dependencies that have _completed analysis results_ do not meet the active polic
 
 ## Prerequisites
 
-The pre-requisites for using the git `pre-commit` hook are:
+The prerequisites for using the git `pre-commit` hook are:
 
 * The [pre-commit] package manager installed
 * A [Phylum token][phylum_tokens] with API access

--- a/docs/integrations/github_actions.md
+++ b/docs/integrations/github_actions.md
@@ -33,7 +33,9 @@ GitHub Action. That is possible with either [container jobs](#container-jobs) or
 
 ### Container Jobs
 
-> ⚠️ **NOTE:** The alternative configuration offered here is only meant to be used if the default `phylum-ci` Docker
+> ⚠️ **INFO** ⚠️
+>
+> The alternative configuration offered here is only meant to be used if the default `phylum-ci` Docker
 > image is not acceptable for any reason. Otherwise, use the [GitHub action][marketplace] directly and view it's
 > documentation for configuration instead.
 
@@ -84,7 +86,9 @@ Those environment variables and the rest of the options are more fully documente
 
 ### Container Steps
 
-> ⚠️ **NOTE:** The alternative configuration offered here is only meant to be used if the default `phylum-ci` Docker
+> ⚠️ **INFO** ⚠️
+>
+> The alternative configuration offered here is only meant to be used if the default `phylum-ci` Docker
 > image is not acceptable for any reason. Otherwise, use the [GitHub action][marketplace] directly and view it's
 > documentation for configuration instead.
 

--- a/docs/integrations/gitlab_ci.md
+++ b/docs/integrations/gitlab_ci.md
@@ -25,9 +25,9 @@ The GitLab CI environment is primarily supported through the use of a Docker ima
 hosted on [https://gitlab.com](https://gitlab.com) are supported. [Self-managed subscriptions][self_managed] are
 supported for "on-premises" installs which still have access to the internet. Self-hosted "offline" (e.g., air-gapped networks) installs of GitLab may work but have not been confirmed.
 
-The pre-requisites for using this image are:
+The prerequisites for using this image are:
 
-* Access to the [phylumio/phylum-ci Docker image][docker_image]
+* Access to the [`phylumio/phylum-ci` Docker image][docker_image]
 * A [GitLab token][gitlab_tokens] with API access
   * This is only required when:
     * Using the integration in merge request pipelines

--- a/docs/integrations/jenkins.md
+++ b/docs/integrations/jenkins.md
@@ -1,0 +1,346 @@
+# Jenkins Pipelines Integration
+
+## Quickstart
+
+1. Create a new "secret text" [credential] containing a [Phylum authentication token][phylum_tokens].
+The credential ID should be specified since it will be used in the `Jenkinsfile` (e.g., `phylum-token`).
+
+1. Add the following "Phylum" stage to an existing `Jenkinsfile` declarative pipeline configuration:
+
+```groovy
+        stage('Phylum') {
+            agent {
+                docker {
+                    image 'phylumio/phylum-ci:latest'
+                    alwaysPull true
+                }
+            }
+            environment {
+                // The environment variable must be named like
+                // this but the credential ID can be different.
+                PHYLUM_API_KEY = credentials('phylum-token')
+            }
+            steps {
+                // The `--force-analysis` and `--all-deps` flags
+                // are needed because this configuration has no
+                // history available for computing changes.
+                sh 'phylum-ci -vv --force-analysis --all-deps'
+            }
+        }
+```
+
+> ⚠️ **INFO** ⚠️
+>
+> This is a limited configuration that provides the current state of **all** dependencies.
+> It does not account for newly added or modified dependencies like would be found in a branch or pull request.
+> Please see the rest of this documentation for more comprehensive configuration options.
+
+[credential]: https://www.jenkins.io/doc/book/using/using-credentials/
+[phylum_tokens]: ../knowledge_base/api-keys.md
+
+## Overview
+
+Once configured for a repository as part of a multibranch pipeline project, the Jenkins Pipelines integration will
+provide analysis of project dependencies from manifests and lockfiles. This can happen as a result of a commit or a
+pull request (PR).
+
+For PR pipelines, analyzed dependencies will include any that are added/modified in the PR. For branch pipelines, the
+analyzed dependencies will be determined by comparing dependency files in the branch to the default branch. **All**
+dependencies will be analyzed when the branch pipeline is run on the default branch.
+
+Results are provided in the pipeline logs. The CI job will return an error (i.e., fail the build) if any of the
+analyzed dependencies fail to meet the established policy unless audit mode is specified. If one or more dependencies
+are still processing (no results available), then the logs will make that clear and the CI job will only fail if
+dependencies that have _completed analysis results_ do not meet the active policy.
+
+## Prerequisites
+
+Jenkins is supported for multibranch pipelines through the use of a Docker image.
+The prerequisites for using this image are:
+
+* Access to the [`phylumio/phylum-ci` Docker image][docker_image]
+* A [Phylum token][phylum_tokens] with API access
+  * [Contact Phylum][phylum_contact] or [register][app_register] to gain access
+    * See also [`phylum auth register`][phylum_register] command documentation
+  * Consider using a bot or group account for this token
+* Access to the Phylum API endpoints
+  * That usually means a connection to the internet, optionally via a proxy
+
+[docker_image]: https://hub.docker.com/r/phylumio/phylum-ci/tags
+[phylum_contact]: https://phylum.io/contact-us/
+[app_register]: https://app.phylum.io/register
+[phylum_register]: ../cli/commands/phylum_auth_register.md
+
+## Configure `Jenkinsfile`
+
+Phylum analysis of dependencies can be added to existing pipelines or on it's own with this minimal declarative
+pipeline configuration:
+
+```groovy
+pipeline {
+    agent none
+    stages {
+        stage('Phylum') {
+            agent {
+                docker {
+                    image 'phylumio/phylum-ci:latest'
+                    alwaysPull true
+                }
+            }
+            environment {
+                PHYLUM_API_KEY = credentials('phylum-token')
+            }
+            options {
+                // This is optional but may save time since
+                // a full checkout is needed later.
+                skipDefaultCheckout()
+            }
+            steps {
+                checkout scmGit(
+                    branches: [[name: '**']],
+                    extensions: [cleanBeforeCheckout()],
+                    // Change to match your repository URL and creds.
+                    userRemoteConfigs: [[
+                        credentialsId: 'CHANGEME',
+                        url: 'https://github.com/CHANGEME/CHANGEME.git'
+                    ]]
+                )
+                withCredentials([gitUsernamePassword(credentialsId: 'CHANGEME', gitToolName: 'Default')]) {
+                    sh 'phylum-ci -vv'
+                }
+            }
+            post {
+                always {
+                    // Cleaning the workspace ensures the git
+                    // checkout is valid for future runs.
+                    cleanWs()
+                }
+            }
+        }
+    }
+}
+```
+
+This configuration contains a single stage named "Phylum" which executes from a custom Docker image. It will run for
+_all_ pull requests and pushes to _any_ branch. It provides debug output but otherwise does not override any of
+the `phylum-ci` arguments, which are all either optional or default to secure values. Let's take a deeper dive into
+each part of the configuration:
+
+### Docker image selection
+
+Choose the Docker image tag to match your comfort level with image dependencies. `latest` is a "rolling" tag that
+will point to the image created for the latest released `phylum-ci` Python package. A particular version tag
+(e.g., `0.42.4-CLIv6.1.2`) is created for each release of the `phylum-ci` Python package and _should_ not change
+once published.
+
+However, to be certain that the image does not change...or be warned when it does because it won't be available
+anymore...use the SHA256 digest of the tag. The digest can be found by looking at the `phylumio/phylum-ci`
+[tags on Docker Hub][docker_image] or with the command:
+
+```sh
+# NOTE: The command-line JSON processor `jq` is used here for the sake of a one line example. It is not required.
+❯ docker manifest inspect --verbose phylumio/phylum-ci:0.42.4-CLIv6.1.2 | jq .Descriptor.digest
+"sha256:77b761ccef10edc28b0f009a40fbeab240bf004522edaaea05572dc3728b6ca6"
+```
+
+For instance, at the time of this writing, all of these tag references pointed to the same image:
+
+```groovy
+            agent {
+                docker {
+                    // NOTE: These are examples. Only one image line for `phylum-ci` is expected.
+                    //
+                    // Not specifying a tag means a default of `latest`
+                    image 'phylumio/phylum-ci'
+                    // Be more explicit about wanting the `latest` tag
+                    image 'phylumio/phylum-ci:latest'
+                    // Use a specific release version of the `phylum-ci` package
+                    image 'phylumio/phylum-ci:0.42.4-CLIv6.1.2'
+                    // Use a specific image with it's SHA256 digest
+                    image 'phylumio/phylum-ci@sha256:77b761ccef10edc28b0f009a40fbeab240bf004522edaaea05572dc3728b6ca6'
+
+                    // This option is useful when image is NOT specified by hash
+                    alwaysPull true
+                }
+            }
+```
+
+Only the last tag reference, by SHA256 digest, is guaranteed to not have the underlying image it points to change.
+If digest references are not used, it is recommended to enable the setting to always pull the image, especially if the
+"latest" tag is configured. That way, the latest changes will be used instead of the ones when the tag was first pulled.
+
+The default `phylum-ci` Docker image contains `git` and the installed `phylum` Python package. It also contains an
+installed version of the Phylum CLI and all required tools needed for [lockfile generation][lockfile_generation].
+An advantage of using the default Docker image is that the complete environment is packaged and made available
+with components that are known to work together.
+
+One disadvantage to the default image is it's size. It can take a while to download and may provide more
+tools than required for your specific use case. Special `slim` tags of the `phylum-ci` image are provided as
+an alternative. These tags differ from the default image in that they do not contain the required tools needed
+for [lockfile generation][lockfile_generation] (with the exception of the `pip` tool). The `slim` tags are
+significantly smaller and allow for faster action run times. They are useful for those instances where **no**
+manifest files are present and/or **only** lockfiles are used.
+
+Here are examples of using the slim image tags:
+
+```groovy
+            agent {
+                docker {
+                    // NOTE: These are examples. Only one image line for `phylum-ci` is expected.
+                    //
+                    // Use the most current release of *both* `phylum-ci` and the Phylum CLI
+                    image 'phylumio/phylum-ci:slim'
+                    // Use the `slim` image with a specific release version of `phylum-ci` and Phylum CLI
+                    image 'phylumio/phylum-ci:0.42.4-CLIv6.1.2-slim'
+
+                    // This option is useful when image is NOT specified by hash
+                    alwaysPull true
+                }
+            }
+```
+
+See the documentation for [using Docker with Pipeline][docker_pipeline] more information.
+
+[lockfile_generation]: ../cli/lockfile_generation.md
+[docker_pipeline]: https://www.jenkins.io/doc/book/pipeline/docker/
+
+### User-defined variables
+
+A [Phylum token][phylum_tokens] with API access is required to perform analysis on project dependencies.
+[Contact Phylum][phylum_contact] or [register][app_register] to gain access.
+See also [`phylum auth register`][phylum_register] command documentation and consider using a bot or group account
+for this token.
+
+Provide the token value in a [user-defined variable][user_vars] named `PHYLUM_API_KEY`, set at the stage level or
+higher. The value for this variable is sensitive and should be set as a secret text [credential].
+**Care should be taken to protect it appropriately**.
+
+```groovy
+            environment {
+                // Variable must be named `PHYLUM_API_KEY`
+                // but the credential ID can be different.
+                PHYLUM_API_KEY = credentials('phylum-token')
+            }
+```
+
+[user_vars]: https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#setting-environment-variables
+
+### Git checkout step
+
+The `git` version control system is used within the `phylum-ci` package to do things like determine if there was a
+dependency file change and, when specified, report on new dependencies only. Therefore, a full clone of the
+repository is required to ensure that the local working copy is always pristine and history is available to pull the
+requested information.
+
+```groovy
+            steps {
+                // A full checkout is needed to provide history and proper diffs.
+                // A `checkout scm` step is not enough here.
+                checkout scmGit(
+                    branches: [[name: '**']],
+                    extensions: [cleanBeforeCheckout()],
+                    // Change to match your repository URL and creds.
+                    userRemoteConfigs: [[
+                        credentialsId: 'CHANGEME',
+                        url: 'https://github.com/CHANGEME/CHANGEME.git'
+                    ]]
+                )
+            }
+```
+
+See the [checkout step][checkout_step] and [checkout plugin][scm_plugin] documentation for more information.
+
+[checkout_step]: https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step/
+[scm_plugin]: https://plugins.jenkins.io/workflow-scm-step/
+
+### `phylum-ci` step arguments
+
+The arguments to the `phylum-ci` script are the way to exert control over the execution of the Phylum analysis.
+The `phylum-ci` script entry point has a number of arguments that are all optional and defaulted to secure values.
+To view the arguments, their description, and default values, run the script with `--help` output as specified in the
+[Usage section of the top-level README.md][usage] or view the [script options output][script_options] for the latest
+release.
+
+[usage]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md#usage
+[script_options]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/script_options.md
+
+```groovy
+            steps {
+                // This block is needed for change detection and using
+                // authenticated git commands. Change the `credentialsId`.
+                withCredentials([gitUsernamePassword(credentialsId: 'CHANGEME', gitToolName: 'Default')]) {
+                    // NOTE: These are examples. Only one `phylum-ci` entry is expected.
+                    //
+                    // Use the defaults for all the arguments.
+                    // The default behavior is to only analyze newly added dependencies
+                    // against the active policy set at the Phylum project level.
+                    sh 'phylum-ci'
+
+                    // Provide debug level output. Highly recommended.
+                    sh 'phylum-ci -vv'
+
+                    // Consider all dependencies in analysis results instead of just the newly added ones.
+                    // The default is to only analyze newly added dependencies, which can be useful for
+                    // existing code bases that may not meet established policy rules yet,
+                    // but don't want to make things worse. Specifying `--all-deps` can be useful for
+                    // casting the widest net for strict adherence to Quality Assurance (QA) standards.
+                    sh 'phylum-ci --all-deps'
+
+                    // Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in that
+                    // they can be named differently and may or may not contain strict dependencies.
+                    // In these cases it is best to specify an explicit path, either with the `--depfile`
+                    // option or in a `.phylum_project` file. The easiest way to do that is with the
+                    // Phylum CLI, using `phylum init` command (docs.phylum.io/cli/commands/phylum_init)
+                    // and committing the generated `.phylum_project` file.
+                    sh 'phylum-ci --depfile requirements-prod.txt'
+
+                    // Specify multiple explicit dependency file paths.
+                    sh 'phylum-ci --depfile requirements-prod.txt Cargo.toml path/to/dependency.file'
+
+                    // Force analysis for all dependencies in a manifest file. This is especially useful
+                    // for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
+                    sh 'phylum-ci --force-analysis --all-deps --depfile Cargo.toml'
+
+                    // Analyze all dependencies in audit mode, to gain insight without failing builds.
+                    sh 'phylum-ci --all-deps --audit'
+
+                    // Ensure the latest Phylum CLI is installed.
+                    sh 'phylum-ci --force-install'
+
+                    // Install a specific version of the Phylum CLI.
+                    sh 'phylum-ci --phylum-release 6.4.0 --force-install'
+
+                    // Mix and match for your specific use case.
+                    sh 'phylum-ci \
+                        -vv \
+                        --depfile requirements-dev.txt \
+                        --depfile requirements-prod.txt path/to/dependency.file \
+                        --depfile Cargo.toml \
+                        --force-analysis \
+                        --all-deps'
+                }
+            }
+```
+
+## Alternatives
+
+There are times where it may not be possible to have full git history with a complete checkout. It may also be the case
+that a complete checkout is undesirable due to the extra time it takes. For these situation, or if using a "standard"
+or "standalone" pipeline configuration, the solution is to force analysis of all current dependencies so that no history
+is needed. This is done with the following flags:
+
+```groovy
+            steps {
+                // Force analysis for all current dependencies.
+                sh 'phylum-ci --force-analysis --all-deps'
+            }
+```
+
+It is also possible to make direct use of the [`phylum` Python package][pypi] within CI.
+This may be necessary if the Docker image is unavailable or undesirable for some reason.
+To use the `phylum` package, install it and call the desired entry points from a script under your control.
+See the [Installation][installation] and [Usage][usage] sections of the [README file][readme] for more detail.
+
+[pypi]: https://pypi.org/project/phylum/
+[readme]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md
+[installation]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md#installation

--- a/scripts/docker_tests.sh
+++ b/scripts/docker_tests.sh
@@ -66,7 +66,7 @@ if [ -z "${IMAGE:-}" ]; then
     echo " [!] \`--image\` option not specified. Attempting to use \`${IMAGE}\` ..."
 fi
 
-# These are the commands to ensure the base pre-requisites are available
+# These are the commands to ensure the base prerequisites are available
 SLIM_COMMANDS=$(cat <<EOF
 set -eux
 type git && git --version || false

--- a/src/phylum/ci/ci_azure.py
+++ b/src/phylum/ci/ci_azure.py
@@ -111,9 +111,9 @@ class CIAzure(CIBase):
             LOG.debug("Pipeline context: CI trigger")
 
     def _check_prerequisites(self) -> None:
-        """Ensure the necessary pre-requisites are met and bail when they aren't.
+        """Ensure the necessary prerequisites are met and bail when they aren't.
 
-        These are the current pre-requisites for operating within an Azure Pipelines Environment:
+        These are the current prerequisites for operating within an Azure Pipelines Environment:
           * The environment must actually be within Azure Pipelines
           * A token providing API access is available to match the triggering repo when operating in a PR pipeline
             * Unless comment generation is skipped

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -69,9 +69,9 @@ class CIBase(ABC):
         self.audit_mode = args.audit
         self._skip_comments = True if self.audit_mode else args.skip_comments
 
-        # Ensure all pre-requisites are met and bail at the earliest opportunity when they aren't
+        # Ensure all prerequisites are met and bail at the earliest opportunity when they aren't
         self._check_prerequisites()
-        LOG.info("All pre-requisites met")
+        LOG.info("All prerequisites met")
 
         self._backup_project_file()
 
@@ -501,13 +501,13 @@ class CIBase(ABC):
 
     @abstractmethod
     def _check_prerequisites(self) -> None:
-        """Ensure the necessary pre-requisites are met and bail when they aren't.
+        """Ensure the necessary prerequisites are met and bail when they aren't.
 
-        The current pre-requisites for *all* CI environments/platforms are:
+        The current prerequisites for *all* CI environments/platforms are:
           * A Phylum CLI version at least as new as the minimum supported version
           * Have `git` installed and available for use on the PATH
         """
-        LOG.info("Confirming pre-requisites ...")
+        LOG.info("Confirming prerequisites ...")
 
         if Version(self.args.version) < Version(MIN_CLI_VER_INSTALLED):
             msg = f"The CLI version must be at least {MIN_CLI_VER_INSTALLED}"

--- a/src/phylum/ci/ci_bitbucket.py
+++ b/src/phylum/ci/ci_bitbucket.py
@@ -76,9 +76,9 @@ class CIBitbucket(CIBase):
             LOG.debug("Pipeline context: branch pipeline")
 
     def _check_prerequisites(self) -> None:
-        """Ensure the necessary pre-requisites are met and bail when they aren't.
+        """Ensure the necessary prerequisites are met and bail when they aren't.
 
-        These are the current pre-requisites for operating within a Bitbucket Pipelines Environment:
+        These are the current prerequisites for operating within a Bitbucket Pipelines Environment:
           * The environment must actually be within Bitbucket Pipelines
           * A Bitbucket token providing API access is available when operating in a PR pipeline
             * Unless comment generation is skipped

--- a/src/phylum/ci/ci_github.py
+++ b/src/phylum/ci/ci_github.py
@@ -85,9 +85,9 @@ class CIGitHub(CIBase):
             self.disable_lockfile_generation = True
 
     def _check_prerequisites(self) -> None:
-        """Ensure the necessary pre-requisites are met and bail when they aren't.
+        """Ensure the necessary prerequisites are met and bail when they aren't.
 
-        These are the current pre-requisites for operating within a GitHub Actions Environment:
+        These are the current prerequisites for operating within a GitHub Actions Environment:
           * The environment must actually be within GitHub Actions
           * A GitHub token providing `issues` API access is available
             * Unless comment generation is skipped

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -58,9 +58,9 @@ class CIGitLab(CIBase):
             LOG.debug("Pipeline context: branch pipeline")
 
     def _check_prerequisites(self) -> None:
-        """Ensure the necessary pre-requisites are met and bail when they aren't.
+        """Ensure the necessary prerequisites are met and bail when they aren't.
 
-        These are the current pre-requisites for operating within a GitLab CI Environment:
+        These are the current prerequisites for operating within a GitLab CI Environment:
           * The environment must actually be within GitLab CI
           * A GitLab token providing API access is available when operating in an MR pipeline
             * Unless comment generation is skipped

--- a/src/phylum/ci/ci_jenkins.py
+++ b/src/phylum/ci/ci_jenkins.py
@@ -1,0 +1,159 @@
+"""Define an implementation for the Jenkinks platform.
+
+Jenkins References:
+  * https://www.jenkins.io
+  * https://www.jenkins.io/doc/
+  * https://www.jenkins.io/doc/book/pipeline/syntax/
+  * https://www.jenkins.io/doc/book/using/using-credentials/
+  * https://www.jenkins.io/doc/book/pipeline/docker/
+  * https://www.jenkins.io/doc/pipeline/steps/
+  * https://www.jenkins.io/doc/book/pipeline/multibranch/#supporting-pull-requests
+  * https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
+  * https://www.jenkins.io/doc/book/pipeline/getting-started/#global-variable-reference
+"""
+
+from argparse import Namespace
+from functools import cached_property, lru_cache
+import os
+import re
+import shlex
+import subprocess
+from typing import Optional
+
+from phylum.ci.ci_base import CIBase
+from phylum.ci.git import git_remote, git_set_remote_head
+from phylum.exceptions import pprint_subprocess_error
+from phylum.logger import LOG
+
+
+@lru_cache(maxsize=1)
+def is_in_pr() -> bool:
+    """Indicate if the integration is operating in the context of a pull request pipeline.
+
+    Jenkins allows for the possibility of running multibranch pipelines in different contexts:
+      * On every push, for the last commit in the push (e.g., branch pipelines)
+      * For pull requests (e.g., pull request pipelines)
+
+    Knowing when the context is within a pull request helps to ensure the logic used
+    to determine the dependency file changes is correct.
+    """
+    # References:
+    # https://github.com/watson/ci-info/blob/master/vendors.json
+    # https://www.jenkins.io/doc/book/pipeline/multibranch/#supporting-pull-requests
+    return any(map(os.getenv, ["CHANGE_ID", "ghprbPullId"]))
+
+
+class CIJenkins(CIBase):
+    """Provide methods for a Jenkins environment."""
+
+    def __init__(self, args: Namespace) -> None:  # noqa: D107 ; the base __init__ docstring is better here
+        super().__init__(args)
+        self.ci_platform_name = "Jenkins"
+        if is_in_pr():
+            LOG.debug("Pipeline context: pull request pipeline")
+        else:
+            LOG.debug("Pipeline context: branch pipeline")
+
+    def _check_prerequisites(self) -> None:
+        """Ensure the necessary prerequisites are met and bail when they aren't.
+
+        These are the current prerequisites for operating within a Jenkins environment:
+          * The environment must actually be within Jenkins
+        """
+        super()._check_prerequisites()
+
+        # References:
+        # https://github.com/watson/ci-info/blob/master/vendors.json
+        if os.getenv("JENKINS_URL") is None or os.getenv("BUILD_ID") is None:
+            msg = "Must be working within a Jenkins environment"
+            raise SystemExit(msg)
+
+    @cached_property
+    def phylum_label(self) -> str:
+        """Get a custom label for use when submitting jobs for analysis."""
+        if is_in_pr():
+            pr_id = os.getenv("CHANGE_ID", "unknown-ID")
+            pr_src_branch = os.getenv("CHANGE_BRANCH", "unknown-branch")
+            label = f"{self.ci_platform_name}_PR#{pr_id}_{pr_src_branch}"
+        else:
+            current_branch = os.getenv("BRANCH_NAME", "unknown-branch")
+            label = f"{self.ci_platform_name}_{current_branch}_{self.depfile_hash_object}"
+
+        label = re.sub(r"\s+", "-", label)
+        return label
+
+    @cached_property
+    def common_ancestor_commit(self) -> Optional[str]:
+        """Find the common ancestor commit.
+
+        Some pre-defined variables are used:
+        https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
+        """
+        remote = git_remote()
+
+        if not is_in_pr() and os.getenv("BRANCH_IS_PRIMARY"):
+            # If the current commit is on the default branch, then the merge base will be the same
+            # as the current commit and it won't be possible to provide a useful common ancestor
+            # commit. In this case, it is better to force analysis of the dependency file(s) and
+            # consider *all* dependencies in analysis results instead of just the newly added ones.
+            LOG.warning("On primary branch. Proceeding with analysis of all dependencies ...")
+            self._force_analysis = True
+            self._all_deps = True
+
+        cmd = ["git", "merge-base", "HEAD", f"refs/remotes/{remote}/HEAD"]
+        LOG.debug("Finding common ancestor commit with command: %s", shlex.join(cmd))
+        try:
+            commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()  # noqa: S603
+        except subprocess.CalledProcessError as outer_err:
+            # The most likely problem is that the remote HEAD ref is not set. The attempt to set it here, inside
+            # the except block, is due to wanting to minimize calling commands that require git credentials.
+            pprint_subprocess_error(outer_err)
+            LOG.warning("Failed to get commit. Remote HEAD ref likely not set. Attempting to set it and try again ...")
+            git_set_remote_head(remote)
+            try:
+                commit = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()  # noqa: S603
+            except subprocess.CalledProcessError as inner_err:
+                pprint_subprocess_error(inner_err)
+                LOG.warning("The common ancestor commit could not be found")
+                commit = None
+        return commit
+
+    @property
+    def is_any_depfile_changed(self) -> bool:
+        """Predicate for detecting if any dependency file has changed."""
+        diff_base_sha = self.common_ancestor_commit
+        LOG.debug("The common ancestor commit: %s", diff_base_sha)
+
+        # Assume no change when there isn't enough information to tell
+        if diff_base_sha is None:
+            return False
+
+        err_msg = """
+            Ensure a full checkout is configured, to provide history and proper
+            diffs. A `checkout scm` step is not enough here. The `phylum-ci`
+            command must also be contained within a `withCredentials` block,
+            where the `credentialsId` is the same as used for the checkout.
+            For more info, reference:
+            * https://plugins.jenkins.io/workflow-scm-step/
+            * https://www.jenkins.io/doc/pipeline/steps/credentials-binding/"""
+        self.update_depfiles_change_status(diff_base_sha, err_msg)
+
+        return any(depfile.is_depfile_changed for depfile in self.depfiles)
+
+    @property
+    def phylum_comment_exists(self) -> bool:
+        """Predicate for detecting whether a Phylum-generated comment exists."""
+        # There are no historical comments in this implementation
+        return False
+
+    @property
+    def repo_url(self) -> Optional[str]:
+        """Get the repository URL for reference in Phylum project metadata."""
+        # This is the "Remote URL of the first git repository in the workspace."
+        # It comes from the git plugin and may not be set depending on the context.
+        # Ref: https://plugins.jenkins.io/git/#plugin-content-environment-variables
+        git_url = os.getenv("GIT_URL")
+        if git_url is None:
+            LOG.warning("Repository URL not found at `GIT_URL`")
+            return None
+        return git_url

--- a/src/phylum/ci/ci_none.py
+++ b/src/phylum/ci/ci_none.py
@@ -25,9 +25,9 @@ class CINone(CIBase):
         self.ci_platform_name = "No CI"
 
     def _check_prerequisites(self) -> None:
-        """Ensure the necessary pre-requisites are met and bail when they aren't.
+        """Ensure the necessary prerequisites are met and bail when they aren't.
 
-        These are the current pre-requisites for when no CI environments/platforms is detected:
+        These are the current prerequisites for when no CI environments/platforms is detected:
           * (None at this time)
         """
         super()._check_prerequisites()

--- a/src/phylum/ci/ci_precommit.py
+++ b/src/phylum/ci/ci_precommit.py
@@ -43,9 +43,9 @@ class CIPreCommit(CIBase):
         self._env.pop("GIT_INDEX_FILE", None)
 
     def _check_prerequisites(self) -> None:
-        """Ensure the necessary pre-requisites are met and bail when they aren't.
+        """Ensure the necessary prerequisites are met and bail when they aren't.
 
-        These are the current pre-requisites for operating within a pre-commit hook:
+        These are the current prerequisites for operating within a pre-commit hook:
           * The extra unparsed arguments passed to the CLI represent the staged files, no more and no less
         """
         super()._check_prerequisites()

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -57,7 +57,7 @@ def detect_ci_platform(args: argparse.Namespace, remainder: list[str]) -> CIBase
 
     # Detect Python pre-commit environment
     # This might be a naive strategy for detecting the `pre-commit` case, but there is at least an attempt,
-    # via a pre-requisite check, to check the extra arguments for common/valid pre-commit usage patterns.
+    # via a prerequisite check, to check the extra arguments for common/valid pre-commit usage patterns.
     if any(remainder):
         LOG.debug("Extra arguments provided. Assuming a Python `pre-commit` working environment.")
         ci_envs.append(CIPreCommit(args, remainder))

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -14,6 +14,7 @@ from phylum.ci.ci_base import CIBase, CIEnvs
 from phylum.ci.ci_bitbucket import CIBitbucket
 from phylum.ci.ci_github import CIGitHub
 from phylum.ci.ci_gitlab import CIGitLab
+from phylum.ci.ci_jenkins import CIJenkins
 from phylum.ci.ci_none import CINone
 from phylum.ci.ci_precommit import CIPreCommit
 from phylum.ci.common import ReturnCode
@@ -48,6 +49,11 @@ def detect_ci_platform(args: argparse.Namespace, remainder: list[str]) -> CIBase
     if os.getenv("BITBUCKET_COMMIT"):
         LOG.debug("CI environment detected: Bitbucket Pipelines")
         ci_envs.append(CIBitbucket(args))
+
+    # Detect Jenkins
+    if all(map(os.getenv, ["JENKINS_URL", "BUILD_ID"])):
+        LOG.debug("CI environment detected: Jenkins")
+        ci_envs.append(CIJenkins(args))
 
     # Detect Python pre-commit environment
     # This might be a naive strategy for detecting the `pre-commit` case, but there is at least an attempt,


### PR DESCRIPTION
This change adds an integration for the Jenkins pipelines CI
environment. Specifically, it adds support for declarative pipeline
syntax in multibranch pipelines. Pipeline runs for both PRs and branches
are supported.

This integration detects and handles both branch pipelines and pull
request (PR) pipelines. When in the PR pipeline context, the results
are only written to logs and NOT as a comment on the PR. This is due to
the nature of the environment, where many different source repositories
are supported (e.g., GitHub, Bitbucket, GitLab, etc.)

The `documentation` repo will be updated separately to add this
integration to the summary overview page.

Several formatting changes were made throughout the code base, in a
separate commit, to include:

* Be consistent on the spelling of `prerequisite`
* Make "INFO" callout blocks more obvious
* Be consistent with code format for `phylumio/phylum-ci` Docker image

Closes #430

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] ~Have you created sufficient tests?~
  - Still no automated tests
  - Manual testing was performed (see screenshots) using the changes from this PR in the form of the `maxrake/phylum-ci:add_jenkins` Docker image
- [x] Have you updated all affected documentation?

## Screenshots

---

Locally hosted Jenkins instance, using a Multibranch Pipelines configuration for the `https://github.com/maxrake/TestJenkinsGH` repository:

<img width="1334" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/40326b49-141e-42cf-b254-4a3fc8706359">

---

Adding a known bad dependency in a new `add_jenkins` branch. The new branch is recognized:

<img width="1334" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/302a7546-c94a-44e4-81e8-d573364a0ce6">

---

The build fails as expected. Notice it is recognized as a branch pipeline.

<img width="1334" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/4915aad6-b0c7-4f40-ae76-f2f464486e8f">

---

Creating a PR from the branch results in the branch scan going away in favor of a PR scan (due to configuration preventing both from being active at the same time):

<img width="1334" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/50ac26f6-cf9e-427f-b934-19d2b777e81e">

---

The build still fails as expected. Notice it is now recognized as a PR pipeline.

<img width="1334" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/16831743-2983-4259-86cb-7eca6181d62a">

<img width="1334" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/a780dbca-191c-4663-8c5f-8537c04ba7e0">

---

Remove the bad dep and add a known good one, while still in the PR:

<img width="1275" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/864c326a-b0d7-43ca-a036-abd929d99abf">

---

The PR status check is updated with the result and shows green now:

<img width="926" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/e4ff41c5-89f3-4d8e-bedc-4f2408291c94">

---

Merging the branch back to `main` kicked off a scan. Since this is the default branch, it analyzed all dependencies.

<img width="1278" alt="image" src="https://github.com/phylum-dev/phylum-ci/assets/18729796/713d8591-d664-49e9-adf1-9055b41a554c">
