### PR TITLE
feat: add `ps` to Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -212,6 +212,7 @@ RUN \
         git \
         bundler \
         maven \
+        procps \
         curl \
         unzip \
         jq \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -180,7 +180,7 @@ RUN set -eux; \
     # Install prerequisites
     apt-get update; \
     apt-get upgrade --yes; \
-    apt-get install --yes --no-install-recommends git binutils; \
+    apt-get install --yes --no-install-recommends git procps binutils; \
     # Make ENTRYPOINT alternative script available
     chmod +x "${PHYLUM_VENV}/bin/entrypoint.sh"; \
     # Install Phylum CLI

--- a/scripts/docker_tests.sh
+++ b/scripts/docker_tests.sh
@@ -66,7 +66,9 @@ if [ -z "${IMAGE:-}" ]; then
     echo " [!] \`--image\` option not specified. Attempting to use \`${IMAGE}\` ..."
 fi
 
-# These are the commands to ensure the base prerequisites are available
+# These are the commands to ensure the base prerequisites are available.
+# NOTE: The `ps` command was added in this PR and may not always be a
+#       prerequisite - https://github.com/phylum-dev/phylum-ci/pull/441
 SLIM_COMMANDS=$(cat <<EOF
 set -eux
 type ps || false

--- a/scripts/docker_tests.sh
+++ b/scripts/docker_tests.sh
@@ -69,6 +69,7 @@ fi
 # These are the commands to ensure the base prerequisites are available
 SLIM_COMMANDS=$(cat <<EOF
 set -eux
+type ps || false
 type git && git --version || false
 type phylum && phylum --version && phylum --help || false
 type phylum-init && phylum-init --version && phylum-init --help || false


### PR DESCRIPTION
This change is based on a request from users of `podman`. Older versions of that tool (prior to v4.6.0) require `ps` to exist on the running container in order to use the `top` command while newer versions do not.

This package adds about 340kB to the compressed image size.

An image was built with these changes and provided for testing as the `phylumio/phylum-ci:with_ps` tag on
[Docker Hub](https://hub.docker.com/r/phylumio/phylum-ci/tags). The user in question has confirmed that the change works for them.
