### PR TITLE
feat: add Windows standalone archive install option

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -96,16 +96,28 @@ jobs:
         run: poetry publish --repository testpypi --username __token__ --password ${{ secrets.TESTPYPI_API_TOKEN }}
 
   build_windows:
-    name: Build Windows standalone binary
+    name: Build Windows ${{ matrix.name }} binary
     if: inputs.CompileWindows
     needs: publish_preview
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: standalone
+            options: --standalone --remove-output
+            binary: ./build/cli.dist/phylum-ci.exe
+            artifact: ./phylum-ci.zip
+          - name: onefile
+            options: --onefile --onefile-tempdir-spec="{CACHE_DIR}/{PRODUCT}/{VERSION}"
+            binary: ./build/phylum-ci.exe
+            artifact: ./build/phylum-ci.exe
     steps:
       - name: Checkout the repo
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
-        # Nuitka needs the packaged form and not the editable install Poetry provides
-        # Ref: https://github.com/Nuitka/Nuitka/issues/2965
+      # Nuitka needs the packaged form and not the editable install Poetry provides
+      # Ref: https://github.com/Nuitka/Nuitka/issues/2965
       - name: Download build artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
 
@@ -132,13 +144,12 @@ jobs:
           PREVIEW_VER: ${{ needs.publish_preview.outputs.next_ver }}
         run: |
           poetry run python -m nuitka `
-            --onefile `
+            ${{ matrix.options }} `
             --output-dir=build `
             --output-filename="phylum-ci.exe" `
             --include-package=phylum `
             --include-package-data=phylum `
             --include-distribution-metadata=phylum `
-            --onefile-tempdir-spec="{CACHE_DIR}/{PRODUCT}/{VERSION}" `
             --product-name=phylum-ci `
             --product-version=${env:PREVIEW_VER} `
             --file-version=${env:GITHUB_RUN_NUMBER} `
@@ -153,27 +164,32 @@ jobs:
             --deployment `
             src/phylum/ci/cli.py
 
+      # Create the archive here because the confirmation step adds files to the source path
+      - name: Create standalone zip archive
+        if: matrix.name == 'standalone'
+        run: Compress-Archive -Path ./build/cli.dist/* -DestinationPath ${{ matrix.artifact }}
+
       - name: Confirm operation of binary
         env:
           PHYLUM_API_KEY: ${{ secrets.PHYLUM_TOKEN }}
           PHYLUM_BYPASS_CI_DETECTION: true
         run: |
-          ./build/phylum-ci.exe -h
-          ./build/phylum-ci.exe -vvaf
+          ${{ matrix.binary }} -h
+          ${{ matrix.binary }} -vvaf
 
-      - name: Upload standalone binary
+      - name: Upload ${{ matrix.name }} artifact
         if: always()
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
-          name: phylum-ci.exe
-          path: ./build/phylum-ci.exe
+          name: phylum-ci-${{ matrix.name }}
+          path: ${{ matrix.artifact }}
           if-no-files-found: error
 
       - name: Upload compilation report
         if: always()
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
-          name: nuitka-compilation-report.xml
+          name: nuitka-compilation-report-${{ matrix.name }}
           path: ./nuitka-compilation-report.xml
           if-no-files-found: warn
 
@@ -182,6 +198,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
-          name: nuitka-crash-report.xml
+          name: nuitka-crash-report-${{ matrix.name }}
           path: ./nuitka-crash-report.xml
           if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,15 +131,27 @@ jobs:
             phylum-ci -h
 
   build_windows:
-    name: Build Windows standalone binary
+    name: Build Windows ${{ matrix.name }} binary
     needs: build_dist
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: standalone
+            options: --standalone --remove-output
+            binary: ./build/cli.dist/phylum-ci.exe
+            artifact: ./phylum-ci.zip
+          - name: onefile
+            options: --onefile --onefile-tempdir-spec="{CACHE_DIR}/{PRODUCT}/{VERSION}"
+            binary: ./build/phylum-ci.exe
+            artifact: ./build/phylum-ci.exe
     steps:
       - name: Checkout the repo
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
-        # Nuitka needs the packaged form and not the editable install Poetry provides
-        # Ref: https://github.com/Nuitka/Nuitka/issues/2965
+      # Nuitka needs the packaged form and not the editable install Poetry provides
+      # Ref: https://github.com/Nuitka/Nuitka/issues/2965
       - name: Download build artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
 
@@ -166,13 +178,12 @@ jobs:
           PHYLUM_REL_VER: ${{ needs.build_dist.outputs.phylum_rel_ver_nuitka }}
         run: |
           poetry run python -m nuitka `
