### PR TITLE
feat!: add organization support

### DIFF
--- a/docs/integrations/azure_pipelines.md
+++ b/docs/integrations/azure_pipelines.md
@@ -300,12 +300,11 @@ view the [script options output][script_options] for the latest release.
       # casting the widest net for strict adherence to Quality Assurance (QA) standards.
       - script: phylum-ci --all-deps
 
-      # Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in that
-      # they can be named differently and may or may not contain strict dependencies.
-      # In these cases it is best to specify an explicit path, either with the `--depfile`
-      # option or in a `.phylum_project` file. The easiest way to do that is with the
-      # Phylum CLI, using `phylum init` command (docs.phylum.io/cli/commands/phylum_init)
-      # and committing the generated `.phylum_project` file.
+      # Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in
+      # that they can be named differently and may or may not contain strict
+      # dependencies. In these cases it is best to specify an explicit path, either
+      # with the `--depfile` option or in a `.phylum_project` file. For more, see:
+      # https://docs.phylum.io/knowledge_base/phylum_project_files
       - script: phylum-ci --depfile requirements-prod.txt
 
       # Specify multiple explicit dependency file paths.
@@ -325,8 +324,10 @@ view the [script options output][script_options] for the latest release.
       # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
       - script: phylum-ci --force-analysis --all-deps --depfile Cargo.toml
 
-      # Perform analysis as part of a group-owned project.
-      # A paid account is needed to use groups: https://phylum.io/pricing
+      # Perform analysis as part of an organization and/or group-owned project.
+      # When an org is specified, a group name must also be specified.
+      # A paid account is needed to use orgs or groups: https://phylum.io/pricing
+      - script: phylum-ci --org my_org --group my_group
       - script: phylum-ci --group my_group
 
       # Analyze all dependencies in audit mode, to gain insight without failing builds.
@@ -342,6 +343,8 @@ view the [script options output][script_options] for the latest release.
       - script: |
         phylum-ci \
           -vv \
+          --org my_org \
+          --group my_group \
           --depfile requirements-dev.txt \
           --depfile requirements-prod.txt path/to/dependency.file \
           --depfile Cargo.toml \
