### PR TITLE
build: fix Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,8 @@ registries:
 updates:
   # "pip" also covers Poetry
   - package-ecosystem: "pip"
-    registries: phylum
+    registries:
+      - phylum
     directory: "/"
     schedule:
       interval: weekly


### PR DESCRIPTION
The configuration introduced in #568 was wrong and this PR fixes it.
It was not possible to test Dependabot in that branch because it only
works when the configuration is on the default branch. The error
provided was:

```
Dependabot encountered the following error when parsing your .github/dependabot.yml:

The property '#/updates/0/registries' of type string did not match one or more of the required schemas

Please update the config file to conform with Dependabot's specification.
```

The documentation is short on details, especially regarding the schema,
but it turns out the referenced `registries` in the `updates` key are
meant to be provided as a list instead of a string. This can be seen
in the [example provided for Maven](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot#maven).