### PR TITLE
feat: add `git-lfs` to Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -210,6 +210,7 @@ RUN \
     apt-get upgrade --yes; \
     apt-get install --yes --no-install-recommends \
         git \
+        git-lfs \
         bundler \
         maven \
         procps \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -180,7 +180,7 @@ RUN set -eux; \
     # Install prerequisites
     apt-get update; \
     apt-get upgrade --yes; \
-    apt-get install --yes --no-install-recommends git procps binutils; \
+    apt-get install --yes --no-install-recommends git git-lfs procps binutils; \
     # Make ENTRYPOINT alternative script available
     chmod +x "${PHYLUM_VENV}/bin/entrypoint.sh"; \
     # Install Phylum CLI


### PR DESCRIPTION
This change adds support for [git large files storage](https://git-lfs.com/) (lfs) by adding the `git-lfs` package to both the default and `slim` Docker images. This change was prompted by a user request and barely increases the uncompressed image size. The feature will be useful for anyone making use of git lfs in the repositories they wish to analyze with Phylum.
