### PR TITLE
feat: add option to exclude dependency files

### DIFF
--- a/docs/integrations/azure_pipelines.md
+++ b/docs/integrations/azure_pipelines.md
@@ -311,7 +311,7 @@ view the [script options output][script_options] for the latest release.
       # Specify multiple explicit dependency file paths.
       - script: phylum-ci --depfile requirements-prod.txt Cargo.toml path/to/dependency.file
 
-      # Exclude dependency files by glob-style pattern.
+      # Exclude dependency files by gitignore-style pattern.
       - script: phylum-ci --exclude "requirements-*.txt"
 
       # Specify multiple exclusion patterns.
@@ -319,7 +319,7 @@ view the [script options output][script_options] for the latest release.
       - script: |
         phylum-ci \
           --exclude "/requirements-*.txt" \
-          --exclude "build.gradle" "tests/fixtures/*"
+          --exclude "build.gradle" "fixtures/"
 
       # Force analysis for all dependencies in a manifest file. This is especially useful
       # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).

--- a/docs/integrations/azure_pipelines.md
+++ b/docs/integrations/azure_pipelines.md
@@ -318,8 +318,8 @@ view the [script options output][script_options] for the latest release.
       - script: phylum-ci --exclude "build.gradle" "tests/fixtures/*"
       - script: |
         phylum-ci \
-          --exclude "build.gradle" \
-          --exclude "tests/fixtures/*"
+          --exclude "/requirements-*.txt" \
+          --exclude "build.gradle" "tests/fixtures/*"
 
       # Force analysis for all dependencies in a manifest file. This is especially useful
       # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).

--- a/docs/integrations/azure_pipelines.md
+++ b/docs/integrations/azure_pipelines.md
@@ -311,6 +311,16 @@ view the [script options output][script_options] for the latest release.
       # Specify multiple explicit dependency file paths.
       - script: phylum-ci --depfile requirements-prod.txt Cargo.toml path/to/dependency.file
 
+      # Exclude dependency files by glob-style pattern.
+      - script: phylum-ci --exclude "requirements-*.txt"
+
+      # Specify multiple exclusion patterns.
+      - script: phylum-ci --exclude "build.gradle" "tests/fixtures/*"
+      - script: |
+        phylum-ci \
+          --exclude "build.gradle" \
+          --exclude "tests/fixtures/*"
+
       # Force analysis for all dependencies in a manifest file. This is especially useful
       # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
       - script: phylum-ci --force-analysis --all-deps --depfile Cargo.toml

--- a/docs/integrations/azure_pipelines.md
+++ b/docs/integrations/azure_pipelines.md
@@ -315,7 +315,7 @@ view the [script options output][script_options] for the latest release.
       - script: phylum-ci --exclude "requirements-*.txt"
 
       # Specify multiple exclusion patterns.
-      - script: phylum-ci --exclude "build.gradle" "tests/fixtures/*"
+      - script: phylum-ci --exclude "build.gradle" "tests/fixtures/"
       - script: |
         phylum-ci \
           --exclude "/requirements-*.txt" \

--- a/docs/integrations/bitbucket_pipelines.md
+++ b/docs/integrations/bitbucket_pipelines.md
@@ -316,8 +316,8 @@ view the [script options output][script_options] for the latest release.
     - phylum-ci --exclude "build.gradle" "tests/fixtures/*"
     - |
       phylum-ci \
-        --exclude "build.gradle" \
-        --exclude "tests/fixtures/*"
+        --exclude "/requirements-*.txt" \
+        --exclude "build.gradle" "tests/fixtures/*"
 
     # Force analysis for all dependencies in a manifest file. This is especially useful
     # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).

--- a/docs/integrations/bitbucket_pipelines.md
+++ b/docs/integrations/bitbucket_pipelines.md
@@ -313,7 +313,7 @@ view the [script options output][script_options] for the latest release.
     - phylum-ci --exclude "requirements-*.txt"
 
     # Specify multiple exclusion patterns.