@@ -409,9 +412,8 @@ information. Since these tokens are sensitive, **care should be taken to protect
 ```yaml
         env:
           # Contact Phylum (phylum.io/contact-us) or register (app.phylum.io/register)
-          # to gain access. See also `phylum auth register`
-          # (docs.phylum.io/cli/commands/phylum_auth_register) command documentation.
-          # Consider using a bot or group account for this token.
+          # to gain access. Consider using a bot or group account for this token. See:
+          # https://docs.phylum.io/knowledge_base/api-keys
           # This value (`PHYLUM_TOKEN`) will need to be set as a secret variable:
           # https://learn.microsoft.com/azure/devops/pipelines/process/set-secret-variables
           PHYLUM_API_KEY: $(PHYLUM_TOKEN)

--- a/docs/integrations/bitbucket_pipelines.md
+++ b/docs/integrations/bitbucket_pipelines.md
@@ -298,12 +298,11 @@ view the [script options output][script_options] for the latest release.
     # casting the widest net for strict adherence to Quality Assurance (QA) standards.
     - phylum-ci --all-deps
 
-    # Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in that
-    # they can be named differently and may or may not contain strict dependencies.
-    # In these cases it is best to specify an explicit path, either with the `--depfile`
-    # option or in a `.phylum_project` file. The easiest way to do that is with the
-    # Phylum CLI, using `phylum init` command (docs.phylum.io/cli/commands/phylum_init)
-    # and committing the generated `.phylum_project` file.
+    # Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in
+    # that they can be named differently and may or may not contain strict
+    # dependencies. In these cases it is best to specify an explicit path, either
+    # with the `--depfile` option or in a `.phylum_project` file. For more, see:
+    # https://docs.phylum.io/knowledge_base/phylum_project_files
     - phylum-ci --depfile requirements-prod.txt
 
     # Specify multiple explicit dependency file paths.
@@ -323,8 +322,10 @@ view the [script options output][script_options] for the latest release.
     # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
     - phylum-ci --force-analysis --all-deps --depfile Cargo.toml
 
-    # Perform analysis as part of a group-owned project.
-    # A paid account is needed to use groups: https://phylum.io/pricing
+    # Perform analysis as part of an organization and/or group-owned project.
+    # When an org is specified, a group name must also be specified.
+    # A paid account is needed to use orgs or groups: https://phylum.io/pricing
+    - phylum-ci --org my_org --group my_group
     - phylum-ci --group my_group
 
     # Analyze all dependencies in audit mode, to gain insight without failing builds.
@@ -340,6 +341,8 @@ view the [script options output][script_options] for the latest release.
     - |
       phylum-ci \
         -vv \
+        --org my_org \
+        --group my_group \
         --depfile requirements-dev.txt \
         --depfile requirements-prod.txt path/to/dependency.file \
         --depfile Cargo.toml \

--- a/docs/integrations/git_precommit.md
+++ b/docs/integrations/git_precommit.md
@@ -137,8 +137,9 @@ with `--help` output as specified in the [Usage section of the top-level README.
 
         # Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in that
         # they can be named differently and may be a manifest or a lockfile. In cases where
-        # only specific dependency files are meant to be analyzed, it is best to specify
-        # an explicit path to them.
+        # only specific dependency files are meant to be analyzed, it is best to specify an
+        # explicit path, either with the `--depfile` option or in a `.phylum_project` file.
+        # For more, see: https://docs.phylum.io/knowledge_base/phylum_project_files
         args: [--depfile=requirements-prod.txt]
 
         # Specify multiple explicit dependency file paths.
@@ -162,9 +163,11 @@ with `--help` output as specified in the [Usage section of the top-level README.
         # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
         args: [--force-analysis, --all-deps, --depfile=Cargo.toml]
 
-        # Perform analysis as part of a group-owned project.
-        # A paid account is needed to use groups: https://phylum.io/pricing
-        args: [--group, my_group]
+        # Perform analysis as part of an organization and/or group-owned project.
+        # When an org is specified, a group name must also be specified.
+        # A paid account is needed to use orgs or groups: https://phylum.io/pricing
+        args: [--org=my_org, --group=my_group]
+        args: [--group=my_group]
 
         # Ensure the latest Phylum CLI is installed.
         args: [--force-install]
@@ -175,6 +178,8 @@ with `--help` output as specified in the [Usage section of the top-level README.
         # Mix and match for your specific use case.
         args:
           - -vv
+          - --org=my_org
+          - --group=my_group
           - --depfile=requirements-prod.txt
           - --depfile=path/to/dependency.file
           - --depfile=Cargo.toml

--- a/docs/integrations/gitlab_ci.md
+++ b/docs/integrations/gitlab_ci.md
@@ -252,9 +252,9 @@ Values for the `GITLAB_TOKEN` and `PHYLUM_API_KEY` variables can come from a [CI
     # Group - https://docs.gitlab.com/ee/user/group/settings/group_access_tokens.html
     GITLAB_TOKEN: $GITLAB_TOKEN_VARIABLE_OR_SECRET_HERE
 
-    # Contact Phylum (phylum.io/contact-us) or register (app.phylum.io/register) to gain
-    # access. See also `phylum auth register` (docs.phylum.io/cli/commands/phylum_auth_register)
-    # command documentation. Consider using a bot or group account for this token.
+    # Contact Phylum (phylum.io/contact-us) or register (app.phylum.io/register)
+    # to gain access. Consider using a bot or group account for this token.
+    # See https://docs.phylum.io/knowledge_base/api-keys
     PHYLUM_API_KEY: $PHYLUM_TOKEN_VARIABLE_OR_SECRET_HERE
 ```
 
@@ -286,12 +286,11 @@ view the [script options output][script_options] for the latest release.
     # casting the widest net for strict adherence to Quality Assurance (QA) standards.
     - phylum-ci --all-deps
 
-    # Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in that
-    # they can be named differently and may or may not contain strict dependencies.
-    # In these cases it is best to specify an explicit path, either with the `--depfile`
-    # option or in a `.phylum_project` file. The easiest way to do that is with the
-    # Phylum CLI, using the `phylum init` command (docs.phylum.io/cli/commands/phylum_init)
-    # and committing the generated `.phylum_project` file.
+    # Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in
+    # that they can be named differently and may or may not contain strict
+    # dependencies. In these cases it is best to specify an explicit path, either
+    # with the `--depfile` option or in a `.phylum_project` file. For more, see:
+    # https://docs.phylum.io/knowledge_base/phylum_project_files
     - phylum-ci --depfile requirements-prod.txt
 
     # Specify multiple explicit dependency file paths.
