### PR TITLE
build: account for top-level dependency updates

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -189,23 +189,6 @@ url = "https://pypi.phylum.io/simple"
 reference = "phylum"
 
 [[package]]
-name = "chardet"
-version = "5.2.0"
-description = "Universal encoding detector for Python 3"
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-files = [
-    {file = "chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"},
-    {file = "chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.phylum.io/simple"
-reference = "phylum"
-
-[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -2526,4 +2509,4 @@ reference = "phylum"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "6384aa2c482e5f84400bf0a3a131f733c239ff4368d5db15bf6ecbd711cfbb6f"
+content-hash = "e660b9276e61a29637fa2c04c4b65b6350be2348ba94767e3f01b2d2c9339f5c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,6 @@ classifiers = [
 # Required dependencies for creating distributions are defined in this `project`
 # table while optional dev dependencies are defined in the `dependency-groups` table.
 dependencies = [
-    # TODO: Remove `chardet` as a top-level dependency after a release of `requests`
-    #       comes out that includes this fix: https://github.com/psf/requests/pull/7220
-    #       This should be the release after v2.32.5 of `requests`.
-    "chardet<6",
     "cryptography",
     "packaging",
     "pathspec",

--- a/src/phylum/__init__.py
+++ b/src/phylum/__init__.py
@@ -1,7 +1,6 @@
 """Top-level package for phylum."""
 
 from importlib.metadata import metadata, version
-import logging
 import pathlib
 
 PKG_METADATA = metadata(__name__)
@@ -12,8 +11,6 @@ __email__ = PKG_METADATA["Author-email"]
 
 PKG_NAME = PKG_METADATA["Name"]
 PKG_SUMMARY = PKG_METADATA["Summary"]
-
-LOG = logging.getLogger(PKG_NAME)
 
 # Provide the path to this package's directory
 PHYLUM_PACKAGE_PATH = pathlib.Path(__file__).resolve().parent

--- a/src/phylum/ci/ci_base.py
+++ b/src/phylum/ci/ci_base.py
@@ -235,7 +235,7 @@ class CIBase(ABC):
 
         try:
             spec = pathspec.GitIgnoreSpec.from_lines(provided_arg_exclusions)
-        except pathspec.patterns.gitwildmatch.GitWildMatchPatternError as err:
+        except pathspec.patterns.gitignore.GitIgnorePatternError as err:
             msg = f"""
                 Could not parse provided gitignore-style exclusion pattern!
                 {err}


### PR DESCRIPTION
This change accounts for recent top-level dependency updates. It also removes an unused `LOG` definition that exists in `logger.py` instead.