-    - phylum-ci --exclude "build.gradle" "tests/fixtures/*"
+    - phylum-ci --exclude "build.gradle" "tests/fixtures/"
     - |
       phylum-ci \
         --exclude "/requirements-*.txt" \

--- a/docs/integrations/bitbucket_pipelines.md
+++ b/docs/integrations/bitbucket_pipelines.md
@@ -309,7 +309,7 @@ view the [script options output][script_options] for the latest release.
     # Specify multiple explicit dependency file paths.
     - phylum-ci --depfile requirements-prod.txt Cargo.toml path/to/dependency.file
 
-    # Exclude dependency files by glob-style pattern.
+    # Exclude dependency files by gitignore-style pattern.
     - phylum-ci --exclude "requirements-*.txt"
 
     # Specify multiple exclusion patterns.
@@ -317,7 +317,7 @@ view the [script options output][script_options] for the latest release.
     - |
       phylum-ci \
         --exclude "/requirements-*.txt" \
-        --exclude "build.gradle" "tests/fixtures/*"
+        --exclude "build.gradle" "fixtures/"
 
     # Force analysis for all dependencies in a manifest file. This is especially useful
     # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).

--- a/docs/integrations/bitbucket_pipelines.md
+++ b/docs/integrations/bitbucket_pipelines.md
@@ -309,6 +309,16 @@ view the [script options output][script_options] for the latest release.
     # Specify multiple explicit dependency file paths.
     - phylum-ci --depfile requirements-prod.txt Cargo.toml path/to/dependency.file
 
+    # Exclude dependency files by glob-style pattern.
+    - phylum-ci --exclude "requirements-*.txt"
+
+    # Specify multiple exclusion patterns.
+    - phylum-ci --exclude "build.gradle" "tests/fixtures/*"
+    - |
+      phylum-ci \
+        --exclude "build.gradle" \
+        --exclude "tests/fixtures/*"
+
     # Force analysis for all dependencies in a manifest file. This is especially useful
     # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
     - phylum-ci --force-analysis --all-deps --depfile Cargo.toml

