### PR TITLE
refactor: address `ruff` preview lint findings

### DIFF
--- a/src/phylum/ci/ci_azure.py
+++ b/src/phylum/ci/ci_azure.py
@@ -261,7 +261,7 @@ class CIAzure(CIBase):
             Consider changing the `fetchDepth` property in CI settings to
             clone/fetch more branch history. For more info, reference:
             https://learn.microsoft.com/azure/devops/pipelines/yaml-schema/steps-checkout"""
-        self.update_depfiles_change_status(diff_base_sha, err_msg)
+        self._update_depfiles_change_status(diff_base_sha, err_msg)
 
         return any(depfile.is_depfile_changed for depfile in self.depfiles)
 

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -529,7 +529,7 @@ class CIBase(ABC):
         return cli_path
 
     @cached_property
-    def git_root_dir(self) -> Path:
+    def _git_root_dir(self) -> Path:
         """Get the root directory of the git working tree."""
         return git_root_dir()
 
@@ -611,7 +611,7 @@ class CIBase(ABC):
         """
         raise NotImplementedError
 
-    def update_depfiles_change_status(self, commit: str, err_msg: Optional[str] = None) -> None:
+    def _update_depfiles_change_status(self, commit: str, err_msg: Optional[str] = None) -> None:
         """Update each dependency file's change status.
 
         The input `commit` is the one to use in a `git diff` command to view the changes relative to the working tree.
@@ -658,7 +658,7 @@ class CIBase(ABC):
         LOG.debug("`git` binary found on the PATH")
 
         # Referencing this property is enough to ensure the prerequisite
