### PR TITLE
docs: add exit code information

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The options for `phylum-ci`, automatically updated to be current for the latest 
 The `phylum-init` script entry point will return a zero (0) exit code when it completes successfully and a one (1)
 otherwise.
 
-The `phylum-ci` script entry point will also return a zero (0) exit code when it completes successfully or one of the
+The `phylum-ci` script entry point will return a zero (0) exit code when it completes successfully or one of the
 following non-zero codes otherwise:
 
 |Exit Code|Meaning|

--- a/README.md
+++ b/README.md
@@ -168,6 +168,25 @@ The options for `phylum-ci`, automatically updated to be current for the latest 
 [jenkins_docs]: https://docs.phylum.io/phylum-ci/jenkins
 [precommit_docs]: https://docs.phylum.io/phylum-ci/git_precommit
 
+### Exit Codes
+
+The `phylum-init` script entry point will return a zero (0) exit code when it completes successfully and a one (1)
+otherwise.
+
+The `phylum-ci` script entry point will also return a zero (0) exit code when it completes successfully or one of the
+following non-zero codes otherwise:
+
+|Exit Code|Meaning|
+|---------|-------|
+|1|Default failure code. An unrecoverable error was encountered.|
+|2|Phylum analysis is complete and contains a policy violation.|
+|6|Phylum analysis is incomplete and contains a policy violation.|
+|10|Dependency file(s) failed filtering and excluded from analysis. See [this FAQ][FAQ] for more.|
+|11|No dependency files were provided or detected.|
+|20|A manifest is attempted to be parsed but lockfile generation has been disabled.|
+
+[FAQ]: https://github.com/marketplace/actions/phylum-analyze-pr#why-does-phylum-report-a-failing-status-check-if-it-shows-a-successful-analysis-comment
+
 ## License
 
 Copyright (C) 2022  Phylum, Inc.

--- a/docs/integrations/azure_pipelines.md
+++ b/docs/integrations/azure_pipelines.md
@@ -438,6 +438,13 @@ information. Since these tokens are sensitive, **care should be taken to protect
           GITHUB_TOKEN: $(GITHUB_PAT)
 ```
 
+### Exit Codes
+
+The Phylum analysis job will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
+The full and current list of exit codes, with explanations, is [documented here][exit_codes].
+
+[exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
+
 ## Alternatives
 
 It is also possible to make direct use of the [`phylum` Python package][pypi] within CI.

--- a/docs/integrations/azure_pipelines.md
+++ b/docs/integrations/azure_pipelines.md
@@ -441,7 +441,7 @@ information. Since these tokens are sensitive, **care should be taken to protect
 ### Exit Codes
 
 The Phylum analysis job will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
-The full and current list of exit codes, with explanations, is [documented here][exit_codes].
+The full and current list of exit codes is [documented here][exit_codes].
 
 [exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
 

--- a/docs/integrations/bitbucket_pipelines.md
+++ b/docs/integrations/bitbucket_pipelines.md
@@ -347,6 +347,13 @@ view the [script options output][script_options] for the latest release.
         --all-deps
 ```
 