@@ -311,8 +310,10 @@ view the [script options output][script_options] for the latest release.
     # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
     - phylum-ci --force-analysis --all-deps --depfile Cargo.toml
 
-    # Perform analysis as part of a group-owned project.
-    # A paid account is needed to use groups: https://phylum.io/pricing
+    # Perform analysis as part of an organization and/or group-owned project.
+    # When an org is specified, a group name must also be specified.
+    # A paid account is needed to use orgs or groups: https://phylum.io/pricing
+    - phylum-ci --org my_org --group my_group
     - phylum-ci --group my_group
 
     # Analyze all dependencies in audit mode, to gain insight without failing builds.
@@ -329,6 +330,8 @@ view the [script options output][script_options] for the latest release.
     - |
       phylum-ci \
         -vv \
+        --org my_org \
+        --group my_group \
         --depfile requirements-dev.txt \
         --depfile requirements-prod.txt path/to/dependency.file \
         --depfile Cargo.toml \

--- a/docs/integrations/jenkins.md
+++ b/docs/integrations/jenkins.md
@@ -286,12 +286,11 @@ release.
           // casting the widest net for strict adherence to Quality Assurance (QA) standards.
           sh 'phylum-ci --all-deps'
 
-          // Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in that
-          // they can be named differently and may or may not contain strict dependencies.
-          // In these cases it is best to specify an explicit path, either with the `--depfile`
-          // option or in a `.phylum_project` file. The easiest way to do that is with the
-          // Phylum CLI, using `phylum init` command (docs.phylum.io/cli/commands/phylum_init)
-          // and committing the generated `.phylum_project` file.
+          // Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in
+          // that they can be named differently and may or may not contain strict
+          // dependencies. In these cases it is best to specify an explicit path, either
+          // with the `--depfile` option or in a `.phylum_project` file. For more, see:
+          // https://docs.phylum.io/knowledge_base/phylum_project_files
           sh 'phylum-ci --depfile requirements-prod.txt'
 
           // Specify multiple explicit dependency file paths.
@@ -310,8 +309,10 @@ release.
           // for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
           sh 'phylum-ci --force-analysis --all-deps --depfile Cargo.toml'
 
-          // Perform analysis as part of a group-owned project.
-          // A paid account is needed to use groups: https://phylum.io/pricing
+          // Perform analysis as part of an organization and/or group-owned project.
+          // When an org is specified, a group name must also be specified.
+          // A paid account is needed to use orgs or groups: https://phylum.io/pricing
+          sh 'phylum-ci --org my_org --group my_group'
           sh 'phylum-ci --group my_group'
 
           // Analyze all dependencies in audit mode, to gain insight without failing builds.
