### PR TITLE
ci: specify artifact download name and path

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Build wheel and source distribution
         run: poetry build -vvv
 
-      - name: Upload build artifacts
+      - name: Upload dist artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist
@@ -122,8 +122,11 @@ jobs:
 
       # Nuitka needs the packaged form and not the editable install Poetry provides
       # Ref: https://github.com/Nuitka/Nuitka/issues/2965
-      - name: Download build artifacts
+      - name: Download dist artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: dist
+          path: ./dist
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Build wheel and source distribution
         run: poetry build -vvv
 
-      - name: Upload build artifacts
+      - name: Upload dist artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist
@@ -166,8 +166,11 @@ jobs:
 
       # Nuitka needs the packaged form and not the editable install Poetry provides
       # Ref: https://github.com/Nuitka/Nuitka/issues/2965
-      - name: Download build artifacts
+      - name: Download dist artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: dist
+          path: ./dist
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0


### PR DESCRIPTION
This change accounts for a breaking major version update in the GitHub action `actions/download-artifact`, released three weeks ago.

The breaking change was inspected at the time and not deemed to affect this repository. However, that does not appear to be the case since the preview workflow is failing now in a way that makes it appear the download was placed in the working directory instead of a new subdirectory with the same name as the artifact. The working assumption is that the action, when used with all default values, is behaving as if artifact IDs were provided, which triggers the changed behavior in the new version of the action.

This PR ensures that each use of the `download-artifact` action specifies explicit `name` and `path` inputs for the artifact.

Ref: https://github.com/actions/download-artifact/releases/tag/v5.0.0