+### Exit Codes
+
+The Phylum analysis step will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
+The full and current list of exit codes, with explanations, is [documented here][exit_codes].
+
+[exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
+
 ## Alternatives
 
 It is also possible to make direct use of the [`phylum` Python package][pypi] within CI.

--- a/docs/integrations/bitbucket_pipelines.md
+++ b/docs/integrations/bitbucket_pipelines.md
@@ -350,7 +350,7 @@ view the [script options output][script_options] for the latest release.
 ### Exit Codes
 
 The Phylum analysis step will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
-The full and current list of exit codes, with explanations, is [documented here][exit_codes].
+The full and current list of exit codes is [documented here][exit_codes].
 
 [exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
 

--- a/docs/integrations/git_precommit.md
+++ b/docs/integrations/git_precommit.md
@@ -185,7 +185,7 @@ with `--help` output as specified in the [Usage section of the top-level README.
 ### Exit Codes
 
 The Phylum analysis hook will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
-The full and current list of exit codes, with explanations, is [documented here][exit_codes].
+The full and current list of exit codes is [documented here][exit_codes].
 
 [exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
 

--- a/docs/integrations/git_precommit.md
+++ b/docs/integrations/git_precommit.md
@@ -182,6 +182,13 @@ with `--help` output as specified in the [Usage section of the top-level README.
           - --all-deps
 ```
 
+### Exit Codes
+
+The Phylum analysis hook will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
+The full and current list of exit codes, with explanations, is [documented here][exit_codes].
+
+[exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
+
 ### Audit Mode
 
 It is possible to use the Phylum hook in an audit mode, where analysis is performed but results do not affect the exit

--- a/docs/integrations/github_actions.md
+++ b/docs/integrations/github_actions.md
@@ -146,3 +146,10 @@ See the [Installation][installation] and [Usage][usage] sections of the [README 
 [readme]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md
 [installation]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md#installation
 [usage]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md#usage
+
+## Exit Codes
+
+The Phylum analysis job/step will return a zero (0) exit code when it completes successfully and a non-zero code
+otherwise. The full and current list of exit codes, with explanations, is [documented here][exit_codes].
+
+[exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes

--- a/docs/integrations/github_actions.md
+++ b/docs/integrations/github_actions.md
@@ -150,6 +150,6 @@ See the [Installation][installation] and [Usage][usage] sections of the [README 
 ## Exit Codes
 
 The Phylum analysis job/step will return a zero (0) exit code when it completes successfully and a non-zero code
-otherwise. The full and current list of exit codes, with explanations, is [documented here][exit_codes].
+otherwise. The full and current list of exit codes is [documented here][exit_codes].
 
 [exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes

--- a/docs/integrations/gitlab_ci.md
+++ b/docs/integrations/gitlab_ci.md
@@ -339,7 +339,7 @@ view the [script options output][script_options] for the latest release.
 ### Exit Codes
 
 The Phylum analysis job will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
-The full and current list of exit codes, with explanations, is [documented here][exit_codes].
+The full and current list of exit codes is [documented here][exit_codes].
 
 [exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
 

--- a/docs/integrations/gitlab_ci.md
+++ b/docs/integrations/gitlab_ci.md
@@ -336,6 +336,13 @@ view the [script options output][script_options] for the latest release.
         --all-deps
 ```
 
+### Exit Codes
+
+The Phylum analysis job will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
+The full and current list of exit codes, with explanations, is [documented here][exit_codes].
+
+[exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
+
 ## Alternatives
 
 It is also possible to make direct use of the [`phylum` Python package][pypi] within CI.

--- a/docs/integrations/jenkins.md
+++ b/docs/integrations/jenkins.md
@@ -335,6 +335,13 @@ release.
       }
 ```
 
+### Exit Codes
+
+The Phylum analysis stage will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
+The full and current list of exit codes, with explanations, is [documented here][exit_codes].
+
+[exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
+
 ## Alternatives
 
 There are times where it may not be possible to have full git history with a complete checkout. It may also be the case

--- a/docs/integrations/jenkins.md
+++ b/docs/integrations/jenkins.md
@@ -338,7 +338,7 @@ release.
 ### Exit Codes
 
 The Phylum analysis stage will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
-The full and current list of exit codes, with explanations, is [documented here][exit_codes].
+The full and current list of exit codes is [documented here][exit_codes].
 
 [exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
 

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 from collections.abc import Sequence
+from inspect import cleandoc
 import os
 import pathlib
 import sys
@@ -252,7 +253,10 @@ def main(args: Optional[Sequence[str]] = None) -> int:
     if ci_env.audit_mode:
         LOG.info("Audit mode enabled. Original return code: %s", returncode)
         returncode = 0
-    LOG.debug("Return code: %s", returncode)
+    msg = f"""
+        Return code: {returncode}
+        More info: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes"""
+    LOG.debug(cleandoc(msg))
     return returncode
 
 

--- a/src/phylum/ci/common.py
+++ b/src/phylum/ci/common.py
@@ -98,6 +98,7 @@ class ReturnCode(IntEnum):
     SUCCESS = 0
     # NOTE: Don't create a unique entry here for the value `1`. That value is used for default
     #       failures (when a `SystemExit` exception is raised with a message instead of a code).
+    #       Updates to this list should be kept in sync with the "Exit Codes" section of `README.md`.
     #
     # Phylum analysis is complete and contains a policy violation
     POLICY_FAILURE = 2


### PR DESCRIPTION
This change documents the various exit codes in use for the `phylum-ci` script entry point. The documentation for integrations that make use of this script were updated to include a reference to the detail. The debug output now includes a link to that same detail.

This change was generated from a user request. They were curious to know why a failing status check was reported when a successful analysis comment was added to their PR. They didn't understand what exit code 10 meant. This specific situation is already answered in a FAQ and now is more likely to be seen since it is referenced in the exit code table.
