### PR TITLE
ci: `ctx` not available in release notes PSR env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,6 @@ and understanding.
 
 <!--next-version-placeholder-->
 
-## [v0.52.0](https://github.com/phylum-dev/phylum-ci/compare/v0.51.0...v0.52.0) (2024-11-07)
-
-### Breaking
-
-* Add organization support ([#499](https://github.com/phylum-dev/phylum-ci/pull/499)) ([`1ad0ea7`](https://github.com/phylum-dev/phylum-ci/commit/1ad0ea723d897455cf5e3c6cba5a130a3e41f876))
-  * Phylum CLI installs before v7.1.4-rc1 are no longer supported. That release is the first one providing support for analysis with organizations via extensions.
-
 ## [v0.51.0](https://github.com/phylum-dev/phylum-ci/compare/v0.50.0...v0.51.0) (2024-10-09)
 
 ### Feature

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "phylum"
-version = "0.52.0"
+version = "0.51.0"
 description = "Utilities for integrating Phylum into CI pipelines"
 license = "GPL-3.0-or-later"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]

--- a/templates/.release_notes.md.j2
+++ b/templates/.release_notes.md.j2
@@ -2,7 +2,7 @@
     This is a Jinja template for generating release notes with Python Semantic Release.
     Ref: https://python-semantic-release.readthedocs.io/en/latest/changelog_templates.html
 #}
-{% set releases = ctx.history.released.items() | list %}
+{% set releases = context.history.released.items() | list %}
 {% set prev_version = releases[1][0].as_tag() %}
 {% include ".changes.j2" %}
 **Full Changelog**: {{ prev_version | compare_url(version.as_tag()) }}


### PR DESCRIPTION
This update changes `ctx` to `context` in the release notes environment for Python Semantic Release (PSR). The pinned version of PSR, v9.12.0, has a bug where `ctx` is not a valid shorthand for release notes templates. This bug was fixed in PSR v9.12.1, but updating to a newer version of PSR always carries a risk of breaking changes. Such an update will be attempted at a later time.

I also had to back out the changes made by the bad v0.52.0 version bump
made by PSR. The tag has already been deleted.