-        LOG.debug("Git repository root found: %s", self.git_root_dir)
+        LOG.debug("Git repository root found: %s", self._git_root_dir)
 
     def _cmd_extender(
         self,
@@ -973,7 +973,7 @@ class CIBase(ABC):
         base_packages: set[Package] = set()
         with git_worktree(self.common_ancestor_commit, env=self._env) as temp_dir:
             for depfile in self.depfiles:
-                prev_depfile_path = temp_dir / depfile.path.relative_to(self.git_root_dir)
+                prev_depfile_path = temp_dir / depfile.path.relative_to(self._git_root_dir)
                 try:
                     prev_depfile_pkgs = parse_depfile(
                         self.cli_path,

--- a/src/phylum/ci/ci_bitbucket.py
+++ b/src/phylum/ci/ci_bitbucket.py
@@ -211,7 +211,7 @@ class CIBitbucket(CIBase):
             Consider changing the `clone depth` variable in CI settings to
             clone/fetch more branch history. For more info, reference:
             https://support.atlassian.com/bitbucket-cloud/docs/git-clone-behavior/"""
-        self.update_depfiles_change_status(diff_base_sha, err_msg)
+        self._update_depfiles_change_status(diff_base_sha, err_msg)
 
         return any(depfile.is_depfile_changed for depfile in self.depfiles)
 

--- a/src/phylum/ci/ci_github.py
+++ b/src/phylum/ci/ci_github.py
@@ -178,7 +178,7 @@ class CIGitHub(CIBase):
         err_msg = """
             Consider changing the `fetch-depth` input during checkout to fetch more
             branch history. For more info: https://github.com/actions/checkout"""
-        self.update_depfiles_change_status(pr_base_sha, err_msg)
+        self._update_depfiles_change_status(pr_base_sha, err_msg)
 
         return any(depfile.is_depfile_changed for depfile in self.depfiles)
 

--- a/src/phylum/ci/ci_gitlab.py
+++ b/src/phylum/ci/ci_gitlab.py
@@ -174,7 +174,7 @@ class CIGitLab(CIBase):
             Consider changing the `GIT_DEPTH` variable in CI settings to
             clone/fetch more branch history. For more info, reference:
             https://docs.gitlab.com/ee/ci/large_repositories/index.html#shallow-cloning"""
-        self.update_depfiles_change_status(diff_base_sha, err_msg)
+        self._update_depfiles_change_status(diff_base_sha, err_msg)
 
         return any(depfile.is_depfile_changed for depfile in self.depfiles)
 

--- a/src/phylum/ci/ci_jenkins.py
+++ b/src/phylum/ci/ci_jenkins.py
@@ -148,7 +148,7 @@ class CIJenkins(CIBase):
             For more info, reference:
             * https://plugins.jenkins.io/workflow-scm-step/
             * https://www.jenkins.io/doc/pipeline/steps/credentials-binding/"""
-        self.update_depfiles_change_status(diff_base_sha, err_msg)
+        self._update_depfiles_change_status(diff_base_sha, err_msg)
 
         return any(depfile.is_depfile_changed for depfile in self.depfiles)
 

--- a/src/phylum/ci/ci_none.py
+++ b/src/phylum/ci/ci_none.py
@@ -90,7 +90,7 @@ class CINone(CIBase):
         """
         remote = git_remote()
         try:
-            self.update_depfiles_change_status(f"refs/remotes/{remote}/HEAD...")
+            self._update_depfiles_change_status(f"refs/remotes/{remote}/HEAD...")
         except subprocess.CalledProcessError as outer_err:
             # The most likely problem is that the remote HEAD ref is not set. The attempt to set it here, inside
             # the except block, is due to wanting to minimize calling commands that require git credentials.
@@ -98,7 +98,7 @@ class CINone(CIBase):
             LOG.warning("Failed to get diff. Remote HEAD ref likely not set. Attempting to set it and try again ...")
             git_set_remote_head(remote)
             try:
-                self.update_depfiles_change_status(f"refs/remotes/{remote}/HEAD...")
+                self._update_depfiles_change_status(f"refs/remotes/{remote}/HEAD...")
             except subprocess.CalledProcessError as inner_err:
                 msg = "Failed to get diff with remote HEAD ref even after setting it."
                 raise PhylumCalledProcessError(inner_err, msg) from outer_err

--- a/src/phylum/ci/common.py
+++ b/src/phylum/ci/common.py
@@ -46,16 +46,16 @@ class DepfileEntry:
     Current commands that return entries in this format include `status --json` and `find-dependency-files`.
     """
 
-    _path: dataclasses.InitVar[Union[str, Path]]
+    path_: dataclasses.InitVar[Union[str, Path]]
     type: str = "auto"
     path: Path = dataclasses.field(init=False)
 
-    def __post_init__(self, _path):
+    def __post_init__(self, path_):
         """Ensure the `path` field is actually a `Path` object."""
-        if isinstance(_path, str):
-            self.path = Path(_path).resolve()
-        elif isinstance(_path, Path):
-            self.path = _path.resolve()
+        if isinstance(path_, str):
+            self.path = Path(path_).resolve()
+        elif isinstance(path_, Path):
+            self.path = path_.resolve()
         else:
             msg = "Provided dependency file path is not `str` or `Path`"
             raise TypeError(msg)


### PR DESCRIPTION
The `ruff` linter has a "preview" mode to show lint findings that are still experimental or otherwise not included in the default set of checks. This change set addresses the following findings in an effort to get ahead of these coming out of preview:

* RUF052: used-dummy-variable
  * Rename `_path` initVar in `DepfileEntry` dataclass to `path_`
* PLR0904: too-many-public-methods (22 > 20)
  * Change two `CIBase` class public methods to private
    * `update_depfiles_change_status` -> `_update_depfiles_change_status`
    * `git_root_dir` -> `_git_root_dir`
* PLR0914: too-many-locals (16 > 15)
  * Extract logic to install the Phylum CLI in `phylum-init` -> `main`

NOTE: the other current preview findings are either false positive (LOG015) or related to docstring changes...which will be either ignored or handled in a separate PR given the scope of the changes required.

## References

* [RUF052](https://docs.astral.sh/ruff/rules/used-dummy-variable/)
* [PLR0904](https://docs.astral.sh/ruff/rules/too-many-public-methods/)
* [PLR0914](https://docs.astral.sh/ruff/rules/too-many-locals/)