--- a/docs/integrations/git_precommit.md
+++ b/docs/integrations/git_precommit.md
@@ -154,6 +154,7 @@ with `--help` output as specified in the [Usage section of the top-level README.
 
         # Specify multiple exclusion patterns.
         args:
+          - --exclude=/requirements-*.txt
           - --exclude=build.gradle
           - --exclude=tests/fixtures/*
 

--- a/docs/integrations/git_precommit.md
+++ b/docs/integrations/git_precommit.md
@@ -149,14 +149,14 @@ with `--help` output as specified in the [Usage section of the top-level README.
           - --depfile=Cargo.toml
           - --depfile=path/to/dependency.file
 
-        # Exclude dependency files by glob-style pattern.
+        # Exclude dependency files by gitignore-style pattern.
         args: [--exclude=requirements-*.txt]
 
         # Specify multiple exclusion patterns.
         args:
           - --exclude=/requirements-*.txt
           - --exclude=build.gradle
-          - --exclude=tests/fixtures/*
+          - --exclude=fixtures/
 
         # Force analysis for all dependencies in a manifest file. This is especially useful
         # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).

--- a/docs/integrations/git_precommit.md
+++ b/docs/integrations/git_precommit.md
@@ -149,6 +149,14 @@ with `--help` output as specified in the [Usage section of the top-level README.
           - --depfile=Cargo.toml
           - --depfile=path/to/dependency.file
 
+        # Exclude dependency files by glob-style pattern.
+        args: [--exclude=requirements-*.txt]
+
+        # Specify multiple exclusion patterns.
+        args:
+          - --exclude=build.gradle
+          - --exclude=tests/fixtures/*
+
         # Force analysis for all dependencies in a manifest file. This is especially useful
         # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
         args: [--force-analysis, --all-deps, --depfile=Cargo.toml]

--- a/docs/integrations/gitlab_ci.md
+++ b/docs/integrations/gitlab_ci.md
@@ -304,8 +304,8 @@ view the [script options output][script_options] for the latest release.
     - phylum-ci --exclude "build.gradle" "tests/fixtures/*"
     - |
       phylum-ci \
-        --exclude "build.gradle" \
-        --exclude "tests/fixtures/*"
+        --exclude "/requirements-*.txt" \
+        --exclude "build.gradle" "tests/fixtures/*"
 
     # Force analysis for all dependencies in a manifest file. This is especially useful
     # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).

--- a/docs/integrations/gitlab_ci.md
+++ b/docs/integrations/gitlab_ci.md
@@ -301,7 +301,7 @@ view the [script options output][script_options] for the latest release.
     - phylum-ci --exclude "requirements-*.txt"
 
     # Specify multiple exclusion patterns.
-    - phylum-ci --exclude "build.gradle" "tests/fixtures/*"
+    - phylum-ci --exclude "build.gradle" "tests/fixtures/"
     - |
       phylum-ci \
         --exclude "/requirements-*.txt" \

--- a/docs/integrations/gitlab_ci.md
+++ b/docs/integrations/gitlab_ci.md
@@ -297,6 +297,16 @@ view the [script options output][script_options] for the latest release.
     # Specify multiple explicit dependency file paths.
     - phylum-ci --depfile requirements-prod.txt Cargo.toml path/to/dependency.file
 
+    # Exclude dependency files by glob-style pattern.
+    - phylum-ci --exclude "requirements-*.txt"
+
+    # Specify multiple exclusion patterns.
+    - phylum-ci --exclude "build.gradle" "tests/fixtures/*"
+    - |
+      phylum-ci \
+        --exclude "build.gradle" \
+        --exclude "tests/fixtures/*"
+
     # Force analysis for all dependencies in a manifest file. This is especially useful
     # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
     - phylum-ci --force-analysis --all-deps --depfile Cargo.toml

--- a/docs/integrations/gitlab_ci.md
+++ b/docs/integrations/gitlab_ci.md
@@ -297,7 +297,7 @@ view the [script options output][script_options] for the latest release.
     # Specify multiple explicit dependency file paths.
     - phylum-ci --depfile requirements-prod.txt Cargo.toml path/to/dependency.file
 
-    # Exclude dependency files by glob-style pattern.
+    # Exclude dependency files by gitignore-style pattern.
     - phylum-ci --exclude "requirements-*.txt"
 
     # Specify multiple exclusion patterns.
@@ -305,7 +305,7 @@ view the [script options output][script_options] for the latest release.
     - |
       phylum-ci \
         --exclude "/requirements-*.txt" \
-        --exclude "build.gradle" "tests/fixtures/*"
+        --exclude "build.gradle" "fixtures/"
 
     # Force analysis for all dependencies in a manifest file. This is especially useful
     # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).

--- a/docs/integrations/jenkins.md
+++ b/docs/integrations/jenkins.md
@@ -297,14 +297,14 @@ release.
           // Specify multiple explicit dependency file paths.
           sh 'phylum-ci --depfile requirements-prod.txt Cargo.toml path/to/dependency.file'
 
-          // Exclude dependency files by glob-style pattern.
+          // Exclude dependency files by gitignore-style pattern.
           sh 'phylum-ci --exclude "requirements-*.txt"'
 
           // Specify multiple exclusion patterns.
           sh 'phylum-ci --exclude "build.gradle" "tests/fixtures/*"'
           sh 'phylum-ci \
               --exclude "/requirements-*.txt" \
-              --exclude "build.gradle" "tests/fixtures/*"'
+              --exclude "build.gradle" "fixtures/"'
 
           // Force analysis for all dependencies in a manifest file. This is especially useful
           // for *workspace* manifest files where there is no companion lockfile (e.g., libraries).

--- a/docs/integrations/jenkins.md
+++ b/docs/integrations/jenkins.md
@@ -301,7 +301,7 @@ release.
           sh 'phylum-ci --exclude "requirements-*.txt"'
 
           // Specify multiple exclusion patterns.
-          sh 'phylum-ci --exclude "build.gradle" "tests/fixtures/*"'
+          sh 'phylum-ci --exclude "build.gradle" "tests/fixtures/"'
           sh 'phylum-ci \
               --exclude "/requirements-*.txt" \
               --exclude "build.gradle" "fixtures/"'

--- a/docs/integrations/jenkins.md
+++ b/docs/integrations/jenkins.md
@@ -297,6 +297,15 @@ release.
           // Specify multiple explicit dependency file paths.
           sh 'phylum-ci --depfile requirements-prod.txt Cargo.toml path/to/dependency.file'
 
+          // Exclude dependency files by glob-style pattern.
+          sh 'phylum-ci --exclude "requirements-*.txt"'
+
+          // Specify multiple exclusion patterns.
+          sh 'phylum-ci --exclude "build.gradle" "tests/fixtures/*"'
+          sh 'phylum-ci \
+              --exclude "build.gradle" \
+              --exclude "tests/fixtures/*"'
+
           // Force analysis for all dependencies in a manifest file. This is especially useful
           // for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
           sh 'phylum-ci --force-analysis --all-deps --depfile Cargo.toml'

--- a/docs/integrations/jenkins.md
+++ b/docs/integrations/jenkins.md
@@ -303,8 +303,8 @@ release.
           // Specify multiple exclusion patterns.
           sh 'phylum-ci --exclude "build.gradle" "tests/fixtures/*"'
           sh 'phylum-ci \
-              --exclude "build.gradle" \
-              --exclude "tests/fixtures/*"'
+              --exclude "/requirements-*.txt" \
+              --exclude "build.gradle" "tests/fixtures/*"'
 
           // Force analysis for all dependencies in a manifest file. This is especially useful
           // for *workspace* manifest files where there is no companion lockfile (e.g., libraries).

--- a/poetry.lock
+++ b/poetry.lock
@@ -830,6 +830,17 @@ files = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "0.12.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
+    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.2.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
@@ -1795,4 +1806,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "c8e1f18af5d06f0f4ffc8d072970b1c7add8ff2cd39fe33a353724bd47f70948"
+content-hash = "15a2a07a4eb90efaf37a1ffb827dcb38b815e47d9cec56164905b0875f81210f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ cryptography = "*"
 packaging = "*"
 "ruamel.yaml" = "*"
 rich = "*"
+pathspec = "*"
 
 [tool.poetry.group.test]
 optional = true

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -201,7 +201,7 @@ class CIBase(ABC):
                 if depfile.path.match(exclusion):
                     excluded_depfiles.append(depfile)
                     # Stop after first matching exclusion
-                    continue
+                    break
         LOG.info("Dependency files excluded by matching patterns: %s", excluded_depfiles)
 
         depfiles = list(set(provided_depfiles).difference(set(excluded_depfiles)))

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -198,7 +198,12 @@ class CIBase(ABC):
         excluded_depfiles: DepfileEntries = []
         for depfile in provided_depfiles:
             for exclusion in provided_arg_exclusions:
-                if depfile.path.match(exclusion):
+                depfile_path = depfile.path
+                if exclusion.startswith("/"):
+                    # Create a fake absolute path "rooted" at the working directory (presumably
+                    # the project root) to allow for matching absolute patterns
+                    depfile_path = Path("/") / str(depfile)
+                if depfile_path.match(exclusion):
                     excluded_depfiles.append(depfile)
                     # Stop after first matching exclusion
                     break

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -198,11 +198,9 @@ class CIBase(ABC):
         excluded_depfiles: DepfileEntries = []
         for depfile in provided_depfiles:
             for exclusion in provided_arg_exclusions:
-                depfile_path = depfile.path
-                if exclusion.startswith("/"):
-                    # Create a fake absolute path "rooted" at the working directory (presumably
-                    # the project root) to allow for matching absolute patterns
-                    depfile_path = Path("/") / str(depfile)
+                # Create a fake absolute path "rooted" at the working directory (presumably
+                # the project root) to allow for matching absolute patterns
+                depfile_path = Path("/") / str(depfile)
                 if depfile_path.match(exclusion):
                     excluded_depfiles.append(depfile)
                     # Stop after first matching exclusion

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -127,8 +127,9 @@ def get_args(args: Optional[Sequence[str]] = None) -> tuple[argparse.Namespace, 
         action="append",
         nargs="*",
         help="""Glob-style exclusion patterns. Ignored when dependency files are specified explicitly by argument.
-        Specify relative patterns and in quotes to prevent shell globbing. Matching is done from the right of paths. The
-        recursive wildcard “**” is not supported (it acts like non-recursive “*”).""",
+        Absolute patterns (those starting with "/") only match whole paths, as rooted from the working directory
+        (e.g., the project root). Relative pattern matching is done from the right of paths. Specify patterns in quotes
+        to prevent shell globbing. The recursive wildcard “**” is not supported (it acts like non-recursive “*”).""",
     )
     analysis_group.add_argument(
         "-a",

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -122,6 +122,15 @@ def get_args(args: Optional[Sequence[str]] = None) -> tuple[argparse.Namespace, 
             """,
     )
     analysis_group.add_argument(
+        "-e",
+        "--exclude",
+        action="append",
+        nargs="*",
+        help="""Glob-style exclusion patterns. Ignored when dependency files are specified explicitly by argument.
+        Specify relative patterns and in quotes to prevent shell globbing. Matching is done from the right of paths. The
+        recursive wildcard “**” is not supported (it acts like non-recursive “*”).""",
+    )
+    analysis_group.add_argument(
         "-a",
         "--all-deps",
         action="store_true",

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -126,10 +126,8 @@ def get_args(args: Optional[Sequence[str]] = None) -> tuple[argparse.Namespace, 
         "--exclude",
         action="append",
         nargs="*",
-        help="""Glob-style exclusion patterns. Ignored when dependency files are specified explicitly by argument.
-        Absolute patterns (those starting with "/") only match whole paths, as rooted from the working directory
-        (e.g., the project root). Relative pattern matching is done from the right of paths. Specify patterns in quotes
-        to prevent shell globbing. The recursive wildcard “**” is not supported (it acts like non-recursive “*”).""",
+        help="""Gitignore-style exclusion patterns. Ignored when dependency files are specified explicitly by argument.
+        Specify patterns in quotes to prevent shell globbing. Patterns are applied relative to working directory.""",
     )
     analysis_group.add_argument(
         "-a",


### PR DESCRIPTION
This PR adds a new feature to specify exclusions to the dependency
files found/detected when not explicitly specified by argument. The
new option accepts gitignore-style patterns, using the [`pathspec`
third-party library](https://python-path-specification.readthedocs.io/en/stable/readme.html).

Closes phylum-dev/roadmap#462

## Testing

The changes in this PR are available for testing with the `maxrake/phylum-ci:exclusions` Docker image found [on Docker Hub](https://hub.docker.com/r/maxrake/phylum-ci/tags).

The changes were tested explicitly for each of the following environments:

* Locally
* pre-commit
* GitHub Actions
* Jenkins

The changes were not tested in the following environments since the syntax for pipeline specification is the same (YAML) as for GitHub Actions:

* Azure
* Bitbucket
* GitLab

## Output

Specifying bad patterns results in a warning:

```
❯ poetry run phylum-ci -vvafe '!'
---TRIMMED---
DEBUG    Exclusion patterns provided as arguments: ['!']
WARNING  Could not parse provided gitignore-style exclusion pattern!
         Invalid git pattern: '!'
         For more info, see: https://git-scm.com/docs/gitignore#_pattern_format
         Continuing without exclusions ...
---TRIMMED---
```

## Related

phylum-dev/phylum-analyze-pr-action#39 was created to apply the same documentation updates for the GitHub Action. That one will not be merged until after the changes from this PR have been approved, merged, and a release created from it.