### PR TITLE
feat: Allow for ignoring non-analysis errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ following non-zero codes otherwise:
 |20|A manifest is attempted to be parsed but lockfile generation has been disabled.|
 
 Exit codes of 10 or higher represent situations not directly linked to Phylum analysis. These errors are important
-because they indicate a complete Phylum analysis was not possible, which is cause for further investigation and
-correction. An [option is available][script_options] to explicitly prevent these errors from setting an exit code.
+because they indicate a complete Phylum analysis was not possible, which necessitates further investigation. An
+[option is available][script_options] to explicitly prevent these errors from setting an exit code.
 
 [script_options]: #phylum-ci-script-entry-point
 [FAQ]: https://github.com/marketplace/actions/phylum-analyze-pr#why-does-phylum-report-a-failing-status-check-if-it-shows-a-successful-analysis-comment

--- a/README.md
+++ b/README.md
@@ -201,7 +201,6 @@ following non-zero codes otherwise:
 |---------|-------|
 |1|Default failure code. An unrecoverable error was encountered.|
 |2|Phylum analysis is complete and contains a policy violation.|
-|5|Phylum analysis is incomplete. Only used when enabled [by option][script_options].|
 |6|Phylum analysis is incomplete and contains a policy violation.|
 |10|Dependency file(s) failed filtering and excluded from analysis. See [this FAQ][FAQ] for more.|
 |11|No dependency files were provided or detected.|

--- a/README.md
+++ b/README.md
@@ -201,12 +201,18 @@ following non-zero codes otherwise:
 |---------|-------|
 |1|Default failure code. An unrecoverable error was encountered.|
 |2|Phylum analysis is complete and contains a policy violation.|
+|5|Phylum analysis is incomplete. Only used when enabled [by option][script_options].|
 |6|Phylum analysis is incomplete and contains a policy violation.|
 |10|Dependency file(s) failed filtering and excluded from analysis. See [this FAQ][FAQ] for more.|
 |11|No dependency files were provided or detected.|
 |12|No dependencies found in any current dependency file.|
 |20|A manifest is attempted to be parsed but lockfile generation has been disabled.|
 
+Exit codes of 10 or higher represent situations not directly linked to Phylum analysis. These errors are important
+because they indicate a complete Phylum analysis was not possible, which is cause for further investigation and
+correction. An [option is available][script_options] to explicitly prevent these errors from setting an exit code.
+
+[script_options]: #phylum-ci-script-entry-point
 [FAQ]: https://github.com/marketplace/actions/phylum-analyze-pr#why-does-phylum-report-a-failing-status-check-if-it-shows-a-successful-analysis-comment
 
 ## License

--- a/docs/integrations/azure_pipelines.md
+++ b/docs/integrations/azure_pipelines.md
@@ -443,9 +443,10 @@ information. Since these tokens are sensitive, **care should be taken to protect
 ### Exit Codes
 
 The Phylum analysis job will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
-The full and current list of exit codes is [documented here][exit_codes].
+The full and current list of exit codes is [documented here][exit_codes] and [options exist][script_options] to be
+strict or loose with setting them.
 
