### PR TITLE
fix: `gradle` lockfile generation requires `javac`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -213,6 +213,7 @@ RUN \
         git-lfs \
         bundler \
         maven \
+        default-jdk-headless \
         procps \
         curl \
         unzip \


### PR DESCRIPTION
Lockfile generation for `gradle` manifests started failing recently with the following error message:

```
Toolchain installation '/usr/lib/jvm/java-17-openjdk-amd64' does not
provide the required capabilities: [JAVA_COMPILER]
```

This is due to
[a known regression](https://github.com/gradle/gradle/issues/30264) introduced in Gradle v8.10. This regression is also documented in the [upgrading guide](https://docs.gradle.org/current/userguide/upgrading_version_8.html#javacompile_tasks_may_fail_when_using_a_jre_even_if_compilation_is_not_necessary), with a suggested fix. However, that fix would require updates in Phylum user repositories...which is not always possible or desired. Instead, this change updates the Docker image to include the java compiler in the form of the system package `default-jdk-headless`. That way, the Java JRE and JDK will match.

## Testing

This is what it looks like when attempting to generate a lockfile from a `build.gradle` manifest with the current latest release of `phylum-ci`:

<details><summary>Details (click to expand...)</summary>
<p>

```
❯ docker run -it --rm -e PHYLUM_API_KEY=$(phylum auth token) --mount type=bind,src=$(pwd),dst=/phylum -w /phylum phylumio/phylum-ci:latest phylum-ci -vvaf -p delme_add_javac -d build.gradle
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
DEBUG    Logging initialized to level 10 (DEBUG)
DEBUG    Phylum CLI version not specified
DEBUG    Found installed Phylum CLI version: v7.1.4
DEBUG    Minimum supported Phylum CLI version required for install: v7.1.4-rc1
DEBUG    Making request to GitHub API URL: https://api.github.com/repos/phylum-dev/cli/releases
DEBUG    59 GitHub API requests remaining until window resets at:
         Tue Nov 26 01:07:32 2024
INFO     Using Phylum CLI version: v7.1.4
DEBUG    No CI environment detected
INFO     Confirming prerequisites ...
DEBUG    `git` binary found on the PATH
INFO     All prerequisites met
DEBUG    Existing Phylum CLI instance found: v7.1.4 at /usr/local/bin/phylum
INFO     Using Phylum CLI instance: v7.1.4 at /usr/local/bin/phylum
DEBUG    Project name provided as argument: delme_add_javac
INFO     Attempting to create a Phylum project with name: delme_add_javac ...
DEBUG    Org name not provided as argument. Checking Phylum settings file ...
DEBUG    Org name not found in Phylum settings file. Assuming no org ...
DEBUG    Group name not provided as argument. Checking project file ...
DEBUG    Group name not found in `.phylum_project` file or file does not exist. Assuming no group ...
INFO     Project/org/group combo already exists. Continuing with it.
             Project: delme_add_javac
             Org:     (no org)
             Group:   (no group)
DEBUG    Repository URL not available to set
DEBUG    Dependency files provided as arguments: [build.gradle]
INFO     Parsing build.gradle as auto dependency file. Manifests take longer.
DEBUG    Determining viability of the Phylum sandbox in this environment ...
DEBUG    Executing command: /usr/local/bin/phylum sandbox --allow-run / true
WARNING  Phylum sandbox does not work in this environment and will be disabled.
         This is common and expected for container environments, like Docker.
         Windows environments are also not currently supported.
         Carefully scrutinize other environments where sandboxing is expected.
DEBUG    Using parse command: /usr/local/bin/phylum parse --type auto --skip-sandbox /phylum/build.gradle
DEBUG    Running command from: /phylum
⠙ Filtering dependency files 0:00:45
╭───────────────────────────────────────────────────────────────── Subprocess Error ─────────────────────────────────────────────────────────────────╮
│ COMMAND: /usr/local/bin/phylum parse --type auto --skip-sandbox /phylum/build.gradle                                                               │
│ RETURN CODE: 1                                                                                                                                     │
│ ╭──────────────────────────────────────────────────────────────────── STDERR ────────────────────────────────────────────────────────────────────╮ │
│ │ Generating lockfile for manifest "build.gradle" using Gradle…                                                                                  │ │
│ │ ❗ Error: Could not parse dependency file "/phylum/build.gradle" as "auto" type                                                                │ │
│ │                                                                                                                                                │ │
│ │ Caused by:                                                                                                                                     │ │
│ │     0: Lockfile generation failed! For details, see: https://docs.phylum.io/cli/lockfile_generation                                            │ │
│ │     1: package manager quit unexpectedly (code: Some(1), signal: None)                                                                         │ │
│ │            STDERR:                                                                                                                             │ │
│ │                                                                                                                                                │ │
│ │                FAILURE: Build failed with an exception.                                                                                        │ │
│ │                                                                                                                                                │ │
│ │                * What went wrong:                                                                                                              │ │
│ │                Execution failed for task ':dependencies'.                                                                                      │ │
│ │                > Could not resolve all dependencies for configuration ':compileClasspath'.                                                     │ │
│ │                   > Failed to calculate the value of task ':compileJava' property 'javaCompiler'.                                              │ │
│ │                      > Toolchain installation '/usr/lib/jvm/java-17-openjdk-amd64' does not provide the required capabilities: [JAVA_COMPILER] │ │
│ │                                                                                                                                                │ │
│ │                * Try:                                                                                                                          │ │
│ │                > Run with --stacktrace option to get the stack trace.                                                                          │ │
│ │                > Run with --info or --debug option to get more log output.                                                                     │ │
│ │                > Run with --scan to get full insights.                                                                                         │ │
│ │                > Get more help at https://help.gradle.org.                                                                                     │ │
│ │                                                                                                                                                │ │
│ │                BUILD FAILED in 44s                                                                                                             │ │
│ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
WARNING  Provided dependency file build.gradle failed to parse
         as type auto. If this is a manifest, consider
         supplying dependency file type explicitly in `.phylum_project` file.
         For more info, see: https://docs.phylum.io/cli/lockfile_generation
         Please report this as a bug if you believe build.gradle
         is a valid auto dependency file.
INFO     No valid dependency files were provided as arguments. An attempt will be made to detect them.
DEBUG    Detected dependency files: []
DEBUG    No dependency file exclusion patterns provided.
DEBUG    Unique new dependency files: []
ERROR    No valid dependency files were detected.
         Consider specifying at least one with
         `--depfile` argument or in `.phylum_project` file.
```

</p>
</details> 

This is what it looks like when attempting to generate a lockfile from the same `build.gradle` manifest, but with an image created from the changes in this PR. Notice that there is no parsing error, but there still is an overall error (due to there not being any dependencies in the manifest...which is an expected error here):

<details><summary>Details (click to expand...)</summary>
<p>

```
❯ docker run -it --rm -e PHYLUM_API_KEY=$(phylum auth token) --mount type=bind,src=$(pwd),dst=/phylum -w /phylum maxrake/phylum-ci:add_javac phylum-ci -vvaf -p delme_add_javac -d build.gradle
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
DEBUG    Using package: phylum v0.52.1
DEBUG    Logging initialized to level 10 (DEBUG)
DEBUG    Phylum CLI version not specified
DEBUG    Found installed Phylum CLI version: v7.1.4
DEBUG    The installed Phylum CLI version is supported
INFO     Using Phylum CLI version: v7.1.4
DEBUG    No CI environment detected
INFO     Confirming prerequisites ...
DEBUG    `git` binary found on the PATH
DEBUG    Git repository root found: /phylum
INFO     All prerequisites met
DEBUG    Existing Phylum CLI instance found: v7.1.4 at /usr/local/bin/phylum
INFO     Using Phylum CLI instance: v7.1.4 at /usr/local/bin/phylum
DEBUG    Project name provided as argument: delme_add_javac
INFO     Attempting to create a Phylum project with name: delme_add_javac ...
DEBUG    Org name not provided as argument. Checking Phylum settings file ...
DEBUG    Org name not found in Phylum settings file. Assuming no org ...
DEBUG    Group name not provided as argument. Checking project file ...
DEBUG    Group name not found in `.phylum_project` file or file does not exist. Assuming no group ...
INFO     Project/org/group combo created successfully.
             Project: delme_add_javac
             Org:     (no org)
             Group:   (no group)
DEBUG    Dependency files provided as arguments: [build.gradle]
INFO     Parsing build.gradle as auto dependency file. Manifests take longer.
DEBUG    Determining viability of the Phylum sandbox in this environment ...
DEBUG    Executing command: /usr/local/bin/phylum sandbox --allow-run / true
WARNING  Phylum sandbox does not work in this environment and will be disabled.
         This is common and expected for container environments, like Docker.
         Windows environments are also not currently supported.
         Carefully scrutinize other environments where sandboxing is expected.
DEBUG    Using parse command: /usr/local/bin/phylum parse --type auto --skip-sandbox /phylum/build.gradle
DEBUG    Running command from: /phylum
INFO     Provided dependency file build.gradle is a manifest
WARNING  At least one manifest file was included.
         Forcing analysis to ensure updated dependencies are included.
DEBUG    Valid provided dependency files: [build.gradle]
DEBUG    Dependency files in use: [build.gradle]
INFO     Forced analysis specified or otherwise set. Proceeding with analysis.
INFO     Label to use for analysis: No-CI_add_javac_69e966c
ERROR    No dependencies found in any current dependency file, possibly due to
         an unsupported format. Please report this if you believe there are
         valid dependencies in the current set of provided dependency files
         at revision 922d285adf0578ecbf871114649f52351a3ae202.
```

</p>
</details> 
