### PR TITLE
build: fix the release

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Publish to TestPyPI
         if: inputs.TestPyPI
-        run: poetry publish --repository testpypi --username __token__ --password ${{ secrets.TESTPYPI_API_TOKEN }}
+        run: poetry publish -vvv --repository testpypi --username __token__ --password ${{ secrets.TESTPYPI_API_TOKEN }}
 
   build_windows:
     name: Build Windows ${{ matrix.name }} binary

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -97,7 +97,10 @@ jobs:
 
       - name: Publish to TestPyPI
         if: inputs.TestPyPI
-        run: poetry publish -vvv --repository testpypi --username __token__ --password ${{ secrets.TESTPYPI_API_TOKEN }}
+        env:
+          # Ref: https://python-poetry.org/docs/repositories/#configuring-credentials
+          POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.TESTPYPI_API_TOKEN }}
+        run: poetry publish -vvv --repository testpypi
 
   build_windows:
     name: Build Windows ${{ matrix.name }} binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,10 @@ jobs:
         # Allow for re-running the workflow, with the same release package version, for situations where that package is
         # already published to TestPyPI (e.g., failures due to TestPyPI being slow to recognize a published package).
         continue-on-error: true
-        run: poetry publish -vvv --repository testpypi --username __token__ --password ${{ secrets.TESTPYPI_API_TOKEN }}
+        env:
+          # Ref: https://python-poetry.org/docs/repositories/#configuring-credentials
+          POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.TESTPYPI_API_TOKEN }}
+        run: poetry publish -vvv --repository testpypi
 
       # This step is currently only verifying that the package uploaded to TestPyPI can be installed and run from there.
       # This would be a good spot to trigger a more holistic E2E or integration (as it were) level testing suite. It is
@@ -360,8 +363,11 @@ jobs:
         # Allow for re-running the workflow, with the same release package version,
         # for situations where that package is already published to PyPI.
         continue-on-error: true
+        env:
+          # Ref: https://python-poetry.org/docs/repositories/#configuring-credentials
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          poetry publish -vvv --username __token__ --password ${{ secrets.PYPI_API_TOKEN }}
+          poetry publish -vvv
           echo "url=https://pypi.org/project/phylum/${{ env.PHYLUM_REL_VER }}/" >> "${GITHUB_OUTPUT}"
 
       # This is the safety net for the previous step allowing "continue-on-error"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,6 @@ and understanding.
 
 <!--next-version-placeholder-->
 
-## [v0.59.0](https://github.com/phylum-dev/phylum-ci/compare/v0.58.1...v0.59.0) (2025-08-28)
-
-### Features
-
-* Support tag pipelines in gitlab integration ([#588](https://github.com/phylum-dev/phylum-ci/pull/588)) ([`d9deb74`](https://github.com/phylum-dev/phylum-ci/commit/d9deb74c34f1f86baf135e8c9da9d25c4d27ee50))
-
-### Documentation
-
-* Remove discord link ([#586](https://github.com/phylum-dev/phylum-ci/pull/586)) ([`4082475`](https://github.com/phylum-dev/phylum-ci/commit/4082475f740f3b8b8d94a16847d83d08c1ae338b))
-
 ## [v0.58.1](https://github.com/phylum-dev/phylum-ci/compare/v0.58.0...v0.58.1) (2025-03-20)
 
 ### Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,7 +192,7 @@ convention = "pep257"
 
 [tool.semantic_release]
 # Reference: https://python-semantic-release.readthedocs.io/en/latest/configuration.html
-version_toml = ["pyproject.toml:tool.poetry.version"]
+version_toml = ["pyproject.toml:project.version"]
 # TODO: remove this setting or change it to `true` after the project is stable and no longer zeroVer
 major_on_zero = false
 # These files (may) get updated in the release workflow before Python Semantic Release runs


### PR DESCRIPTION
This change reverts the previous release bump commit since the release workflow failed. The reason it failed is due to the `pyproject.toml` config file not getting updated correctly with the new version. This has been corrected, by configuring Python Semantic Release (PSR) to update the version in the new location. This change was tested locally and should be the last one needed to fix this repo's release workflow 🤞

The previous GitHub tag and release were also reverted/removed so that the next time a release workflow is started it will use the v0.59.0 version, as expected.