@@ -326,6 +327,8 @@ release.
           // Mix and match for your specific use case.
           sh 'phylum-ci \
             -vv \
+            --org my_org \
+            --group my_group \
             --depfile requirements-dev.txt \
             --depfile requirements-prod.txt path/to/dependency.file \
             --depfile Cargo.toml \

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -167,6 +167,14 @@ def get_args(args: Optional[Sequence[str]] = None) -> tuple[argparse.Namespace, 
             A deterministic project name will be used when neither are provided.""",
     )
     analysis_group.add_argument(
+        "-o",
+        "--org",
+        help="""Optional organization name. Can also specify this option's value in the Phylum settings file:
+        https://docs.phylum.io/cli/commands/phylum_org_link. The value specified with this option takes precedence when
+        both are provided. When an org is specified, a group name must also be specified. Orgs require a paid account:
+        https://phylum.io/pricing""",
+    )
+    analysis_group.add_argument(
         "-g",
         "--group",
         help="""Optional group name, which will be the owner of the project. Can also specify this option's value in the

--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -3,12 +3,12 @@
 from phylum import __version__
 
 # This is the minimum CLI version supported for new installs.
-# Support for analysis on Windows was enabled in v7.1.0-rc1
-MIN_CLI_VER_FOR_INSTALL = "v7.1.0-rc1"
+# Support for analysis with organizations via extensions was enabled in v7.1.4-rc1
+MIN_CLI_VER_FOR_INSTALL = "v7.1.4-rc1"
 
 # This is the minimum CLI version supported for existing installs.
-# Support for analysis on Windows was enabled in v7.1.0-rc1
-MIN_CLI_VER_INSTALLED = "v7.1.0-rc1"
+# Support for analysis with organizations via extensions was enabled in v7.1.4-rc1
+MIN_CLI_VER_INSTALLED = "v7.1.4-rc1"
 
 # Keys are lowercase machine hardware names as returned from `uname -m`.
 # Values are the mapped rustc architecture.

--- a/src/phylum/exts/ci/main.ts
+++ b/src/phylum/exts/ci/main.ts
@@ -4,17 +4,34 @@ import { Package, PackageWithOrigin, PhylumApi } from "phylum";
 const args = Deno.args.slice(0);
 if (args.length < 4) {
     console.error(
-        "Usage: phylum ci <PROJECT> <LABEL> [--group <GROUP>] <BASE> <CURRENT>",
+        "Usage: phylum ci [--org <ORG>] [--group <GROUP>] <PROJECT> <LABEL> <BASE> <CURRENT>",
     );
     Deno.exit(1);
 }
 
-// Find optional groups argument.
+// Find optional org argument.
+let org = undefined;
+const orgArgsIndex = args.indexOf("--org");
+if (orgArgsIndex != -1) {
+    const orgArgs = args.splice(orgArgsIndex, 2);
+    org = orgArgs[1];
+}
+
+// Find optional group argument.
 let group = undefined;
 const groupArgsIndex = args.indexOf("--group");
 if (groupArgsIndex != -1) {
     const groupArgs = args.splice(groupArgsIndex, 2);
     group = groupArgs[1];
+}
+
+// It is not possible to specify an org without a group.
+if (org !== undefined && group === undefined) {
+    console.error(
+        "An organization was specified without a group.",
+        "Specify one with `--group` option.",
+    );
+    Deno.exit(1);
 }
 
 // Parse remaining arguments.
@@ -43,6 +60,7 @@ const jobID = await PhylumApi.analyze(
     project,
     group,
     label,
+    org,
 );
 
 // Get analysis job results.

--- a/src/phylum/init/cli.py
+++ b/src/phylum/init/cli.py
@@ -273,7 +273,7 @@ def is_token_set(phylum_settings_path: Path, token: Optional[str] = None) -> boo
     """
     try:
         settings_data = phylum_settings_path.read_text(encoding="utf-8")
-    except FileNotFoundError:
+    except OSError:
         return False
 
     yaml = YAML()


### PR DESCRIPTION
This change adds support for organizations. It does so by adding an optional `--org` argument to the `phylum-ci` entry point. That argument will take precedence over any value found in the Phylum settings file. The argument and all the logic and documentation around it allow for no org to be specified. This is intentional since there will have to be a transition period where some users may not be using orgs just yet.

When an org is specified, it is required that a group also be specified. However, it is still possible to specify a group without an org and even no group at all. The log output was updated to make it more clear which project/org/group combo is in use.

Additional changes made include:

* Update the custom `ci` Phylum analysis extension
  * Add `--org` option and use it when calling `PhylumApi::analyze`
* Account for change in `phylum project status` json output
  * Change `repository_url` to `repositoryUrl`
  * Fixes subtle bug where existing `repo_url` entries were overwritten
* Update documentation
  * Add example usage
  * Link to https://docs.phylum.io/knowledge_base/phylum_project_files
  * Link to https://docs.phylum.io/knowledge_base/api-keys in more spots
* Refactor and format throughout
  * Create `_cmd_extender` helper function to add common CLI options
    * This also helps to keep the McCabe complexity score low for QA
  * Use the parent `OSError` exception instead of more specific one
    * This may help prevent unhandled exceptions on Windows

BREAKING CHANGE: Phylum CLI installs before v7.1.4-rc1 are no longer supported. That release is the first one providing support for analysis with organizations via extensions.

## Testing

The changes in this PR are available for testing with the `maxrake/phylum-ci:orgs` Docker image found [on Docker Hub](https://hub.docker.com/r/maxrake/phylum-ci/tags).

The changes were tested explicitly for each of the following scenarios:

* org specified in `settings.yaml` file only
* org specified with `--org` option only
* different orgs specified in `settings.yaml` file and `--org` option
* non-existent org specified
* org specified without a group
* org/group pair that does not already exist
* org/group pair that does already exist
* group specified without an org
* project/org/group combos that do not already exist
* project/org/group combos that do already exist

## TODO

A separate PR in the `phylum-analyze-pr-action` repository will be created to update the documentation there. That PR won't be merged until after the changes from this PR have been approved, merged, and a release created from it.
