### PR TITLE
build: pin `python-semantic-release` to v9.8.3

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1084,13 +1084,13 @@ yaml = ["PyYaml (>=6.0.1)"]
 
 [[package]]
 name = "python-semantic-release"
-version = "9.8.6"
+version = "9.8.3"
 description = "Automatic Semantic Versioning for Python projects"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "python_semantic_release-9.8.6-py3-none-any.whl", hash = "sha256:018729c09edbb1d4ad8b08af81bc2a42d002d54e37f87ed4b706fa283636ce3f"},
-    {file = "python_semantic_release-9.8.6.tar.gz", hash = "sha256:6e2e4626112bdbf43e86aac4535557e8c0a9274a4ea5352f14623cbabbfe498a"},
+    {file = "python_semantic_release-9.8.3-py3-none-any.whl", hash = "sha256:da90401ebce238bb71cc6c2506852fd8266b3e608946cbbae0bb0bda216a459a"},
+    {file = "python_semantic_release-9.8.3.tar.gz", hash = "sha256:c4d83296917476ce6fb53ffdd52f254b9fd0de04cc1b255426f209f8f7984189"},
 ]
 
 [package.dependencies]
@@ -1109,9 +1109,9 @@ tomlkit = ">=0.11,<1.0"
 
 [package.extras]
 build = ["build (>=1.2,<2.0)"]
-dev = ["pre-commit (>=3.5,<4.0)", "ruff (==0.5.0)", "tox (>=4.11,<5.0)"]
+dev = ["pre-commit (>=3.5,<4.0)", "ruff (==0.4.9)", "tox (>=4.11,<5.0)"]
 docs = ["Sphinx (>=6.0,<7.0)", "furo (>=2024.1,<2025.0)", "sphinx-autobuild (==2024.2.4)", "sphinxcontrib-apidoc (==0.5.0)"]
-mypy = ["mypy (==1.10.1)", "types-requests (>=2.32.0,<2.33.0)"]
+mypy = ["mypy (==1.10.0)", "types-requests (>=2.31.0,<2.32.0)"]
 test = ["coverage[toml] (>=7.0,<8.0)", "pytest (>=7.0,<8.0)", "pytest-clarity (>=1.0,<2.0)", "pytest-cov (>=5.0,<6.0)", "pytest-env (>=1.0,<2.0)", "pytest-lazy-fixture (>=0.6.3,<0.7.0)", "pytest-mock (>=3.0,<4.0)", "pytest-pretty (>=1.2,<2.0)", "pytest-xdist (>=3.0,<4.0)", "requests-mock (>=1.10,<2.0)", "responses (>=0.25.0,<0.26.0)", "types-pytest-lazy-fixture (>=0.6.3,<0.7.0)"]
 
 [[package]]
@@ -1759,4 +1759,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "3e27277105d0e97ded38709341f4302537fc058e7013a1351cc68766dca34734"
+content-hash = "c8e1f18af5d06f0f4ffc8d072970b1c7add8ff2cd39fe33a353724bd47f70948"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,9 @@ optional = true
 [tool.poetry.group.ci.dependencies]
 tox-gh-actions = "*"
 pytest-github-actions-annotate-failures = "*"
-python-semantic-release = "*"
+# TODO: Remove pin when PSR defines the `context` variable in release notes templates:
+#       https://github.com/python-semantic-release/python-semantic-release/issues/984
+python-semantic-release = "9.8.3"
 rich-codex = "*"
 
 [tool.poetry.group.qa]


### PR DESCRIPTION
This change pins the `python-semantic-release` (PSR) dependency to the last known working version of v9.8.3. After that release, a number of large refactors were made and introduced breaking changes, even though they were only bugfix releases (I know, the irony). Specifically, the `context` variable stopped being defined for the release notes template.

This variable is used in the `phylum-ci` project to create "compare" links for making it easy to see what has changed from the previous release. Instead of removing the compare link from the template, the PSR dependency was pinned, with a note to remove the pin [when PSR fixes the regression](https://github.com/python-semantic-release/python-semantic-release/issues/984).

