### PR TITLE
feat: automatically analyze newly created projects

### DIFF
--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -757,6 +757,8 @@ class CIBase(ABC):
         LOG.info(cleandoc(project_created_msg))
         if self._project_file_already_existed:
             LOG.warning("Overwrote previous `.phylum_project` file found at: %s", self._phylum_project_file)
+        LOG.warning("Forcing analysis to ensure new project is initially populated ...")
+        self._force_analysis = True
 
     def _created_group(self) -> bool:
         """Ensure a Phylum group is created and in place, when specified.

--- a/src/phylum/ci/cli.py
+++ b/src/phylum/ci/cli.py
@@ -149,8 +149,8 @@ def get_args(args: Optional[Sequence[str]] = None) -> tuple[argparse.Namespace, 
         "-f",
         "--force-analysis",
         action="store_true",
-        help="""Specify this flag to force analysis, even when no dependency file has changed. This flag is implicitly
-            set when *any* manifest is included, to maximize the chance that updated dependencies are accounted.""",
+        help="""Specify this flag to force analysis, even when no dependency file has changed. Implicitly set for newly
+            created projects or when *any* manifest is included, to account for possible dependency updates.""",
     )
     analysis_group.add_argument(
         "-k",


### PR DESCRIPTION
This change forces analysis when a new project is created. This ensures the project is initially populated with results in the Phylum UI, which helps for users configuring Phylum analysis exclusively through the CI integrations. This is doubly true when the set of dependency files do not include a manifest, which is the other trigger for automatically forcing analysis.

The desire expressed from users of the integrations is that setting up the integration and running it the first time should cause the project dependencies to be ingested without needing to set the `--force-analysis` flag or wait until a PR with a modified dependency file emerges. They also don't want to have to use the Phylum CLI to populate the project(s) before scanning them with the CI integrations.

## Testing

This is what it looks like with the current released version of `phylum-ci`. A new project is specified and created automatically. However, analysis is not performed because the `poetry.lock` file has not changed. This manifests in the Phylum UI as a "PROJECT SETUP INCOMPLETE" entry in the project listing page for this (legacy/personal) organization.

<details><summary>Details (click to expand...)</summary>
<p>

```
❯ phylum-ci -vv --project delme_first_run_prod --group delme --depfile poetry.lock
DEBUG    Using package: phylum v0.55.0
DEBUG    Logging initialized to level 10 (DEBUG)
DEBUG    Called with args: ['-vv', '--project', 'delme_first_run_prod', '--group', 'delme', '--depfile', 'poetry.lock']
DEBUG    Phylum CLI version not specified
DEBUG    Found installed Phylum CLI version: v7.2.0
DEBUG    The installed Phylum CLI version is supported
INFO     Using Phylum CLI version: v7.2.0
DEBUG    No CI environment detected
INFO     Confirming prerequisites ...
DEBUG    `git` binary found on the PATH
DEBUG    Git repository root found: /Users/maxrake/dev/phylum/phylum-ci
INFO     All prerequisites met
DEBUG    Existing Phylum CLI instance found: v7.2.0 at /Users/maxrake/.local/bin/phylum
INFO     Using Phylum CLI instance: v7.2.0 at /Users/maxrake/.local/bin/phylum
DEBUG    Project name provided as argument: delme_first_run_prod
INFO     Attempting to create a Phylum project with name: delme_first_run_prod ...
DEBUG    Org name not provided as argument. Checking Phylum settings file ...
DEBUG    Org name not found in Phylum settings file. Assuming no org ...
DEBUG    Group name provided as argument: delme
INFO     Using Phylum group: delme
INFO     Project/org/group combo created successfully.
             Project: delme_first_run_prod
             Org:     (no org)
             Group:   delme
WARNING  Overwrote previous `.phylum_project` file found at: /Users/maxrake/dev/phylum/phylum-ci/.phylum_project
DEBUG    Dependency files provided as arguments: [poetry.lock]
INFO     Parsing poetry.lock as auto dependency file. Manifests take longer.
DEBUG    Determining viability of the Phylum sandbox in this environment ...
DEBUG    Executing command: /Users/maxrake/.local/bin/phylum sandbox --allow-run / true
INFO     The Phylum sandbox works in this environment and will be enabled
DEBUG    Using parse command: /Users/maxrake/.local/bin/phylum parse --type auto
         /Users/maxrake/dev/phylum/phylum-ci/poetry.lock
DEBUG    Running command from: /Users/maxrake/dev/phylum/phylum-ci
INFO     Provided dependency file poetry.lock is a lockfile
DEBUG    Valid provided dependency files: [poetry.lock]
DEBUG    Dependency files in use: [poetry.lock]
DEBUG    Checking poetry.lock for changes ...
DEBUG    Dependency file poetry.lock has NOT changed
WARNING  No lockfile has changed. Nothing to do.
```

</p>
</details> 

This is what it looks like to run the same command, but with the changes from this PR. The project name is also different/new so that a new project is created. Notice this time that analysis is forced but the results show no findings because the lockfile has not changed and `--all-deps` was not specified. The Phylum UI is populated with the full analysis results, which is the desired behavior.

<details><summary>Details (click to expand...)</summary>
<p>

```
❯ poetry run phylum-ci -vv --project delme_first_run_pr --group delme --depfile poetry.lock
DEBUG    Using package: phylum v0.55.0
DEBUG    Logging initialized to level 10 (DEBUG)
DEBUG    Called with args: ['-vv', '--project', 'delme_first_run_pr', '--group', 'delme', '--depfile', 'poetry.lock']
DEBUG    Phylum CLI version not specified
DEBUG    Found installed Phylum CLI version: v7.2.0
DEBUG    The installed Phylum CLI version is supported
INFO     Using Phylum CLI version: v7.2.0
DEBUG    No CI environment detected
INFO     Confirming prerequisites ...
DEBUG    `git` binary found on the PATH
DEBUG    Git repository root found: /Users/maxrake/dev/phylum/phylum-ci
INFO     All prerequisites met
DEBUG    Existing Phylum CLI instance found: v7.2.0 at /Users/maxrake/.local/bin/phylum
INFO     Using Phylum CLI instance: v7.2.0 at /Users/maxrake/.local/bin/phylum
DEBUG    Project name provided as argument: delme_first_run_pr
INFO     Attempting to create a Phylum project with name: delme_first_run_pr ...
DEBUG    Org name not provided as argument. Checking Phylum settings file ...
DEBUG    Org name not found in Phylum settings file. Assuming no org ...
DEBUG    Group name provided as argument: delme
INFO     Using Phylum group: delme
INFO     Project/org/group combo created successfully.
             Project: delme_first_run_pr
             Org:     (no org)
             Group:   delme
WARNING  Overwrote previous `.phylum_project` file found at: /Users/maxrake/dev/phylum/phylum-ci/.phylum_project
WARNING  Forcing analysis to ensure new project is initially populated ...
DEBUG    Dependency files provided as arguments: [poetry.lock]
INFO     Parsing poetry.lock as auto dependency file. Manifests take longer.
DEBUG    Determining viability of the Phylum sandbox in this environment ...
DEBUG    Executing command: /Users/maxrake/.local/bin/phylum sandbox --allow-run / true
INFO     The Phylum sandbox works in this environment and will be enabled
DEBUG    Using parse command: /Users/maxrake/.local/bin/phylum parse --type auto
         /Users/maxrake/dev/phylum/phylum-ci/poetry.lock
DEBUG    Running command from: /Users/maxrake/dev/phylum/phylum-ci
INFO     Provided dependency file poetry.lock is a lockfile
DEBUG    Valid provided dependency files: [poetry.lock]
DEBUG    Dependency files in use: [poetry.lock]
INFO     Forced analysis specified or otherwise set. Proceeding with analysis.
INFO     Label to use for analysis: No-CI_first_run_908606f
DEBUG    70 unique current dependencies from 1 file
INFO     Only considering newly added dependencies ...
DEBUG    Adding git worktree for base iteration in a temporary directory ...
DEBUG    Using command: git worktree add --detach /var/folders/gh/wnf14j7n4q34y2t36hq2jz800000gn/T/phylum_2pc1tmga
         85d69fa090a308273bf47f89a8367b68534f78bc
INFO     Parsing poetry.lock as auto dependency file. Manifests take longer.
DEBUG    Using parse command: /Users/maxrake/.local/bin/phylum parse --type auto
         /private/var/folders/gh/wnf14j7n4q34y2t36hq2jz800000gn/T/phylum_2pc1tmga/poetry.lock
DEBUG    Running command from: /private/var/folders/gh/wnf14j7n4q34y2t36hq2jz800000gn/T/phylum_2pc1tmga
DEBUG    Removing the git worktree for the base iteration ...
DEBUG    Using command: git worktree remove --force
         /private/var/folders/gh/wnf14j7n4q34y2t36hq2jz800000gn/T/phylum_2pc1tmga
DEBUG    0 new dependencies: []
INFO     Performing analysis. This may take a few seconds.
DEBUG    Using analysis command: /Users/maxrake/.local/bin/phylum extension run --yes
         /Users/maxrake/dev/phylum/phylum-ci/src/phylum/exts/ci delme_first_run_pr No-CI_first_run_908606f --group delme
         /var/folders/gh/wnf14j7n4q34y2t36hq2jz800000gn/T/base_y42zxphg.json
         /var/folders/gh/wnf14j7n4q34y2t36hq2jz800000gn/T/curr_0tzraguj.json
INFO     Analysis is complete and there were NO failures
DEBUG    Analysis output:

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃                                   Phylum OSS Supply Chain Risk Analysis - SUCCESS                                    ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛

The Phylum risk analysis is complete and has passed the active policy.

View this project in the Phylum UI (https://app.phylum.io/projects/82cb982a-4202-4bfe-94af-9e04dec10017?group=delme&label=No-CI_first_run_908606f)
DEBUG    Return code: 0
         More info: https://github.com/phylum-dev/phylum-ci#exit-codes
```

</p>
</details>

This is what it looks like to run the same command a second time. This time, the project already exists and so there is nothing to do, which is the expected behavior.

<details><summary>Details (click to expand...)</summary>
<p>

```
❯ poetry run phylum-ci -vv --project delme_first_run_pr --group delme --depfile poetry.lock
DEBUG    Using package: phylum v0.55.0
DEBUG    Logging initialized to level 10 (DEBUG)
DEBUG    Called with args: ['-vv', '--project', 'delme_first_run_pr', '--group', 'delme', '--depfile', 'poetry.lock']
DEBUG    Phylum CLI version not specified
DEBUG    Found installed Phylum CLI version: v7.2.0
DEBUG    The installed Phylum CLI version is supported
INFO     Using Phylum CLI version: v7.2.0
DEBUG    No CI environment detected
INFO     Confirming prerequisites ...
DEBUG    `git` binary found on the PATH
DEBUG    Git repository root found: /Users/maxrake/dev/phylum/phylum-ci
INFO     All prerequisites met
DEBUG    Existing Phylum CLI instance found: v7.2.0 at /Users/maxrake/.local/bin/phylum
INFO     Using Phylum CLI instance: v7.2.0 at /Users/maxrake/.local/bin/phylum
DEBUG    Project name provided as argument: delme_first_run_pr
INFO     Attempting to create a Phylum project with name: delme_first_run_pr ...
DEBUG    Org name not provided as argument. Checking Phylum settings file ...
DEBUG    Org name not found in Phylum settings file. Assuming no org ...
DEBUG    Group name provided as argument: delme
INFO     Using Phylum group: delme
INFO     Project/org/group combo already exists. Continuing with it.
             Project: delme_first_run_pr
             Org:     (no org)
             Group:   delme
DEBUG    Repository URL not available to set
DEBUG    Dependency files provided as arguments: [poetry.lock]
INFO     Parsing poetry.lock as auto dependency file. Manifests take longer.
DEBUG    Determining viability of the Phylum sandbox in this environment ...
DEBUG    Executing command: /Users/maxrake/.local/bin/phylum sandbox --allow-run / true
INFO     The Phylum sandbox works in this environment and will be enabled
DEBUG    Using parse command: /Users/maxrake/.local/bin/phylum parse --type auto
         /Users/maxrake/dev/phylum/phylum-ci/poetry.lock
DEBUG    Running command from: /Users/maxrake/dev/phylum/phylum-ci
INFO     Provided dependency file poetry.lock is a lockfile
DEBUG    Valid provided dependency files: [poetry.lock]
DEBUG    Dependency files in use: [poetry.lock]
DEBUG    Checking poetry.lock for changes ...
DEBUG    Dependency file poetry.lock has NOT changed
WARNING  No lockfile has changed. Nothing to do.
```

</p>
</details> 

This is what it looks like to add the `--all-deps` flag. The project name is also different/new so that a new project is created. Notice this time that analysis is forced and the results show all the findings. The Phylum UI is again populated with the full analysis results.

<details><summary>Details (click to expand...)</summary>
<p>

```
❯ poetry run phylum-ci -vv --all-deps --project delme_first_run_pr_all --group delme --depfile poetry.lock
DEBUG    Using package: phylum v0.55.0
DEBUG    Logging initialized to level 10 (DEBUG)
DEBUG    Called with args: ['-vv', '--all-deps', '--project', 'delme_first_run_pr_all', '--group', 'delme', '--depfile',
         'poetry.lock']
DEBUG    Phylum CLI version not specified
DEBUG    Found installed Phylum CLI version: v7.2.0
DEBUG    The installed Phylum CLI version is supported
INFO     Using Phylum CLI version: v7.2.0
DEBUG    No CI environment detected
INFO     Confirming prerequisites ...
DEBUG    `git` binary found on the PATH
DEBUG    Git repository root found: /Users/maxrake/dev/phylum/phylum-ci
INFO     All prerequisites met
DEBUG    Existing Phylum CLI instance found: v7.2.0 at /Users/maxrake/.local/bin/phylum
INFO     Using Phylum CLI instance: v7.2.0 at /Users/maxrake/.local/bin/phylum
DEBUG    Project name provided as argument: delme_first_run_pr_all
INFO     Attempting to create a Phylum project with name: delme_first_run_pr_all ...
DEBUG    Org name not provided as argument. Checking Phylum settings file ...
DEBUG    Org name not found in Phylum settings file. Assuming no org ...
DEBUG    Group name provided as argument: delme
INFO     Using Phylum group: delme
INFO     Project/org/group combo created successfully.
             Project: delme_first_run_pr_all
             Org:     (no org)
             Group:   delme
WARNING  Overwrote previous `.phylum_project` file found at: /Users/maxrake/dev/phylum/phylum-ci/.phylum_project
WARNING  Forcing analysis to ensure new project is initially populated ...
DEBUG    Dependency files provided as arguments: [poetry.lock]
INFO     Parsing poetry.lock as auto dependency file. Manifests take longer.
DEBUG    Determining viability of the Phylum sandbox in this environment ...
DEBUG    Executing command: /Users/maxrake/.local/bin/phylum sandbox --allow-run / true
INFO     The Phylum sandbox works in this environment and will be enabled
DEBUG    Using parse command: /Users/maxrake/.local/bin/phylum parse --type auto
         /Users/maxrake/dev/phylum/phylum-ci/poetry.lock
DEBUG    Running command from: /Users/maxrake/dev/phylum/phylum-ci
INFO     Provided dependency file poetry.lock is a lockfile
DEBUG    Valid provided dependency files: [poetry.lock]
DEBUG    Dependency files in use: [poetry.lock]
INFO     Forced analysis specified or otherwise set. Proceeding with analysis.
INFO     Label to use for analysis: No-CI_first_run_908606f
DEBUG    70 unique current dependencies from 1 file
INFO     Considering all current dependencies ...
INFO     Performing analysis. This may take a few seconds.
DEBUG    Using analysis command: /Users/maxrake/.local/bin/phylum extension run --yes
         /Users/maxrake/dev/phylum/phylum-ci/src/phylum/exts/ci delme_first_run_pr_all No-CI_first_run_908606f --group
         delme /var/folders/gh/wnf14j7n4q34y2t36hq2jz800000gn/T/base_ihhb0ioa.json
         /var/folders/gh/wnf14j7n4q34y2t36hq2jz800000gn/T/curr_wcxige1e.json
ERROR    Analysis is complete and there were failures
DEBUG    Setting return code to: 2
DEBUG    Analysis output:

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃                                    Phylum OSS Supply Chain Risk Analysis - FAILED                                    ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛

This repository analyzes the risk of new dependencies. An administrator of this repository has set requirements via Phylum policy.

If you see this comment, one or more dependencies have failed Phylum's risk analysis.


                                       Package: charset-normalizer@3.4.0 failed.

                             charset-normalizer@3.4.0 is decoding hardcoded Base64 strings

Risk Domain: Malicious Code
Risk Level: low

Reason: Obfuscated code


                                          Package: cryptography@43.0.3 failed.

                                    cryptography@43.0.3 contains obfuscated Python.

Risk Domain: Malicious Code
Risk Level: high

Reason: Obfuscated code

                                     cryptography@43.0.3 is decoding Base64 strings

Risk Domain: Malicious Code
Risk Level: low

Reason: Obfuscated code


                                            Package: dulwich@0.22.6 failed.

                                       dulwich@0.22.6 contains obfuscated Python.

Risk Domain: Malicious Code
Risk Level: high

Reason: Obfuscated code

                              dulwich@0.22.6 contains suspicious behavior in the setup.py.

Risk Domain: Malicious Code
Risk Level: low

Reason: Install Code Execution (Suspicious)


                                            Package: pydantic@2.10.3 failed.

                                      pydantic@2.10.3 contains obfuscated Python.

Risk Domain: Malicious Code
Risk Level: high

Reason: Obfuscated code

                                       pydantic@2.10.3 is decoding Base64 strings

Risk Domain: Malicious Code
Risk Level: low

Reason: Obfuscated code


                                         Package: pydantic-core@2.27.1 failed.

                                    pydantic-core@2.27.1 contains obfuscated Python.

Risk Domain: Malicious Code
Risk Level: high

Reason: Obfuscated code


                                             Package: pytest@8.3.4 failed.

                                        pytest@8.3.4 contains obfuscated Python.

Risk Domain: Malicious Code
Risk Level: high

Reason: Obfuscated code


                                         Package: python-gitlab@4.13.0 failed.

                               python-gitlab@4.13.0 is decoding hardcoded Base64 strings

Risk Domain: Malicious Code
Risk Level: low

Reason: Obfuscated code


                                        Package: ruamel-yaml-clib@0.2.12 failed.

                         ruamel.yaml.clib@0.2.12 contains suspicious behavior in the setup.py.

Risk Domain: Malicious Code
Risk Level: low

Reason: Install Code Execution (Suspicious)

View this project in the Phylum UI (https://app.phylum.io/projects/3be78921-02a3-401e-b968-7e85d6d23cab?group=delme&label=No-CI_first_run_908606f)
DEBUG    Return code: 2
         More info: https://github.com/phylum-dev/phylum-ci#exit-codes
```

</p>
</details>

---

This is what the Phylum UI project view shows for each of the runs above:

<img width="1621" alt="image" src="https://github.com/user-attachments/assets/28472d82-8da0-4864-9a99-0b722292b3e9" />
