### PR TITLE
fix: exit cleanly when no current dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ following non-zero codes otherwise:
 |6|Phylum analysis is incomplete and contains a policy violation.|
 |10|Dependency file(s) failed filtering and excluded from analysis. See [this FAQ][FAQ] for more.|
 |11|No dependency files were provided or detected.|
+|12|No dependencies found in any current dependency file.|
 |20|A manifest is attempted to be parsed but lockfile generation has been disabled.|
 
 [FAQ]: https://github.com/marketplace/actions/phylum-analyze-pr#why-does-phylum-report-a-failing-status-check-if-it-shows-a-successful-analysis-comment

--- a/src/phylum/ci/ci_precommit.py
+++ b/src/phylum/ci/ci_precommit.py
@@ -15,7 +15,6 @@ import os
 from pathlib import Path
 import re
 import subprocess
-import sys
 from typing import Optional
 
 from phylum.ci.ci_base import CIBase
@@ -77,8 +76,8 @@ class CIPreCommit(CIBase):
             if any(depfile.path in extra_arg_paths for depfile in self.depfiles):
                 LOG.info("Valid pre-commit scenario found: dependency file(s) found in extra arguments")
                 return
-            LOG.warning("A dependency file is not included in extra args. Nothing to do. Exiting ...")
-            sys.exit(0)
+            LOG.warning("No dependency file included in extra args. Nothing to do. Exiting ...")
+            raise SystemExit(self.returncode)
 
         # Allow for a pre-commit config set up to filter the files sent to the hook
         if all(extra_arg in staged_files for extra_arg in self.extra_args):
@@ -86,8 +85,8 @@ class CIPreCommit(CIBase):
             if any(depfile.path in extra_arg_paths for depfile in self.depfiles):
                 LOG.info("Valid pre-commit scenario found: dependency file(s) found in extra arguments")
                 return
-            LOG.warning("A dependency file is not included in extra args. Nothing to do. Exiting ...")
-            sys.exit(0)
+            LOG.warning("No dependency file included in extra args. Nothing to do. Exiting ...")
+            raise SystemExit(self.returncode)
 
         # Allow for cases where the dependency file is included or explicitly specified.
         # Example: `pre-commit run --all-files`
@@ -100,9 +99,9 @@ class CIPreCommit(CIBase):
         #       `psutil` to acquire the command line from the parent process and inspect it for `pre-commit` usage.
         #       That is a heavyweight solution and one that will not be pursued until the need for it is more clear.
         else:
-            LOG.warning("A dependency file was not included in the extra args...possible invalid pre-commit scenario")
+            LOG.warning("No dependency file included in extra args...possible invalid pre-commit scenario")
             LOG.error("Unrecognized arguments: [code]%s[/]", " ".join(self.extra_args), extra=MARKUP)
-            sys.exit(0)
+            raise SystemExit(self.returncode)
 
     @cached_property
     def phylum_label(self) -> str:

--- a/src/phylum/ci/common.py
+++ b/src/phylum/ci/common.py
@@ -115,6 +115,8 @@ class ReturnCode(IntEnum):
     DEPFILE_FILTER = 10
     # No dependency files were provided or detected
     NO_DEPFILES_PROVIDED = 11
+    # No dependencies found in any current dependency file
+    NO_CURRENT_DEPS_FOUND = 12
     # A manifest is attempted to be parsed but lockfile generation has been disabled
     MANIFEST_WITHOUT_GENERATION = 20
 

--- a/src/phylum/logger.py
+++ b/src/phylum/logger.py
@@ -10,7 +10,7 @@ from rich.logging import RichHandler
 from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 import rich.traceback
 
-from phylum import PKG_NAME
+from phylum import PKG_NAME, __version__
 from phylum.console import console
 
 # Import and use this throughout the `phylum` package to write consistent log entries