-            --onefile `
+            ${{ matrix.options }} `
             --output-dir=build `
             --output-filename="phylum-ci.exe" `
             --include-package=phylum `
             --include-package-data=phylum `
             --include-distribution-metadata=phylum `
-            --onefile-tempdir-spec="{CACHE_DIR}/{PRODUCT}/{VERSION}" `
             --product-name=phylum-ci `
             --product-version=${env:PHYLUM_REL_VER} `
             --file-version=${env:GITHUB_RUN_NUMBER} `
@@ -187,27 +198,32 @@ jobs:
             --deployment `
             src/phylum/ci/cli.py
 
+      # Create the archive here because the confirmation step adds files to the source path
+      - name: Create standalone zip archive
+        if: matrix.name == 'standalone'
+        run: Compress-Archive -Path ./build/cli.dist/* -DestinationPath ${{ matrix.artifact }}
+
       - name: Confirm operation of binary
         env:
           PHYLUM_API_KEY: ${{ secrets.PHYLUM_TOKEN }}
           PHYLUM_BYPASS_CI_DETECTION: true
         run: |
-          ./build/phylum-ci.exe -h
-          ./build/phylum-ci.exe -vvaf
+          ${{ matrix.binary }} -h
+          ${{ matrix.binary }} -vvaf
 
-      - name: Upload standalone binary
+      - name: Upload ${{ matrix.name }} artifact
         if: always()
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
-          name: build
-          path: ./build/phylum-ci.exe
+          name: phylum-ci-${{ matrix.name }}
+          path: ${{ matrix.artifact }}
           if-no-files-found: error
 
       - name: Upload compilation report
         if: always()
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
-          name: nuitka-compilation-report.xml
+          name: nuitka-compilation-report-${{ matrix.name }}
           path: ./nuitka-compilation-report.xml
           if-no-files-found: warn
 
@@ -216,7 +232,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
-          name: nuitka-crash-report.xml
+          name: nuitka-crash-report-${{ matrix.name }}
           path: ./nuitka-crash-report.xml
           if-no-files-found: ignore
 
@@ -252,8 +268,18 @@ jobs:
           git_commit_gpgsign: true
           git_tag_gpgsign: true
 
+      - name: Download dist artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: dist
+          path: ./dist
+
       - name: Download build artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          path: ./build
+          pattern: phylum-ci-*
+          merge-multiple: true
 
       - name: Install poetry
         run: pipx install poetry==${{ env.POETRY_VERSION }}

--- a/README.md
+++ b/README.md
@@ -54,13 +54,14 @@ Windows binaries are offered as [release artifacts][latest_rels] for a "standalo
 Python or Docker to run. There are two options for this installation method:
 
 * `phylum-ci.zip`
-  * [Download the latest version][latest_zip] and extract the archive
+  * [Download the latest archive version][latest_zip] and extract the archive
   * Add the extracted directory to `PATH` or reference the contained `phylum-ci.exe` binary directly
 * `phylum-ci.exe`
-  * [Download the latest version][latest_exe] and place this binary on `PATH` or reference it directly
+  * [Download the latest executable version][latest_exe] and place this binary on `PATH` or reference it directly
   * This is a self-extracting executable that adds a version-specific directory in the local user cache
-  * An advantage to this solution is that it is a single file
-  * A disadvantage is that the file may trigger AV since it uses a packer and is not digitally signed
+
+An advantage to the self-extracting archive solution is that it is a single file.
+A disadvantage is that the file may trigger AV since it uses a packer and is not digitally signed.
 
 Either Windows "installation" method allows access to the same [`phylum-ci` script entry point features][anchor_script].
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,24 @@ pipx run --spec phylum phylum-ci <options>
 These installation methods require Python 3.9+ to run.
 For a self contained environment, consider using the Docker image as described below.
 
-A Windows binary, `phylum-ci.exe`, is offered as a [release artifact][latest_rels] and does not require Python to run.
-Simply [download the latest version][latest_artifact] and run it to access the same
-[`phylum-ci` script entry point features][anchor_script].
+Windows binaries are offered as [release artifacts][latest_rels] for a "standalone" solution that does not require
+Python or Docker to run. There are two options for this installation method:
+
+* `phylum-ci.zip`
+  * [Download the latest version][latest_zip] and extract the archive
+  * Add the extracted directory to `PATH` or reference the contained `phylum-ci.exe` binary directly
+* `phylum-ci.exe`
+  * [Download the latest version][latest_exe] and place this binary on `PATH` or reference it directly
+  * This is a self-extracting executable that adds a version-specific directory in the local user cache
+  * An advantage to this solution is that it is a single file
+  * A disadvantage is that the file may trigger AV since it uses a packer and is not digitally signed
+
+Either Windows "installation" method allows access to the same [`phylum-ci` script entry point features][anchor_script].
 
 [pipx]: https://pypa.github.io/pipx/
 [latest_rels]: https://github.com/phylum-dev/phylum-ci/releases/latest
-[latest_artifact]: https://github.com/phylum-dev/phylum-ci/releases/latest/download/phylum-ci.exe
+[latest_zip]: https://github.com/phylum-dev/phylum-ci/releases/latest/download/phylum-ci.zip
+[latest_exe]: https://github.com/phylum-dev/phylum-ci/releases/latest/download/phylum-ci.exe
 [anchor_script]: #phylum-ci-script-entry-point
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ Windows binaries are offered as [release artifacts][latest_rels] for a "standalo
 Python or Docker to run. There are two options for this installation method:
 
 * `phylum-ci.zip`
-  * [Download the latest archive version][latest_zip] and extract the archive
+  * [Download the latest archive version][latest_zip] and extract it
   * Add the extracted directory to `PATH` or reference the contained `phylum-ci.exe` binary directly
 * `phylum-ci.exe`
   * [Download the latest executable version][latest_exe] and place this binary on `PATH` or reference it directly
   * This is a self-extracting executable that adds a version-specific directory in the local user cache
 
-An advantage to the self-extracting archive solution is that it is a single file.
+An advantage to the self-extracting archive is that it is a single file.
 A disadvantage is that the file may trigger AV since it uses a packer and is not digitally signed.
 
 Either Windows "installation" method allows access to the same [`phylum-ci` script entry point features][anchor_script].

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,7 @@ commit_author = "phylum-bot <69485888+phylum-bot@users.noreply.github.com>"
 logging_use_named_masks = true
 
 [tool.semantic_release.publish]
-dist_glob_patterns = ["dist/*", "build/phylum-ci.exe"]
+dist_glob_patterns = ["dist/*", "build/phylum-ci.exe", "build/phylum-ci.zip"]
 
 [tool.semantic_release.changelog.environment]
 trim_blocks = true


### PR DESCRIPTION
This change adds another Windows standalone "installation" option, in the form of a zip archive that contains all the files needed to run the `phylum-ci.exe` binary...which is also included in the archive. This option is not as convenient as the single file self-extracting executable since it requires an additional unzipping step. It does have the advantage of not getting flagged by antivirus. This option was added based on direct feedback from an existing customer and directed by @furi0us333.

## Testing

The changes from this branch were tested in a Preview workflow run made from a `standalone_test` branch and can [be viewed here](https://github.com/phylum-dev/phylum-ci/actions/runs/11258132652). The zip archive did not flag AV and the contents were successfully used on a Windows system to analyze a git repository.