### PR TITLE
fix: include `phylum-ci.exe` in release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
-          name: phylum-ci.exe
+          name: build
           path: ./build/phylum-ci.exe
           if-no-files-found: error
 


### PR DESCRIPTION
This change corrects a bug in the release workflow where the `phylum-ci.exe` artifact is not published to the newly created GitHub release. The `python-semantic-release` tool has the following config, in `pyproject.toml`, for publishing artifacts by pattern:

```
[tool.semantic_release.publish]
dist_glob_patterns = ["dist/*", "build/phylum-ci.exe"]
```

The issue was that the `actions/upload-artifact` step used `phylum-ci.exe` as the artifact name, which resulted in the following directory structure for the corresponding `actions/download-artifact` step:

`./phylum-ci.exe/phylum-ci.exe`

This clearly won't match the glob pattern of `build/phylum-ci.exe`. So, this change is a simple one: change the upload artifact name to `build` so that the downloaded artifact will exist at `./build/phylum-ci.exe`.
