### PR TITLE
ci: prevent PR merges when analysis is incomplete

### DIFF
--- a/.github/workflows/phylum_analyze_pr.yml
+++ b/.github/workflows/phylum_analyze_pr.yml
@@ -19,3 +19,4 @@ jobs:
         uses: phylum-dev/phylum-analyze-pr-action@f428af5c1ee8a705740d51b67424106012740f38 # v2.2.0
         with:
           phylum_token: ${{ secrets.PHYLUM_TOKEN }}
+          cmd: phylum-ci -vv --fail-incomplete


### PR DESCRIPTION
This change takes advantage of the new `--fail-incomplete` flag to be more strict in how the Phylum analysis check is handled. Before this change it was possible to merge a PR with new/changed dependencies even before the Phylum analysis was complete. With this change, the status check will report as a failure, blocking the ability to merge, when the analysis is incomplete. This provides a degree of strictness to prevent adding *any* new dependency until it passes established policy.