-[exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
+[exit_codes]: https://github.com/phylum-dev/phylum-ci#exit-codes
 
 ## Alternatives
 

--- a/docs/integrations/azure_pipelines.md
+++ b/docs/integrations/azure_pipelines.md
@@ -444,7 +444,7 @@ information. Since these tokens are sensitive, **care should be taken to protect
 
 The Phylum analysis job will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
 The full and current list of exit codes is [documented here][exit_codes] and [options exist][script_options] to be
-strict or loose with setting them.
+loose with setting them.
 
 [exit_codes]: https://github.com/phylum-dev/phylum-ci#exit-codes
 

--- a/docs/integrations/bitbucket_pipelines.md
+++ b/docs/integrations/bitbucket_pipelines.md
@@ -353,9 +353,10 @@ view the [script options output][script_options] for the latest release.
 ### Exit Codes
 
 The Phylum analysis step will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
-The full and current list of exit codes is [documented here][exit_codes].
+The full and current list of exit codes is [documented here][exit_codes] and [options exist][script_options] to be
+strict or loose with setting them.
 
-[exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
+[exit_codes]: https://github.com/phylum-dev/phylum-ci#exit-codes
 
 ## Alternatives
 

--- a/docs/integrations/bitbucket_pipelines.md
+++ b/docs/integrations/bitbucket_pipelines.md
@@ -354,7 +354,7 @@ view the [script options output][script_options] for the latest release.
 
 The Phylum analysis step will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
 The full and current list of exit codes is [documented here][exit_codes] and [options exist][script_options] to be
-strict or loose with setting them.
+loose with setting them.
 
 [exit_codes]: https://github.com/phylum-dev/phylum-ci#exit-codes
 

--- a/docs/integrations/git_precommit.md
+++ b/docs/integrations/git_precommit.md
@@ -191,7 +191,7 @@ with `--help` output as specified in the [Usage section of the top-level README.
 
 The Phylum analysis hook will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
 The full and current list of exit codes is [documented here][exit_codes] and [options exist][script_options] to be
-strict or loose with setting them.
+loose with setting them.
 
 [exit_codes]: https://github.com/phylum-dev/phylum-ci#exit-codes
 

--- a/docs/integrations/git_precommit.md
+++ b/docs/integrations/git_precommit.md
@@ -190,9 +190,10 @@ with `--help` output as specified in the [Usage section of the top-level README.
 ### Exit Codes
 
 The Phylum analysis hook will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
-The full and current list of exit codes is [documented here][exit_codes].
+The full and current list of exit codes is [documented here][exit_codes] and [options exist][script_options] to be
+strict or loose with setting them.
 
-[exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
+[exit_codes]: https://github.com/phylum-dev/phylum-ci#exit-codes
 
 ### Audit Mode
 
@@ -209,7 +210,7 @@ repos:
       - id: phylum
         # Additional args are possible, but `--audit` is the new one.
         args: [--audit]
-        # Since the hook will always pass in audit mode, forcing the output of the
-        # hook to be printed will ensure failures have a chance of being noticed.
+        # Since the hook will pass in audit mode, forcing the output of the hook
+        # to be printed will ensure failures have a chance of being noticed.
         verbose: true
 ```

--- a/docs/integrations/github_actions.md
+++ b/docs/integrations/github_actions.md
@@ -150,6 +150,8 @@ See the [Installation][installation] and [Usage][usage] sections of the [README 
 ## Exit Codes
 
 The Phylum analysis job/step will return a zero (0) exit code when it completes successfully and a non-zero code
-otherwise. The full and current list of exit codes is [documented here][exit_codes].
+otherwise. The full and current list of exit codes is [documented here][exit_codes] and [options exist][script_options]
+to be strict or loose with setting them.
 
-[exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
+[exit_codes]: https://github.com/phylum-dev/phylum-ci#exit-codes
+[script_options]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/script_options.md

--- a/docs/integrations/github_actions.md
+++ b/docs/integrations/github_actions.md
@@ -151,7 +151,7 @@ See the [Installation][installation] and [Usage][usage] sections of the [README 
 
 The Phylum analysis job/step will return a zero (0) exit code when it completes successfully and a non-zero code
 otherwise. The full and current list of exit codes is [documented here][exit_codes] and [options exist][script_options]
-to be strict or loose with setting them.
+to be loose with setting them.
 
 [exit_codes]: https://github.com/phylum-dev/phylum-ci#exit-codes
 [script_options]: https://github.com/phylum-dev/phylum-ci/blob/main/docs/script_options.md

--- a/docs/integrations/gitlab_ci.md
+++ b/docs/integrations/gitlab_ci.md
@@ -343,7 +343,7 @@ view the [script options output][script_options] for the latest release.
 
 The Phylum analysis job will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
 The full and current list of exit codes is [documented here][exit_codes] and [options exist][script_options]
-to be strict or loose with setting them.
+to be loose with setting them.
 
 [exit_codes]: https://github.com/phylum-dev/phylum-ci#exit-codes
 

--- a/docs/integrations/gitlab_ci.md
+++ b/docs/integrations/gitlab_ci.md
@@ -342,9 +342,10 @@ view the [script options output][script_options] for the latest release.
 ### Exit Codes
 
 The Phylum analysis job will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
-The full and current list of exit codes is [documented here][exit_codes].
+The full and current list of exit codes is [documented here][exit_codes] and [options exist][script_options]
+to be strict or loose with setting them.
 
-[exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
+[exit_codes]: https://github.com/phylum-dev/phylum-ci#exit-codes
 
 ## Alternatives
 

--- a/docs/integrations/jenkins.md
+++ b/docs/integrations/jenkins.md
@@ -341,9 +341,10 @@ release.
 ### Exit Codes
 
 The Phylum analysis stage will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
-The full and current list of exit codes is [documented here][exit_codes].
+The full and current list of exit codes is [documented here][exit_codes] and [options exist][script_options]
+to be strict or loose with setting them.
 
-[exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
+[exit_codes]: https://github.com/phylum-dev/phylum-ci#exit-codes
 
 ## Alternatives
 

--- a/docs/integrations/jenkins.md
+++ b/docs/integrations/jenkins.md
@@ -342,7 +342,7 @@ release.
 
 The Phylum analysis stage will return a zero (0) exit code when it completes successfully and a non-zero code otherwise.
 The full and current list of exit codes is [documented here][exit_codes] and [options exist][script_options]
-to be strict or loose with setting them.
+to be loose with setting them.
 
 [exit_codes]: https://github.com/phylum-dev/phylum-ci#exit-codes
 

--- a/scripts/docker_tests.sh
+++ b/scripts/docker_tests.sh
@@ -92,6 +92,7 @@ type poetry && poetry --version || false
 type bundle && bundle --version || false
 type mvn && mvn --version || false
 type gradle && gradle --version || false
+type javac && javac --version || false
 type go && go version || false
 type cargo && cargo --version || false
 type rustup && rustup --version && rustup show || false

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -130,6 +130,10 @@ class CIBase(ABC):
         if value == self._returncode:
             return
 
+        # Don't set a failure code when analysis results are unknown
+        if value == ReturnCode.ANALYSIS_INCOMPLETE:
+            return
+
         # Don't set non-analysis custom failure codes when flag to ignore errors specified
         if self.args.ignore_errors and value > ReturnCode.LARGEST_POSSIBLE_ANALYSIS_ERROR:
             msg = f"""
@@ -142,14 +146,6 @@ class CIBase(ABC):
         if self.audit_mode and value <= ReturnCode.LARGEST_POSSIBLE_ANALYSIS_ERROR:
             msg = f"""Audit mode enabled to keep return code {self._returncode} instead of setting to {value}"""
             LOG.info(cleandoc(msg))
-            return
-
-        # Don't set a failure code when analysis results are unknown unless told to
-        if value == ReturnCode.ANALYSIS_INCOMPLETE:
-            if self.args.fail_incomplete:
-                LOG.info("[code]--fail-incomplete[/] specified. Setting return code to: %s", value, extra=MARKUP)
-                self._returncode = value
-                return
             return
 
         # Don't allow setting a `SUCCESS` value once the return code has already been set to an error value

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -126,8 +126,35 @@ class CIBase(ABC):
     @returncode.setter
     def returncode(self, value: ReturnCode) -> None:
         """Set the return code value."""
-        # Do not allow setting a `SUCCESS` value once the return code has already been set to an error value.
+        # Exit early when there is nothing to do
+        if value == self._returncode:
+            return
+
+        # Don't set non-analysis custom failure codes when flag to ignore errors specified
+        if self.args.ignore_errors and value > ReturnCode.LARGEST_POSSIBLE_ANALYSIS_ERROR:
+            msg = f"""
+                [code]--ignore-errors[/] detected to keep return code {self._returncode} instead of setting to {value}
+                More info: https://github.com/phylum-dev/phylum-ci#exit-codes"""
+            LOG.warning(cleandoc(msg), extra=MARKUP)
+            return
+
+        # Don't set analysis failure codes in audit mode
+        if self.audit_mode and value <= ReturnCode.LARGEST_POSSIBLE_ANALYSIS_ERROR:
+            msg = f"""Audit mode enabled to keep return code {self._returncode} instead of setting to {value}"""
+            LOG.info(cleandoc(msg))
+            return
+
+        # Don't set a failure code when analysis results are unknown unless told to
+        if value == ReturnCode.ANALYSIS_INCOMPLETE:
+            if self.args.fail_incomplete:
+                LOG.info("[code]--fail-incomplete[/] specified. Setting return code to: %s", value, extra=MARKUP)
+                self._returncode = value
+                return
+            return
+
+        # Don't allow setting a `SUCCESS` value once the return code has already been set to an error value
         if self._returncode == ReturnCode.SUCCESS or value != ReturnCode.SUCCESS:
+            LOG.debug("Setting return code to: %s", value)
             self._returncode = value
 
     def _find_potential_depfiles(self) -> None:
@@ -193,8 +220,7 @@ class CIBase(ABC):
             least one with `--depfile` argument or in `.phylum_project` file:
             https://docs.phylum.io/knowledge_base/phylum_project_files"""
         LOG.error(cleandoc(msg))
-        if not self.returncode:
-            self.returncode = ReturnCode.NO_DEPFILES_PROVIDED
+        self.returncode = ReturnCode.NO_DEPFILES_PROVIDED
         raise SystemExit(self.returncode)
 
     def _exclude_depfiles(self, provided_depfiles: DepfileEntries) -> DepfileEntries:
@@ -882,11 +908,14 @@ class CIBase(ABC):
                 valid dependencies in the current set of provided dependency files
                 at revision [code]{self.common_ancestor_commit}[/]."""
             LOG.error(cleandoc(msg), extra=MARKUP)
-            if not self.returncode:
-                self.returncode = ReturnCode.NO_CURRENT_DEPS_FOUND
+            self.returncode = ReturnCode.NO_CURRENT_DEPS_FOUND
             raise SystemExit(self.returncode)
 
-        LOG.debug("%s unique current dependencies from %s file(s)", len(current_packages), len(self.depfiles))
+        num_current_packages = len(current_packages)
+        num_depfiles = len(self.depfiles)
+        dep_txt = "dependency" if num_current_packages == 1 else "dependencies"
+        file_txt = "file" if num_depfiles == 1 else "files"
+        LOG.debug("%s unique current %s from %s %s", num_current_packages, dep_txt, num_depfiles, file_txt)
         if self.all_deps:
             LOG.info("Considering all current dependencies ...")
             base_packages = []
@@ -894,7 +923,9 @@ class CIBase(ABC):
             LOG.info("Only considering newly added dependencies ...")
             base_packages = self._get_base_packages()
             new_packages = sorted(set(current_packages).difference(set(base_packages)))
-            LOG.debug("%s new dependencies: %s", len(new_packages), new_packages)
+            num_new_packages = len(new_packages)
+            dep_txt = "dependency" if num_new_packages == 1 else "dependencies"
+            LOG.debug("%s new %s: %s", num_new_packages, dep_txt, new_packages)
 
         # TODO(maxrake): Better formatting with parenthesized context managers is available in Python 3.10+
         #     https://github.com/phylum-dev/phylum-ci/issues/357
@@ -995,16 +1026,16 @@ class CIBase(ABC):
         if analysis.incomplete_count == 0:
             if analysis.is_failure:
                 LOG.error("Analysis is complete and there were failures")
-                self.returncode = ReturnCode.POLICY_FAILURE
+                self.returncode = ReturnCode.ANALYSIS_POLICY_FAILURE
             else:
                 LOG.info("Analysis is complete and there were NO failures")
                 self.returncode = ReturnCode.SUCCESS
         elif analysis.is_failure:
             LOG.error("There were failures in one or more completed packages")
-            self.returncode = ReturnCode.FAILURE_INCOMPLETE
+            self.returncode = ReturnCode.ANALYSIS_FAILURE_INCOMPLETE
         else:
             LOG.warning("There were no failures in the packages that have completed so far")
-            self.returncode = ReturnCode.INCOMPLETE
+            self.returncode = ReturnCode.ANALYSIS_INCOMPLETE
 
 
 # Type alias

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -189,14 +189,7 @@ def get_args(args: Optional[Sequence[str]] = None) -> tuple[argparse.Namespace, 
         help="""Specify this flag to disable posting comments/notes on pull/merge requests. This flag is implicitly
             set when audit mode is enabled.""",
     )
-    strict_loose_group = output_mod_group.add_mutually_exclusive_group()
-    strict_loose_group.add_argument(
-        "--fail-incomplete",
-        action="store_true",
-        help="""Specify this flag to set a failure code when some analysis results are unknown. Useful in environments
-            where strictness is desired to prevent adding any new dependency until it passes established policy.""",
-    )
-    strict_loose_group.add_argument(
+    output_mod_group.add_argument(
         "--audit",
         action="store_true",
         help="Specify this flag to enable audit mode: analysis is performed but results do not affect the exit code.",

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -18,7 +18,6 @@ from phylum.ci.ci_gitlab import CIGitLab
 from phylum.ci.ci_jenkins import CIJenkins
 from phylum.ci.ci_none import CINone
 from phylum.ci.ci_precommit import CIPreCommit
-from phylum.ci.common import ReturnCode
 from phylum.constants import HELP_MSG_API_URI, HELP_MSG_TARGET, HELP_MSG_TOKEN, HELP_MSG_VERSION
 from phylum.init.cli import get_target_triple, process_version
 from phylum.logger import LOG, set_logger_level
@@ -181,17 +180,31 @@ def get_args(args: Optional[Sequence[str]] = None) -> tuple[argparse.Namespace, 
             `.phylum_project` file. The value specified with this option takes precedence when both are provided. Group
             will be created if it does not already exist. Groups require a paid account: https://phylum.io/pricing""",
     )
-    analysis_group.add_argument(
+
+    output_mod_group = parser.add_argument_group(title="Output Modification Options")
+    output_mod_group.add_argument(
         "-s",
         "--skip-comments",
         action="store_true",
         help="""Specify this flag to disable posting comments/notes on pull/merge requests. This flag is implicitly
             set when audit mode is enabled.""",
     )
-    analysis_group.add_argument(
+    strict_loose_group = output_mod_group.add_mutually_exclusive_group()
+    strict_loose_group.add_argument(
+        "--fail-incomplete",
+        action="store_true",
+        help="""Specify this flag to set a failure code when some analysis results are unknown. Useful in environments
+            where strictness is desired to prevent adding any new dependency until it passes established policy.""",
+    )
+    strict_loose_group.add_argument(
         "--audit",
         action="store_true",
         help="Specify this flag to enable audit mode: analysis is performed but results do not affect the exit code.",
+    )
+    output_mod_group.add_argument(
+        "--ignore-errors",
+        action="store_true",
+        help="Specify this flag to ignore non-analysis warnings and errors that would otherwise affect the exit code.",
     )
 
     cli_group = parser.add_argument_group(
@@ -235,6 +248,10 @@ def main(args: Optional[Sequence[str]] = None) -> int:
     parsed_args, remainder_args = get_args(args=args)
     set_logger_level(parsed_args.verbose - parsed_args.quiet)
 
+    # Show how this entry point was called, for analyzing user-provided logs
+    main_args = args or sys.argv[1:]
+    LOG.debug("Called with args: %s", main_args)
+
     # Perform version check and normalization separately from the argument parsing so as to minimize GitHub
     # API calls when showing the help message but still bail early when the version provided is invalid.
     parsed_args.version = process_version(parsed_args.version)
@@ -265,14 +282,11 @@ def main(args: Optional[Sequence[str]] = None) -> int:
     # Output the results of the analysis
     ci_env.post_output()
 
-    # Don't return a failure code in audit mode or if analysis results are unknown at this point
-    returncode = 0 if ci_env.returncode == ReturnCode.INCOMPLETE else ci_env.returncode.value
-    if ci_env.audit_mode:
-        LOG.info("Audit mode enabled. Original return code: %s", returncode)
-        returncode = 0
+    # Exit with the effective return code
+    returncode = ci_env.returncode.value
     msg = f"""
         Return code: {returncode}
-        More info: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes"""
+        More info: https://github.com/phylum-dev/phylum-ci#exit-codes"""
     LOG.debug(cleandoc(msg))
     return returncode
 

--- a/src/phylum/ci/common.py
+++ b/src/phylum/ci/common.py
@@ -100,17 +100,33 @@ DepfileEntries = list[DepfileEntry]
 class ReturnCode(IntEnum):
     """Integer enumeration to track return codes."""
 
+    # NOTE: Updates to this list should be kept in sync with the "Exit Codes" section of `README.md`.
+    #       They should also adhere to the guarantees made by `--audit` and `--ignore-errors` flags.
+    #       Analysis-related codes should have a value in the range from 2-9, inclusive.
+    #       All other custom codes should have a value of 10 or greater.
+
     SUCCESS = 0
     # NOTE: Don't create a unique entry here for the value `1`. That value is used for default
     #       failures (when a `SystemExit` exception is raised with a message instead of a code).
-    #       Updates to this list should be kept in sync with the "Exit Codes" section of `README.md`.
+    # DEFAULT_FAILURE = 1   # noqa: ERA001 ; we want commented code here as a reminder not to add it
+
+    # ========================================================================================
+    # Analysis results that contain a policy violation can be silenced with the `--audit` flag
+    # ========================================================================================
     #
     # Phylum analysis is complete and contains a policy violation
-    POLICY_FAILURE = 2
+    ANALYSIS_POLICY_FAILURE = 2
     # Phylum analysis is incomplete and does not contain any policy violations
-    INCOMPLETE = 5
+    ANALYSIS_INCOMPLETE = 5
     # Phylum analysis is incomplete and contains a policy violation
-    FAILURE_INCOMPLETE = 6
+    ANALYSIS_FAILURE_INCOMPLETE = 6
+    # Dummy value to check for analysis-related codes vs. all other custom codes (can be reused/repeated)
+    LARGEST_POSSIBLE_ANALYSIS_ERROR = 9
+
+    # =====================================================================
+    # Codes in this section can be silenced with the `--ignore-errors` flag
+    # =====================================================================
+    #
     # A provided or detected dependency file failed one of the filters and was not included for analysis
     DEPFILE_FILTER = 10
     # No dependency files were provided or detected


### PR DESCRIPTION
This change adds an `--ignore-errors` flag to allow for explicitly ignoring non-analysis warnings and errors that would otherwise affect the exit code. All modifications to the `phylum-ci` return code are now handled in one spot, the class property setter method. This ensures all the logic for setting known return codes (i.e., `2` or greater) is grouped together.

Making this change helped to identify (and fix) a bug where dependency file filter failures (exit code `10`) were incorrectly suppressed when the analysis was incomplete but without any analysis failures.

Additional changes made include:

* Add script entry point debug log entry to show args it was called with
* Add Docker image test to ensure `javac` is installed and on the PATH
  * This should have been included in #507
* Update documentation
  * Update "Exit Code" section of README
    * Description of analysis vs non-analysis codes and how to silence
  * Update the link to the exit code doc to shorter form
  * Update docs for each integration to match
* Refactor and format throughout
  * Prefix `ReturnCode` entries related to analysis with `ANALYSIS_`
  * Account for plural or singular form in log messages
  * Create a new help output section for "Output Modification Options"

## Testing

The changes in this PR are available for testing with the `maxrake/phylum-ci:silence_errors` Docker image found [on Docker Hub](https://hub.docker.com/r/maxrake/phylum-ci/tags).

The changes were tested explicitly for each of the new changes. Here is a sample of the scenarios:

* Depfile provided that fails filtering while another depfile provided that contains new deps that have not been processed
  * Returns `10` normally
  * Returns `10` in audit mode
  * Returns `0` when `--ignore-errors` specified
  * Returns `0` when `--audit` and `--ignore-errors` specified
* Same depfiles provided as above, plus another one that contains known bad deps
  * Returns `6` normally
  * Returns `10` in audit mode
  * Returns `6` when `--ignore-errors` specified
  * Returns `0` when `--audit` and `--ignore-errors` specified

## TODO

* [x] Another PR for the `phylum-analyze-pr-action` repo will be created to
update the documentation there to match the changes here
  * https://github.com/phylum-dev/phylum-analyze-pr-action/pull/43
