### PR TITLE
build: update `python-semantic-release` pin

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1099,13 +1099,13 @@ yaml = ["PyYaml (>=6.0.1)"]
 
 [[package]]
 name = "python-semantic-release"
-version = "9.8.3"
+version = "9.8.7"
 description = "Automatic Semantic Versioning for Python projects"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "python_semantic_release-9.8.3-py3-none-any.whl", hash = "sha256:da90401ebce238bb71cc6c2506852fd8266b3e608946cbbae0bb0bda216a459a"},
-    {file = "python_semantic_release-9.8.3.tar.gz", hash = "sha256:c4d83296917476ce6fb53ffdd52f254b9fd0de04cc1b255426f209f8f7984189"},
+    {file = "python_semantic_release-9.8.7-py3-none-any.whl", hash = "sha256:ed26c69878dd5439ad1dc8120e5f4251088277b1a760278b60bf7957f0e88630"},
+    {file = "python_semantic_release-9.8.7.tar.gz", hash = "sha256:0781e615c3c12583bee78c7e772f14b75078de17f81ab2527bb71a1e13706b74"},
 ]
 
 [package.dependencies]
@@ -1124,10 +1124,10 @@ tomlkit = ">=0.11,<1.0"
 
 [package.extras]
 build = ["build (>=1.2,<2.0)"]
-dev = ["pre-commit (>=3.5,<4.0)", "ruff (==0.4.9)", "tox (>=4.11,<5.0)"]
+dev = ["pre-commit (>=3.5,<4.0)", "ruff (==0.5.0)", "tox (>=4.11,<5.0)"]
 docs = ["Sphinx (>=6.0,<7.0)", "furo (>=2024.1,<2025.0)", "sphinx-autobuild (==2024.2.4)", "sphinxcontrib-apidoc (==0.5.0)"]
-mypy = ["mypy (==1.10.0)", "types-requests (>=2.31.0,<2.32.0)"]
-test = ["coverage[toml] (>=7.0,<8.0)", "pytest (>=7.0,<8.0)", "pytest-clarity (>=1.0,<2.0)", "pytest-cov (>=5.0,<6.0)", "pytest-env (>=1.0,<2.0)", "pytest-lazy-fixture (>=0.6.3,<0.7.0)", "pytest-mock (>=3.0,<4.0)", "pytest-pretty (>=1.2,<2.0)", "pytest-xdist (>=3.0,<4.0)", "requests-mock (>=1.10,<2.0)", "responses (>=0.25.0,<0.26.0)", "types-pytest-lazy-fixture (>=0.6.3,<0.7.0)"]
+mypy = ["mypy (==1.10.1)", "types-requests (>=2.32.0,<2.33.0)"]
+test = ["coverage[toml] (>=7.0,<8.0)", "pytest (>=8.3,<9.0)", "pytest-clarity (>=1.0,<2.0)", "pytest-cov (>=5.0,<6.0)", "pytest-env (>=1.0,<2.0)", "pytest-lazy-fixtures (>=1.1.1,<1.2.0)", "pytest-mock (>=3.0,<4.0)", "pytest-pretty (>=1.2,<2.0)", "pytest-xdist (>=3.0,<4.0)", "requests-mock (>=1.10,<2.0)", "responses (>=0.25.0,<0.26.0)"]
 
 [[package]]
 name = "pyyaml"
@@ -1795,4 +1795,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "c8e1f18af5d06f0f4ffc8d072970b1c7add8ff2cd39fe33a353724bd47f70948"
+content-hash = "39105accb86f3d007901cc48e1750e33e93c68b58bc11c66eb478f50d1f2110a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,9 +68,11 @@ optional = true
 [tool.poetry.group.ci.dependencies]
 tox-gh-actions = "*"
 pytest-github-actions-annotate-failures = "*"
-# TODO: Remove pin when PSR defines the `context` variable in release notes templates:
-#       https://github.com/python-semantic-release/python-semantic-release/issues/984
-python-semantic-release = "9.8.3"
+# PSR re-defined the `context` variable in release notes templates in v9.8.7, but
+# expects to remove it again in the next major version. Pin to prevent that upgrade.
+# https://github.com/python-semantic-release/python-semantic-release/pull/1005
+# https://github.com/python-semantic-release/python-semantic-release/issues/984
+python-semantic-release = "^9.8.7"
 rich-codex = "*"
 
 [tool.poetry.group.qa]

--- a/templates/.release_notes.md.j2
+++ b/templates/.release_notes.md.j2
@@ -3,6 +3,6 @@
     Ref: https://python-semantic-release.readthedocs.io/en/latest/changelog_templates.html
 #}
 {% set releases = context.history.released.items() | list %}
-{% set prev_version = "v{}".format(releases[1][0]) %}
+{% set prev_version = releases[1][0].as_tag() %}
 {% include ".changes.j2" %}
-**Full Changelog**: {{ prev_version | compare_url("v{}".format(version)) }}
+**Full Changelog**: {{ prev_version | compare_url(version.as_tag()) }}


### PR DESCRIPTION
This change is an update to the one made in #454. Since then, the `python-semantic-release` (PSR) dependency has responded to their breaking change by re-defining the `context` variable for release notes templates. However, they also say that the variable was not meant to be exposed in the first place and that it will be removed again in the next major version release. Therefore, the pin has been changed to a caret-style one to allow for getting future releases that are at least v9.8.7 but less than v10.

Discussions with the maintainer are ongoing, to request the features relied upon with the current implementation are accounted for in the next major version release.

References:
* https://github.com/python-semantic-release/python-semantic-release/pull/1005
* https://github.com/python-semantic-release/python-semantic-release/issues/984

Additionally, the release notes template was refactored a tiny bit to account for new methods of doing the same thing, but with less code. The changes were tested locally and found to produce the same output as the previous template.
