### PR TITLE
fix: account for analysis started in repo sub-dirs

### DIFF
--- a/src/phylum/ci/depfile.py
+++ b/src/phylum/ci/depfile.py
@@ -12,7 +12,6 @@ import json
 import os
 from pathlib import Path
 import shlex
-import shutil
 import subprocess
 from typing import Optional
 
@@ -53,13 +52,9 @@ class Depfile:
         self._path = provided_depfile.path.resolve()
         self._type = provided_depfile.type
         self.cli_path = cli_path
-        self.disable_lockfile_generation = disable_lockfile_generation
         self._depfile_type = depfile_type
+        self.disable_lockfile_generation = disable_lockfile_generation
         self._is_depfile_changed: Optional[bool] = None
-
-        if not shutil.which("git"):
-            msg = "`git` is required to be installed and available on the PATH"
-            raise SystemExit(msg)
 
     def __repr__(self) -> str:
         """Return a debug printable string representation of the `Depfile` object."""

--- a/src/phylum/ci/git.py
+++ b/src/phylum/ci/git.py
@@ -159,6 +159,28 @@ def git_default_branch_name(remote: str, git_c_path: Optional[Path] = None) -> s
     return default_branch_name
 
 
+def git_root_dir(git_c_path: Optional[Path] = None) -> Path:
+    """Get the top-level (root) directory of the git working tree and return it.
+
+    The optional `git_c_path` is used to tell `git` to run as if it were started in that
+    path instead of the current working directory, which is the default when not provided.
+    """
+    base_cmd = git_base_cmd(git_c_path=git_c_path)
+    cmd = [*base_cmd, "rev-parse", "--show-toplevel"]
+    try:
+        git_root = subprocess.run(  # noqa: S603
+            cmd,
+            check=True,
+            text=True,
+            capture_output=True,
+            encoding="utf-8",
+        ).stdout.strip()
+    except subprocess.CalledProcessError as err:
+        msg = "Must be operating within the context of a git repository"
+        raise PhylumCalledProcessError(err, msg) from err
+    return Path(git_root).resolve()
+
+
 def git_curent_branch_name(git_c_path: Optional[Path] = None) -> str:
     """Get the current branch name and return it.
 


### PR DESCRIPTION
This change accounts for the possibility that dependency files are specified or detected at levels lower than the root git directory. This is the case when analysis is started in a sub-directory (e.g., monorepos).

When determining the base dependencies to make sure only the newly added dependencies are considered, a temporary git worktree is created with the common ancestor commit. That worktree is of the **entire** git repo at that commit and therefore the relative path to dependency files specified/detected at lower levels in the path are not correct. The effect is an error in parsing the file due to it not existing (at the expected path).

The fallback when this happens is to assume that all current dependencies are new and to analyze them (e.g., the same as if the `--all-deps` option was provided). So, in that sense, the bug is an "over-analysis" compared to what was expected (fail secure/closed).

This change creates a path for the previous dependency file that is relative to the git root directory instead of the current working directory.

Other changes made include:

* Add `CIBase` class prerequisite
  * Must be operating within the context of a git repository
* Remove `Depfile` class `git` prerequisite as dead code
  * The `Depfile` class does not directly use `git`
* Format and refactor throughout

## Testing

The changes in this PR are available for testing with the `maxrake/phylum-ci:git_depth` Docker image found [on Docker Hub](https://hub.docker.com/r/maxrake/phylum-ci/tags).

This is what it looks like with the current released version of `phylum-ci`. The `phylum-dev/isildurs_bane` monorepo is used for testing. A branch was created there and several dependency files were updated and committed. In this example, the `cargo_workspace` sub-directory was updated such that the `Cargo.lock` there has new dependencies. Analysis is started from within that sub-directory.

<details><summary>Details (click to expand...)</summary>
<p>

```
❯ docker run -it --rm -e PHYLUM_API_KEY=$(phylum auth token) --mount type=bind,src=$(pwd),dst=/phylum -w /phylum phylumio/phylum-ci:latest bash
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
root@78c3b2aefae9:/phylum# pushd cargo_workspace/
/phylum/cargo_workspace /phylum
root@78c3b2aefae9:/phylum/cargo_workspace# phylum-ci -vv --project delme_mono_cargo_workspace --group delme_mono_cargo_workspace
DEBUG    Logging initialized to level 10 (DEBUG)
DEBUG    Phylum CLI version not specified
DEBUG    Found installed Phylum CLI version: v7.1.4
DEBUG    Minimum supported Phylum CLI version required for install: v7.1.4-rc1
DEBUG    Making request to GitHub API URL: https://api.github.com/repos/phylum-dev/cli/releases
DEBUG    55 GitHub API requests remaining until window resets at:
         Wed Nov 20 21:21:02 2024
INFO     Using Phylum CLI version: v7.1.4
DEBUG    No CI environment detected
INFO     Confirming prerequisites ...
DEBUG    `git` binary found on the PATH
INFO     All prerequisites met
DEBUG    Existing Phylum CLI instance found: v7.1.4 at /usr/local/bin/phylum
INFO     Using Phylum CLI instance: v7.1.4 at /usr/local/bin/phylum
DEBUG    Project name provided as argument: delme_mono_cargo_workspace
INFO     Attempting to create a Phylum project with name: delme_mono_cargo_workspace ...
DEBUG    Org name not provided as argument. Checking Phylum settings file ...
DEBUG    Org name not found in Phylum settings file. Assuming no org ...
DEBUG    Group name provided as argument: delme_mono_cargo_workspace
INFO     Using Phylum group: delme_mono_cargo_workspace
WARNING  Attempting to create a Phylum project outside the top level of a `git` repository
INFO     Project/org/group combo already exists. Continuing with it.
             Project: delme_mono_cargo_workspace
             Org:     (no org)
             Group:   delme_mono_cargo_workspace
DEBUG    Repository URL not available to set
INFO     No valid dependency files were provided as arguments. An attempt will be made to detect them.
DEBUG    Detected dependency files: [Cargo.lock]
DEBUG    No dependency file exclusion patterns provided.
INFO     Parsing Cargo.lock as cargo dependency file. Manifests take longer.
DEBUG    Determining viability of the Phylum sandbox in this environment ...
DEBUG    Executing command: /usr/local/bin/phylum sandbox --allow-run / true
WARNING  Phylum sandbox does not work in this environment and will be disabled.
         This is common and expected for container environments, like Docker.
         Windows environments are also not currently supported.
         Carefully scrutinize other environments where sandboxing is expected.
DEBUG    Using parse command: /usr/local/bin/phylum parse --type cargo --skip-sandbox
         /phylum/cargo_workspace/Cargo.lock
DEBUG    Running command from: /phylum/cargo_workspace
INFO     Provided dependency file Cargo.lock is a lockfile
DEBUG    Valid detected dependency files: [Cargo.lock]
DEBUG    Dependency files in use: [Cargo.lock]
DEBUG    Checking Cargo.lock for changes ...
DEBUG    Dependency file Cargo.lock has changed
INFO     A lockfile has changed. Proceeding with analysis.
INFO     Label to use for analysis: No-CI_support_workspace_projects_a892731
DEBUG    9 unique current dependencies from 1 file(s)
INFO     Only considering newly added dependencies ...
DEBUG    Adding git worktree for base iteration in a temporary directory ...
DEBUG    Using command: git worktree add --detach /tmp/phylum_t70vjy1i
         851c8f217db84b18f6506b656994e0f834aa3ad6
INFO     Parsing Cargo.lock as cargo dependency file. Manifests take longer.
DEBUG    Using parse command: /usr/local/bin/phylum parse --type cargo --skip-sandbox
         /tmp/phylum_t70vjy1i/Cargo.lock
DEBUG    Running command from: /tmp/phylum_t70vjy1i
⠼ Analyzing dependencies with Phylum 0:00:00
╭──────────────────────────────────────── Subprocess Error ────────────────────────────────────────╮
│ COMMAND: /usr/local/bin/phylum parse --type cargo --skip-sandbox /tmp/phylum_t70vjy1i/Cargo.lock │
│ RETURN CODE: 1                                                                                   │
│ ╭────────────────────────────────────────── STDERR ───────────────────────────────────────────╮  │
│ │ ❗ Error: Could not parse dependency file "/tmp/phylum_t70vjy1i/Cargo.lock" as "cargo" type │  │
│ │                                                                                             │  │
│ │ Caused by:                                                                                  │  │
│ │     No such file or directory (os error 2)                                                  │  │
│ ╰─────────────────────────────────────────────────────────────────────────────────────────────╯  │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
WARNING  Due to error, assuming no previous packages in Cargo.lock.
         Consider supplying dependency file type explicitly in `.phylum_project`
         file. For more info: https://docs.phylum.io/cli/lockfile_generation
         Please report this as a bug if you believe Cargo.lock
         is a valid cargo lockfile at revision
         851c8f217db84b18f6506b656994e0f834aa3ad6.
DEBUG    Removing the git worktree for the base iteration ...
DEBUG    Using command: git worktree remove --force /tmp/phylum_t70vjy1i
DEBUG    9 new dependencies: [Package(name='block-buffer', version='0.10.4', type='cargo',
         lockfile='Cargo.lock'), Package(name='crypto-common', version='0.1.6', type='cargo',
         lockfile='Cargo.lock'), Package(name='digest', version='0.10.7', type='cargo',
         lockfile='Cargo.lock'), Package(name='generic-array', version='0.14.7', type='cargo',
         lockfile='Cargo.lock'), Package(name='itoa', version='1.0.9', type='cargo', lockfile='Cargo.lock'),
         Package(name='libc', version='0.2.148', type='cargo', lockfile='Cargo.lock'), Package(name='md4',
         version='0.10.2', type='cargo', lockfile='Cargo.lock'), Package(name='typenum', version='1.17.0',
         type='cargo', lockfile='Cargo.lock'), Package(name='version_check', version='0.9.5', type='cargo',
         lockfile='Cargo.lock')]
INFO     Performing analysis. This may take a few seconds.
DEBUG    Using analysis command: /usr/local/bin/phylum extension run --yes
         /opt/venv/lib/python3.12/site-packages/phylum/exts/ci delme_mono_cargo_workspace
         No-CI_support_workspace_projects_a892731 --group delme_mono_cargo_workspace /tmp/base_k7sif5na.json
         /tmp/curr_t0mdcgfz.json
INFO     Analysis is complete and there were NO failures
DEBUG    Analysis output:

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃                              Phylum OSS Supply Chain Risk Analysis - SUCCESS                               ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛

The Phylum risk analysis is complete and has passed the active policy.

View this project in the Phylum UI (https://app.phylum.io/projects/97978914-b1e0-4e93-b01f-a02ee8b23871?group=delme_mono_cargo_workspace&label=No-CI_support_workspace_projects_a892731)
DEBUG    Return code: 0
         More info: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
```

</p>
</details> 

This is what the same sequence looks like now, using the changes from this PR.
Notice that there is no error and only the newly added/changed dependencies are used (7 instead of 9).

<details><summary>Details (click to expand...)</summary>
<p>

```
❯ docker run -it --rm -e PHYLUM_API_KEY=$(phylum auth token) --mount type=bind,src=$(pwd),dst=/phylum -w /phylum maxrake/phylum-ci:git_depth bash
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
root@cb34b056a95b:/phylum# pushd cargo_workspace/
/phylum/cargo_workspace /phylum
root@cb34b056a95b:/phylum/cargo_workspace# phylum-ci -vv --project delme_mono_cargo_workspace --group delme_mono_cargo_workspace
DEBUG    Using package: phylum v0.52.0
DEBUG    Logging initialized to level 10 (DEBUG)
DEBUG    Phylum CLI version not specified
DEBUG    Found installed Phylum CLI version: v7.1.4
DEBUG    Minimum supported Phylum CLI version required for install: v7.1.4-rc1
DEBUG    Making request to GitHub API URL: https://api.github.com/repos/phylum-dev/cli/releases
DEBUG    54 GitHub API requests remaining until window resets at:
         Wed Nov 20 21:28:08 2024
INFO     Using Phylum CLI version: v7.1.4
DEBUG    No CI environment detected
INFO     Confirming prerequisites ...
DEBUG    `git` binary found on the PATH
DEBUG    Root directory of git repository: /phylum
INFO     All prerequisites met
DEBUG    Existing Phylum CLI instance found: v7.1.4 at /usr/local/bin/phylum
INFO     Using Phylum CLI instance: v7.1.4 at /usr/local/bin/phylum
DEBUG    Project name provided as argument: delme_mono_cargo_workspace
INFO     Attempting to create a Phylum project with name: delme_mono_cargo_workspace ...
DEBUG    Org name not provided as argument. Checking Phylum settings file ...
DEBUG    Org name not found in Phylum settings file. Assuming no org ...
DEBUG    Group name provided as argument: delme_mono_cargo_workspace
INFO     Using Phylum group: delme_mono_cargo_workspace
WARNING  Attempting to create a Phylum project outside the top level of a `git` repository
INFO     Project/org/group combo already exists. Continuing with it.
             Project: delme_mono_cargo_workspace
             Org:     (no org)
             Group:   delme_mono_cargo_workspace
DEBUG    Repository URL not available to set
INFO     No valid dependency files were provided as arguments. An attempt will be made to detect them.
DEBUG    Detected dependency files: [Cargo.lock]
DEBUG    No dependency file exclusion patterns provided.
INFO     Parsing Cargo.lock as cargo dependency file. Manifests take longer.
DEBUG    Determining viability of the Phylum sandbox in this environment ...
DEBUG    Executing command: /usr/local/bin/phylum sandbox --allow-run / true
WARNING  Phylum sandbox does not work in this environment and will be disabled.
         This is common and expected for container environments, like Docker.
         Windows environments are also not currently supported.
         Carefully scrutinize other environments where sandboxing is expected.
DEBUG    Using parse command: /usr/local/bin/phylum parse --type cargo --skip-sandbox
         /phylum/cargo_workspace/Cargo.lock
DEBUG    Running command from: /phylum/cargo_workspace
INFO     Provided dependency file Cargo.lock is a lockfile
DEBUG    Valid detected dependency files: [Cargo.lock]
DEBUG    Dependency files in use: [Cargo.lock]
DEBUG    Checking Cargo.lock for changes ...
DEBUG    Dependency file Cargo.lock has changed
INFO     A lockfile has changed. Proceeding with analysis.
INFO     Label to use for analysis: No-CI_support_workspace_projects_a892731
DEBUG    9 unique current dependencies from 1 file(s)
INFO     Only considering newly added dependencies ...
DEBUG    Adding git worktree for base iteration in a temporary directory ...
DEBUG    Using command: git worktree add --detach /tmp/phylum_mmj05cb8
         851c8f217db84b18f6506b656994e0f834aa3ad6
INFO     Parsing cargo_workspace/Cargo.lock as cargo dependency file. Manifests take longer.
DEBUG    Using parse command: /usr/local/bin/phylum parse --type cargo --skip-sandbox
         /tmp/phylum_mmj05cb8/cargo_workspace/Cargo.lock
DEBUG    Running command from: /tmp/phylum_mmj05cb8
DEBUG    Removing the git worktree for the base iteration ...
DEBUG    Using command: git worktree remove --force /tmp/phylum_mmj05cb8
DEBUG    7 new dependencies: [Package(name='block-buffer', version='0.10.4', type='cargo',
         lockfile='Cargo.lock'), Package(name='crypto-common', version='0.1.6', type='cargo',
         lockfile='Cargo.lock'), Package(name='digest', version='0.10.7', type='cargo',
         lockfile='Cargo.lock'), Package(name='generic-array', version='0.14.7', type='cargo',
         lockfile='Cargo.lock'), Package(name='md4', version='0.10.2', type='cargo', lockfile='Cargo.lock'),
         Package(name='typenum', version='1.17.0', type='cargo', lockfile='Cargo.lock'),
         Package(name='version_check', version='0.9.5', type='cargo', lockfile='Cargo.lock')]
INFO     Performing analysis. This may take a few seconds.
DEBUG    Using analysis command: /usr/local/bin/phylum extension run --yes
         /opt/venv/lib/python3.12/site-packages/phylum/exts/ci delme_mono_cargo_workspace
         No-CI_support_workspace_projects_a892731 --group delme_mono_cargo_workspace /tmp/base_5krgpn4k.json
         /tmp/curr_xhm3ay1e.json
INFO     Analysis is complete and there were NO failures
DEBUG    Analysis output:

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃                              Phylum OSS Supply Chain Risk Analysis - SUCCESS                               ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛

The Phylum risk analysis is complete and has passed the active policy.

View this project in the Phylum UI (https://app.phylum.io/projects/97978914-b1e0-4e93-b01f-a02ee8b23871?group=delme_mono_cargo_workspace&label=No-CI_support_workspace_projects_a892731)
DEBUG    Return code: 0
         More info: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
```

</p>
</details> 

This is what it looks like when trying to operate outside the context of a git repository:

<details><summary>Details (click to expand...)</summary>
<p>

```
❯ pushd cargo_workspace
~/dev/phylum/isildurs_bane/cargo_workspace ~/dev/phylum/isildurs_bane ~

❯ docker run -it --rm -e PHYLUM_API_KEY=$(phylum auth token) --mount type=bind,src=$(pwd),dst=/phylum -w /phylum maxrake/phylum-ci:git_depth phylum-ci -vv --project delme_mono_cargo_workspace --group delme_mono_cargo_workspace
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
DEBUG    Using package: phylum v0.52.0
DEBUG    Logging initialized to level 10 (DEBUG)
DEBUG    Phylum CLI version not specified
DEBUG    Found installed Phylum CLI version: v7.1.4
DEBUG    Minimum supported Phylum CLI version required for install: v7.1.4-rc1
DEBUG    Making request to GitHub API URL: https://api.github.com/repos/phylum-dev/cli/releases
DEBUG    51 GitHub API requests remaining until window resets at:
         Wed Nov 20 21:18:42 2024
INFO     Using Phylum CLI version: v7.1.4
DEBUG    No CI environment detected
INFO     Confirming prerequisites ...
DEBUG    `git` binary found on the PATH

╭─────────────────────────────── Subprocess Error ───────────────────────────────╮
│ COMMAND: git rev-parse --show-toplevel                                         │
│ RETURN CODE: 128                                                               │
│ ╭────────────────────────────────── STDERR ──────────────────────────────────╮ │
│ │ fatal: not a git repository (or any parent up to mount point /)            │ │
│ │ Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set). │ │
│ ╰────────────────────────────────────────────────────────────────────────────╯ │
╰────────────────────────────────────────────────────────────────────────────────╯
CRITICAL Must be operating within the context of a git repository
```

</p>
</details> 