### PR TITLE
build: allow DBot code execution in external registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
       - phylum
     # Allowing external code execution is required for Dependabot to update the
     # "pip" ecosystem when a custom external registry is specified. Reference:
-    # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot#allowing-external-code-execution
+    # https://docs.github.com/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot#allowing-external-code-execution
     insecure-external-code-execution: allow
     directory: "/"
     schedule:


### PR DESCRIPTION
This is the next update to Dependabot, seeking to address the
[most recent error](https://github.com/phylum-dev/phylum-ci/network/updates/1027420507), provided by triggering it to run on the
default branch:

> **Dependabot refused to execute external code**
> Dependabot blocked external code required for this update.
> Please set `insecure-external-code-execution: allow` in the
> config if you trust all dependencies' supply chain.

References:
* [Option: `insecure-external-code-execution`](https://docs.github.com/code-security/dependabot/working-with-dependabot/dependabot-options-reference#insecure-external-code-execution)
* [Allowing external code execution](https://docs.github.com/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot#allowing-external-code-execution)