### PR TITLE
feat: avoid GitHub API calls during version check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: black
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: cafecb2f683a620516412e109877570ca7648cbd  # frozen: v0.7.4
+    rev: 0710b94280408eef12748cde4782972942370ad2  # frozen: v0.8.0
     hooks:
       - id: ruff
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ format = "github"
 ignore = [184]
 
 [tool.ruff]
-# Reference: https://beta.ruff.rs/docs/settings
+# Reference: https://docs.astral.sh/ruff/configuration/
 line-length = 120
 target-version = "py39"
 force-exclude = true
@@ -123,7 +123,7 @@ select = [
     "ALL",
 ]
 ignore = [
-    # Reference: https://beta.ruff.rs/docs/rules/
+    # Reference: https://docs.astral.sh/ruff/rules/
     #
     # `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible. Prefer D211.
     "D203", # one-blank-line-before-class
@@ -145,7 +145,7 @@ ignore = [
     "S404", # suspicious-subprocess-import
     # These ignores will be removed during https://github.com/phylum-dev/phylum-ci/issues/238
     "ANN", # flake8-annotations
-    "TCH", # flake8-type-checking
+    "TC",  # flake8-type-checking
     "FA",  # flake8-future-annotations
 ]
 

--- a/src/phylum/constants.py
+++ b/src/phylum/constants.py
@@ -2,11 +2,13 @@
 
 from phylum import __version__
 
-# This is the minimum CLI version supported for new installs.
+# This is the minimum CLI version supported for *new* installs.
 # Support for analysis with organizations via extensions was enabled in v7.1.4-rc1
 MIN_CLI_VER_FOR_INSTALL = "v7.1.4-rc1"
 
-# This is the minimum CLI version supported for existing installs.
+# This is the minimum CLI version supported for *existing* installs.
+# This version *may* be lower than the minimum version supported for new installs due to
+# logic sometimes accounting for new features or breaking changes in a phased approach.
 # Support for analysis with organizations via extensions was enabled in v7.1.4-rc1
 MIN_CLI_VER_INSTALLED = "v7.1.4-rc1"
 


### PR DESCRIPTION
This change updates the version processing logic to avoid GitHub API calls when a Phylum CLI is already installed and its version is supported. This is especially useful for the Docker image, where there is already a known good Phylum CLI bundled in. This change originated with a user request where they are seeking to limit outbound network requests.

There is also an effort made to be more intentional about the difference between Phylum CLI versions *to be* installed vs. those that are already installed.

Other changes made include:

* Create a new `is_installed_version_supported` predicate
  * Use it instead of scattered checks against `MIN_CLI_VER_INSTALLED`
* Update `ruff` to latest version
* Format and refactor throughout
  * Rename `is_supported_version` to `is_version_for_install_supported`
  * Extract basic version normalization code to a function

## Testing

The changes in this PR are available for testing with the `maxrake/phylum-ci:avoid_calls` Docker image found [on Docker Hub](https://hub.docker.com/r/maxrake/phylum-ci/tags).

This is what it looks like to run `phylum-ci` on a system with a valid installed Phylum CLI, using the current latest released version of `phylum-ci`. Notice the GitHub API request in the debug logs.

<details><summary>Details (click to expand...)</summary>
<p>

```
❯ phylum-ci -vv
DEBUG    Using package: phylum v0.52.1
DEBUG    Logging initialized to level 10 (DEBUG)
DEBUG    Phylum CLI version not specified
DEBUG    Found installed Phylum CLI version: v7.1.4
DEBUG    Minimum supported Phylum CLI version required for install: v7.1.4-rc1
DEBUG    Making request to GitHub API URL: https://api.github.com/repos/phylum-dev/cli/releases
DEBUG    56 GitHub API requests remaining until window resets at:
         Fri Nov 22 12:38:38 2024
INFO     Using Phylum CLI version: v7.1.4
DEBUG    No CI environment detected
INFO     Confirming prerequisites ...
DEBUG    `git` binary found on the PATH
DEBUG    Root directory of git repository: /Users/maxrake/dev/phylum/phylum-ci
INFO     All prerequisites met
DEBUG    Existing Phylum CLI instance found: v7.1.4 at /Users/maxrake/.local/bin/phylum
INFO     Using Phylum CLI instance: v7.1.4 at /Users/maxrake/.local/bin/phylum
INFO     Project name not provided as argument. Checking project file ...
DEBUG    Project name provided in `.phylum_project` file: phylum-ci
INFO     Attempting to create a Phylum project with name: phylum-ci ...
DEBUG    Org name not provided as argument. Checking Phylum settings file ...
DEBUG    Org name not found in Phylum settings file. Assuming no org ...
DEBUG    Group name not provided as argument. Checking project file ...
DEBUG    Group name provided in `.phylum_project` file: phylum_bot
INFO     Using Phylum group: phylum_bot
INFO     Project/org/group combo already exists. Continuing with it.
             Project: phylum-ci
             Org:     (no org)
             Group:   phylum_bot
DEBUG    Repository URL not available to set
INFO     No valid dependency files were provided as arguments. An attempt will be made to detect them.
DEBUG    Dependency files provided in `.phylum_project` file: [poetry.lock]
DEBUG    No dependency file exclusion patterns provided.
INFO     Parsing poetry.lock as poetry dependency file. Manifests take longer.
DEBUG    Determining viability of the Phylum sandbox in this environment ...
DEBUG    Executing command: /Users/maxrake/.local/bin/phylum sandbox --allow-run / true
INFO     The Phylum sandbox works in this environment and will be enabled
DEBUG    Using parse command: /Users/maxrake/.local/bin/phylum parse --type poetry /Users/maxrake/dev/phylum/phylum-ci/poetry.lock
DEBUG    Running command from: /Users/maxrake/dev/phylum/phylum-ci
INFO     Provided dependency file poetry.lock is a lockfile
DEBUG    Valid detected dependency files: [poetry.lock]
DEBUG    Dependency files in use: [poetry.lock]
DEBUG    Checking poetry.lock for changes ...
DEBUG    Dependency file poetry.lock has NOT changed
WARNING  No lockfile has changed. Nothing to do.
```

</p>
</details>

This is what it looks like to run that same command with the changes from this PR. Notice there is no GitHub API call this time.

<details><summary>Details (click to expand...)</summary>
<p>

```
❯ poetry run phylum-ci -vv
DEBUG    Using package: phylum v0.52.1
DEBUG    Logging initialized to level 10 (DEBUG)
DEBUG    Phylum CLI version not specified
DEBUG    Found installed Phylum CLI version: v7.1.4
DEBUG    The installed Phylum CLI version is supported
INFO     Using Phylum CLI version: v7.1.4
DEBUG    No CI environment detected
INFO     Confirming prerequisites ...
DEBUG    `git` binary found on the PATH
DEBUG    Git repository root found: /Users/maxrake/dev/phylum/phylum-ci
INFO     All prerequisites met
DEBUG    Existing Phylum CLI instance found: v7.1.4 at /Users/maxrake/.local/bin/phylum
INFO     Using Phylum CLI instance: v7.1.4 at /Users/maxrake/.local/bin/phylum
INFO     Project name not provided as argument. Checking project file ...
DEBUG    Project name provided in `.phylum_project` file: phylum-ci
INFO     Attempting to create a Phylum project with name: phylum-ci ...
DEBUG    Org name not provided as argument. Checking Phylum settings file ...
DEBUG    Org name not found in Phylum settings file. Assuming no org ...
DEBUG    Group name not provided as argument. Checking project file ...
DEBUG    Group name provided in `.phylum_project` file: phylum_bot
INFO     Using Phylum group: phylum_bot
INFO     Project/org/group combo already exists. Continuing with it.
             Project: phylum-ci
             Org:     (no org)
             Group:   phylum_bot
DEBUG    Repository URL not available to set
INFO     No valid dependency files were provided as arguments. An attempt will be made to detect them.
DEBUG    Dependency files provided in `.phylum_project` file: [poetry.lock]
DEBUG    No dependency file exclusion patterns provided.
INFO     Parsing poetry.lock as poetry dependency file. Manifests take longer.
DEBUG    Determining viability of the Phylum sandbox in this environment ...
DEBUG    Executing command: /Users/maxrake/.local/bin/phylum sandbox --allow-run / true
INFO     The Phylum sandbox works in this environment and will be enabled
DEBUG    Using parse command: /Users/maxrake/.local/bin/phylum parse --type poetry /Users/maxrake/dev/phylum/phylum-ci/poetry.lock
DEBUG    Running command from: /Users/maxrake/dev/phylum/phylum-ci
INFO     Provided dependency file poetry.lock is a lockfile
DEBUG    Valid detected dependency files: [poetry.lock]
DEBUG    Dependency files in use: [poetry.lock]
DEBUG    Checking poetry.lock for changes ...
DEBUG    Dependency file poetry.lock has NOT changed
WARNING  No lockfile has changed. Nothing to do.
```

</p>
</details> 