### PR TITLE
ci: use proper line continuation for powershell

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -132,8 +132,8 @@ jobs:
 
       - name: Install poetry
         run: |
-          pipx install \
-            --index-url "https://Phylum%2FPhylum:${{ secrets.PHYLUM_TOKEN }}@pypi.phylum.io/simple/" \
+          pipx install `
+            --index-url "https://Phylum%2FPhylum:${{ secrets.PHYLUM_TOKEN }}@pypi.phylum.io/simple/" `
             poetry==${{ env.POETRY_VERSION }}
 
       - name: Configure poetry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,8 +176,8 @@ jobs:
 
       - name: Install poetry
         run: |
-          pipx install \
-            --index-url "https://Phylum%2FPhylum:${{ secrets.PHYLUM_TOKEN }}@pypi.phylum.io/simple/" \
+          pipx install `
+            --index-url "https://Phylum%2FPhylum:${{ secrets.PHYLUM_TOKEN }}@pypi.phylum.io/simple/" `
             poetry==${{ env.POETRY_VERSION }}
 
       - name: Configure poetry


### PR DESCRIPTION
This change corrects the line continuation in the PowerShell scripts in the release and preview workflows. They were using backslash instead of backtick.