@@ -125,6 +125,7 @@ def set_logger_level(level: int) -> None:
 
     # Set the level _after_ adding trace logging to avoid tracing the tracing setup
     LOG.setLevel(logging_level)
+    LOG.debug("Using package: %s v%s", PKG_NAME, __version__)
     LOG.debug("Logging initialized to level %s (%s)", logging_level, logging.getLevelName(logging_level))
 
 


### PR DESCRIPTION
This change accounts for the possibility that there are no current dependencies to analyze, even with recognized dependency files. Before this change, the `phylum-ci` entry point would exit with an unhandled exception and a large stack trace due to an empty analysis result being returned from the custom `ci` extension. Now, the situation is recognized and handled cleanly with a descriptive warning and new system exit code of `12`.

Other changes made include:

* Remove old dead code checking for CLI exit code value of `100`
  * The analysis is performed with the custom `ci` extension now
* Use `SystemExit` in `CIPreCommit` instead of `sys.exit`
  * Exit with the current return code
* Format and refactor throughout
  * Add link to phylum project file docs in error message
  * Add initial debug log message to show `phylum` package version

## Testing

The changes in this PR are available for testing with the `maxrake/phylum-ci:no_current_deps` Docker image found [on Docker Hub](https://hub.docker.com/r/maxrake/phylum-ci/tags).

This is what the unhandled error looks like with the current released version of `phylum-ci`:

<details><summary>Details (click to expand...)</summary>
<p>

```
❯ cat requirements-empty.txt
#There aren't any dependencies in this file
#requests
#phylum==0.52.0


❯ phylum-ci -vvaf --audit -p phylum-ci -g phylum_bot -d requirements-empty.txt
DEBUG    Logging initialized to level 10 (DEBUG)
DEBUG    Phylum CLI version not specified
DEBUG    Found installed Phylum CLI version: v7.1.4
DEBUG    Minimum supported Phylum CLI version required for install: v7.1.4-rc1
DEBUG    Making request to GitHub API URL: https://api.github.com/repos/phylum-dev/cli/releases
DEBUG    56 GitHub API requests remaining until window resets at:
         Wed Nov 20 13:59:28 2024
INFO     Using Phylum CLI version: v7.1.4
DEBUG    No CI environment detected
INFO     Confirming prerequisites ...
DEBUG    `git` binary found on the PATH
INFO     All prerequisites met
DEBUG    Existing Phylum CLI instance found: v7.1.4 at /Users/maxrake/.local/bin/phylum
INFO     Using Phylum CLI instance: v7.1.4 at /Users/maxrake/.local/bin/phylum
DEBUG    Project name provided as argument: phylum-ci
INFO     Attempting to create a Phylum project with name: phylum-ci ...
DEBUG    Org name not provided as argument. Checking Phylum settings file ...
DEBUG    Org name not found in Phylum settings file. Assuming no org ...
DEBUG    Group name provided as argument: phylum_bot
INFO     Using Phylum group: phylum_bot
INFO     Project/org/group combo already exists. Continuing with it.
             Project: phylum-ci
             Org:     (no org)
             Group:   phylum_bot
DEBUG    Repository URL not available to set
DEBUG    Dependency files provided as arguments: [requirements-empty.txt]
INFO     Parsing requirements-empty.txt as auto dependency file. Manifests take longer.
DEBUG    Determining viability of the Phylum sandbox in this environment ...
DEBUG    Executing command: /Users/maxrake/.local/bin/phylum sandbox --allow-run / true
INFO     The Phylum sandbox works in this environment and will be enabled
DEBUG    Using parse command: /Users/maxrake/.local/bin/phylum parse --type auto /Users/maxrake/dev/phylum/phylum-ci/requirements-empty.txt
DEBUG    Running command from: /Users/maxrake/dev/phylum/phylum-ci
WARNING  Provided dependency file requirements-empty.txt is a lockifest.
         It will be treated as a manifest.
         For more info, see: https://docs.phylum.io/cli/lockfile_generation
WARNING  At least one manifest file was included.
         Forcing analysis to ensure updated dependencies are included.
DEBUG    Valid provided dependency files: [requirements-empty.txt]
DEBUG    Dependency files in use: [requirements-empty.txt]
INFO     Forced analysis specified or otherwise set. Proceeding with analysis.
INFO     Label to use for analysis: No-CI_no_current_deps_667f7ee
DEBUG    0 unique current dependencies from 1 file(s)
INFO     Considering all current dependencies ...
INFO     Performing analysis. This may take a few seconds.
DEBUG    Using analysis command: /Users/maxrake/.local/bin/phylum extension run --yes
         /Users/maxrake/.local/pipx/venvs/phylum/lib/python3.12/site-packages/phylum/exts/ci phylum-ci No-CI_no_current_deps_667f7ee --group phylum_bot
         /var/folders/gh/wnf14j7n4q34y2t36hq2jz800000gn/T/base_xsm99p_j.json /var/folders/gh/wnf14j7n4q34y2t36hq2jz800000gn/T/curr_n71tn6k9.json
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /Users/maxrake/.local/bin/phylum-ci:8 in <module>                                                │
│                                                                                                  │
│   5 from phylum.ci.cli import script_main                                                        │
│   6 if __name__ == '__main__':                                                                   │
│   7 │   sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])                         │
│ ❱ 8 │   sys.exit(script_main())                                                                  │
│   9                                                                                              │
│                                                                                                  │
│ ╭─────────────────────────────────────────── locals ───────────────────────────────────────────╮ │
│ │  re = <module 're' from                                                                      │ │
│ │       '/Users/maxrake/.pyenv/versions/3.12.7/lib/python3.12/re/__init__.py'>                 │ │
│ │ sys = <module 'sys' (built-in)>                                                              │ │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
│                                                                                                  │
│ /Users/maxrake/.local/pipx/venvs/phylum/lib/python3.12/site-packages/phylum/ci/cli.py:283 in scr │
│                                                                                                  │
│   280 def script_main() -> None:                                                                 │
│   281 │   """Script entry point."""                                                              │
│   282 │   # The only point of this function is to ensure the proper exit code is set when call   │
│ ❱ 283 │   sys.exit(main())                                                                       │
│   284                                                                                            │
│   285                                                                                            │
│   286 if __name__ == "__main__":                                                                 │
│                                                                                                  │
│ /Users/maxrake/.local/pipx/venvs/phylum/lib/python3.12/site-packages/phylum/ci/cli.py:263 in mai │
│                                                                                                  │
│   260 │   LOG.info("Label to use for analysis: %s", ci_env.phylum_label)                         │
│   261 │                                                                                          │
│   262 │   # Analyze current project dependency file(s) with Phylum CLI                           │
│ ❱ 263 │   ci_env.analyze()                                                                       │
│   264 │                                                                                          │
│   265 │   # Output the results of the analysis                                                   │
│   266 │   ci_env.post_output()                                                                   │
│                                                                                                  │
│ ╭─────────────────────────────────────────── locals ───────────────────────────────────────────╮ │
│ │           args = None                                                                        │ │
│ │         ci_env = <phylum.ci.ci_none.CINone object at 0x103553110>                            │ │
│ │    parsed_args = Namespace(verbose=2, quiet=0,                                               │ │
│ │                  depfile=[[PosixPath('requirements-empty.txt')]], exclude=None,              │ │
│ │                  all_deps=True, force_analysis=True, token=None, project='phylum-ci',        │ │
│ │                  org=None, group='phylum_bot', skip_comments=False, audit=True,              │ │
│ │                  version='v7.1.4', target='aarch64-apple-darwin', uri=None,                  │ │
│ │                  force_install=False)                                                        │ │
│ │ remainder_args = []                                                                          │ │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
│                                                                                                  │
│ /Users/maxrake/.local/pipx/venvs/phylum/lib/python3.12/site-packages/phylum/logger.py:236 in tra │
│                                                                                                  │
│   233 │   │   │   │   transient=True,                                                            │
│   234 │   │   │   ) as progress:                                                                 │
│   235 │   │   │   │   task = progress.add_task(desc, total=None)                                 │
│ ❱ 236 │   │   │   │   result = func(*args, **kwargs)                                             │
│   237 │   │   │   │   progress.stop_task(task)                                                   │
│   238 │   │   │   return result                                                                  │
│   239                                                                                            │
│                                                                                                  │
│ ╭──────────────────────────── locals ────────────────────────────╮                               │
│ │     args = (<phylum.ci.ci_none.CINone object at 0x103553110>,) │                               │
│ │     desc = 'Analyzing dependencies with Phylum'                │                               │
│ │   kwargs = {}                                                  │                               │
│ │ progress = <rich.progress.Progress object at 0x10546ed80>      │                               │
│ │     task = 0                                                   │                               │
│ ╰────────────────────────────────────────────────────────────────╯                               │
│                                                                                                  │
│ /Users/maxrake/.local/pipx/venvs/phylum/lib/python3.12/site-packages/phylum/ci/ci_base.py:923 in │
│                                                                                                  │
│   920 │   │   │   │   │   │   If the command was expected to succeed, please report this as a    │
│       bug."""                                                                                    │
│   921 │   │   │   │   │   raise PhylumCalledProcessError(err, cleandoc(msg)) from err            │
│   922 │   │                                                                                      │
│ ❱ 923 │   │   self._parse_analysis_result(analysis_result)                                       │
│   924 │                                                                                          │
│   925 │   def _get_base_packages(self) -> Packages:                                              │
│   926 │   │   """Get the dependencies from the common ancestor commit and return them in         │
│       sorted order."""                                                                           │
│                                                                                                  │
│ ╭─────────────────────────────────────────── locals ───────────────────────────────────────────╮ │
│ │  analysis_result = '{}\n'                                                                    │ │
│ │          base_fd = <tempfile._TemporaryFileWrapper object at 0x10519d2e0>                    │ │
│ │    base_packages = []                                                                        │ │
│ │              cmd = [                                                                         │ │
│ │                    │   '/Users/maxrake/.local/bin/phylum',                                   │ │
│ │                    │   'extension',                                                          │ │
│ │                    │   'run',                                                                │ │
│ │                    │   '--yes',                                                              │ │
│ │                    │                                                                         │ │
│ │                    '/Users/maxrake/.local/pipx/venvs/phylum/lib/python3.12/site-packages/ph… │ │
│ │                    │   'phylum-ci',                                                          │ │
│ │                    │   'No-CI_no_current_deps_667f7ee',                                      │ │
│ │                    │   '--group',                                                            │ │
│ │                    │   'phylum_bot',                                                         │ │
│ │                    │                                                                         │ │
│ │                    '/var/folders/gh/wnf14j7n4q34y2t36hq2jz800000gn/T/base_xsm99p_j.json',    │ │
│ │                    │   ... +1                                                                │ │
│ │                    ]                                                                         │ │
│ │          curr_fd = <tempfile._TemporaryFileWrapper object at 0x10519ce30>                    │ │
│ │ current_packages = []                                                                        │ │
│ │             self = <phylum.ci.ci_none.CINone object at 0x103553110>                          │ │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
│                                                                                                  │
│ /Users/maxrake/.local/pipx/venvs/phylum/lib/python3.12/site-packages/phylum/ci/ci_base.py:970 in │
│                                                                                                  │
│   967 │                                                                                          │
│   968 │   def _parse_analysis_result(self, analysis_result: str) -> None:                        │
│   969 │   │   """Parse the results of a Phylum analysis command output."""                       │
│ ❱ 970 │   │   analysis = JobPolicyEvalResult(**json.loads(analysis_result))                      │
│   971 │   │                                                                                      │
│   972 │   │   self._analysis_report = analysis.report                                            │
│   973                                                                                            │
│                                                                                                  │
│ ╭────────────────────────────── locals ──────────────────────────────╮                           │
│ │ analysis_result = '{}\n'                                           │                           │
│ │            self = <phylum.ci.ci_none.CINone object at 0x103553110> │                           │
│ ╰────────────────────────────────────────────────────────────────────╯                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: JobPolicyEvalResult.__init__() missing 4 required positional arguments: 'is_failure', 'incomplete_count', 'output', and 'report'
```

</p>
</details> 

This is what it looks like with the changes in this PR:

<details><summary>Details (click to expand...)</summary>
<p>

```
❯ poetry run phylum-ci -vvaf --audit -p phylum-ci -g phylum_bot -d requirements-empty.txt
DEBUG    Using package: phylum v0.52.0
DEBUG    Logging initialized to level 10 (DEBUG)
DEBUG    Phylum CLI version not specified
DEBUG    Found installed Phylum CLI version: v7.1.4
DEBUG    Minimum supported Phylum CLI version required for install: v7.1.4-rc1
DEBUG    Making request to GitHub API URL: https://api.github.com/repos/phylum-dev/cli/releases
DEBUG    47 GitHub API requests remaining until window resets at:
         Wed Nov 20 13:28:29 2024
INFO     Using Phylum CLI version: v7.1.4
DEBUG    No CI environment detected
INFO     Confirming prerequisites ...
DEBUG    `git` binary found on the PATH
INFO     All prerequisites met
DEBUG    Existing Phylum CLI instance found: v7.1.4 at /Users/maxrake/.local/bin/phylum
INFO     Using Phylum CLI instance: v7.1.4 at /Users/maxrake/.local/bin/phylum
DEBUG    Project name provided as argument: phylum-ci
INFO     Attempting to create a Phylum project with name: phylum-ci ...
DEBUG    Org name not provided as argument. Checking Phylum settings file ...
DEBUG    Org name not found in Phylum settings file. Assuming no org ...
DEBUG    Group name provided as argument: phylum_bot
INFO     Using Phylum group: phylum_bot
INFO     Project/org/group combo already exists. Continuing with it.
             Project: phylum-ci
             Org:     (no org)
             Group:   phylum_bot
DEBUG    Repository URL not available to set
DEBUG    Dependency files provided as arguments: [requirements-empty.txt]
INFO     Parsing requirements-empty.txt as auto dependency file. Manifests take longer.
DEBUG    Determining viability of the Phylum sandbox in this environment ...
DEBUG    Executing command: /Users/maxrake/.local/bin/phylum sandbox --allow-run / true
INFO     The Phylum sandbox works in this environment and will be enabled
DEBUG    Using parse command: /Users/maxrake/.local/bin/phylum parse --type auto /Users/maxrake/dev/phylum/phylum-ci/requirements-empty.txt
DEBUG    Running command from: /Users/maxrake/dev/phylum/phylum-ci
WARNING  Provided dependency file requirements-empty.txt is a lockifest.
         It will be treated as a manifest.
         For more info, see: https://docs.phylum.io/cli/lockfile_generation
WARNING  At least one manifest file was included.
         Forcing analysis to ensure updated dependencies are included.
DEBUG    Valid provided dependency files: [requirements-empty.txt]
DEBUG    Dependency files in use: [requirements-empty.txt]
INFO     Forced analysis specified or otherwise set. Proceeding with analysis.
INFO     Label to use for analysis: No-CI_no_current_deps_667f7ee
ERROR    No dependencies found in any current dependency file, possibly due to
         an unsupported format. Please report this if you believe there are
         valid dependencies in the current set of provided dependency files
         at revision e22762898837194b869fed66f9f1788cb668d006.

❯ echo $?
12
```

</p>
</details> 
